### PR TITLE
Prevent trying to assign capacity to streams that were just reset

### DIFF
--- a/tests/h2-support/src/prelude.rs
+++ b/tests/h2-support/src/prelude.rs
@@ -70,7 +70,7 @@ where
     B: IntoBuf + 'static,
 {
     fn run<F: Future>(&mut self, f: F) -> Result<F::Item, F::Error> {
-        use futures::future::{self, Future};
+        use futures::future;
         use futures::future::Either::*;
 
         let res = future::poll_fn(|| self.poll()).select2(f).wait();


### PR DESCRIPTION
Try as I might, I can't seem to trigger the panic in #362, but looking at the backtrace from that issue, it seems quite likely that the stream received a RST_STREAM while it was waiting for window capacity, and so when calling `recv_reset` and the capacity is released back to the connection, it enters `counts.transition` a second time. That nested `transition` unlinks the pointer, and the outer `transition` panics.