### PR TITLE
Fix write loop when a header is too big to encode

### DIFF
--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -35,6 +35,9 @@ pub enum UserError {
     /// The payload size is too big
     PayloadTooBig,
 
+    /// A header size is too big
+    HeaderTooBig,
+
     /// The application attempted to initiate too many streams to remote.
     Rejected,
 
@@ -131,6 +134,7 @@ impl error::Error for UserError {
             InactiveStreamId => "inactive stream",
             UnexpectedFrameType => "unexpected frame type",
             PayloadTooBig => "payload too big",
+            HeaderTooBig => "header too big",
             Rejected => "rejected",
             ReleaseCapacityTooBig => "release capacity too big",
             OverflowedStreamId => "stream ID overflowed",

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -39,7 +39,10 @@ enum Next<B> {
 }
 
 /// Initialze the connection with this amount of write buffer.
-const DEFAULT_BUFFER_CAPACITY: usize = 4 * 1_024;
+///
+/// The minimum MAX_FRAME_SIZE is 16kb, so always be able to send a HEADERS
+/// frame that big.
+const DEFAULT_BUFFER_CAPACITY: usize = 16 * 1_024;
 
 /// Min buffer required to attempt to write a frame
 const MIN_BUFFER_CAPACITY: usize = frame::HEADER_LEN + CHAIN_THRESHOLD;

--- a/src/hpack/mod.rs
+++ b/src/hpack/mod.rs
@@ -1,6 +1,6 @@
 mod encoder;
 mod decoder;
-mod header;
+pub(crate) mod header;
 mod huffman;
 mod table;
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -85,6 +85,10 @@ impl Send {
             }
         }
 
+        if frame.has_too_big_field() {
+            return Err(UserError::HeaderTooBig);
+        }
+
         let end_stream = frame.is_end_stream();
 
         // Update the state
@@ -214,6 +218,10 @@ impl Send {
         // TODO: Should this logic be moved into state.rs?
         if !stream.state.is_send_streaming() {
             return Err(UserError::UnexpectedFrameType);
+        }
+
+        if frame.has_too_big_field() {
+            return Err(UserError::HeaderTooBig);
         }
 
         stream.state.send_close();

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -180,8 +180,9 @@ where
                     Ok(()) => Ok(()),
                     Err(RecvHeaderBlockError::Oversize(resp)) => {
                         if let Some(resp) = resp {
-                            let _ = actions.send.send_headers(
+                            let sent = actions.send.send_headers(
                                 resp, send_buffer, stream, counts, &mut actions.task);
+                            debug_assert!(sent.is_ok(), "oversize response should not fail");
 
                             actions.send.schedule_implicit_reset(
                                 stream,


### PR DESCRIPTION
If any single header value was bigger than the write buffer, we'd write a CONTINUATION frame, and then get ready to write the header after. But since the write buffer doesn't grow in size, we'd loop on that condition forever.

- The immediate fix checks if the `CONTINUATION` frame that was written is empty. Instead of looping forever, this will panic, as it's now considered an internal bug.
- So as to not reach the panic, `HEADERS` frames are now checked that they don't contain a header that would be larger than the write buffer.
- Lastly, since this was found with a 6000 length header, the write buffer size has been increased from 4kb to 16kb.