### PR TITLE
Header encoding fixes

### DIFF
--- a/src/hpack/decoder.rs
+++ b/src/hpack/decoder.rs
@@ -572,7 +572,6 @@ impl From<DecoderError> for frame::Error {
 
 /// Get an entry from the static table
 pub fn get_static(idx: usize) -> Header {
-    use http::header;
     use http::header::HeaderValue;
 
     match idx {


### PR DESCRIPTION
- Fixes panic if a "resume" had to pause at a header with a repeat name.
- Fixes erroneous name index usage when repeated header used an index of a header that had evicted itself.