### PR TITLE
Log protocol errors

### DIFF
--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -63,7 +63,7 @@ impl<T> FramedRead<T> {
         let head = frame::Head::parse(&bytes);
 
         if self.partial.is_some() && head.kind() != Kind::Continuation {
-            trace!("connection error PROTOCOL_ERROR -- expected CONTINUATION, got {:?}", head.kind());
+            proto_err!(conn: "expected CONTINUATION, got {:?}", head.kind());
             return Err(Connection(Reason::PROTOCOL_ERROR));
         }
 
@@ -81,7 +81,7 @@ impl<T> FramedRead<T> {
                 let (mut frame, mut payload) = match frame::$frame::load($head, $bytes) {
                     Ok(res) => res,
                     Err(frame::Error::InvalidDependencyId) => {
-                        debug!("stream error PROTOCOL_ERROR -- invalid HEADERS dependency ID");
+                        proto_err!(stream: "invalid HEADERS dependency ID");
                         // A stream cannot depend on itself. An endpoint MUST
                         // treat this as a stream error (Section 5.4.2) of type
                         // `PROTOCOL_ERROR`.
@@ -91,7 +91,7 @@ impl<T> FramedRead<T> {
                         });
                     },
                     Err(e) => {
-                        debug!("connection error PROTOCOL_ERROR -- failed to load frame; err={:?}", e);
+                        proto_err!(conn: "failed to load frame; err={:?}", e);
                         return Err(Connection(Reason::PROTOCOL_ERROR));
                     }
                 };
@@ -103,15 +103,15 @@ impl<T> FramedRead<T> {
                     Ok(_) => {},
                     Err(frame::Error::Hpack(hpack::DecoderError::NeedMore(_))) if !is_end_headers => {},
                     Err(frame::Error::MalformedMessage) => {
-
-                        debug!("stream error PROTOCOL_ERROR -- malformed header block");
+                        let id = $head.stream_id();
+                        proto_err!(stream: "malformed header block; stream={:?}", id);
                         return Err(Stream {
-                            id: $head.stream_id(),
+                            id,
                             reason: Reason::PROTOCOL_ERROR,
                         });
                     },
                     Err(e) => {
-                        debug!("connection error PROTOCOL_ERROR -- failed HPACK decoding; err={:?}", e);
+                        proto_err!(conn: "failed HPACK decoding; err={:?}", e);
                         return Err(Connection(Reason::PROTOCOL_ERROR));
                     }
                 }
@@ -136,7 +136,7 @@ impl<T> FramedRead<T> {
                 let res = frame::Settings::load(head, &bytes[frame::HEADER_LEN..]);
 
                 res.map_err(|e| {
-                    debug!("connection error PROTOCOL_ERROR -- failed to load SETTINGS frame; err={:?}", e);
+                    proto_err!(conn: "failed to load SETTINGS frame; err={:?}", e);
                     Connection(Reason::PROTOCOL_ERROR)
                 })?.into()
             },
@@ -144,7 +144,7 @@ impl<T> FramedRead<T> {
                 let res = frame::Ping::load(head, &bytes[frame::HEADER_LEN..]);
 
                 res.map_err(|e| {
-                    debug!("connection error PROTOCOL_ERROR -- failed to load PING frame; err={:?}", e);
+                    proto_err!(conn: "failed to load PING frame; err={:?}", e);
                     Connection(Reason::PROTOCOL_ERROR)
                 })?.into()
             },
@@ -152,7 +152,7 @@ impl<T> FramedRead<T> {
                 let res = frame::WindowUpdate::load(head, &bytes[frame::HEADER_LEN..]);
 
                 res.map_err(|e| {
-                    debug!("connection error PROTOCOL_ERROR -- failed to load WINDOW_UPDATE frame; err={:?}", e);
+                    proto_err!(conn: "failed to load WINDOW_UPDATE frame; err={:?}", e);
                     Connection(Reason::PROTOCOL_ERROR)
                 })?.into()
             },
@@ -162,7 +162,7 @@ impl<T> FramedRead<T> {
 
                 // TODO: Should this always be connection level? Probably not...
                 res.map_err(|e| {
-                    debug!("connection error PROTOCOL_ERROR -- failed to load DATA frame; err={:?}", e);
+                    proto_err!(conn: "failed to load DATA frame; err={:?}", e);
                     Connection(Reason::PROTOCOL_ERROR)
                 })?.into()
             },
@@ -172,14 +172,14 @@ impl<T> FramedRead<T> {
             Kind::Reset => {
                 let res = frame::Reset::load(head, &bytes[frame::HEADER_LEN..]);
                 res.map_err(|e| {
-                    debug!("connection error PROTOCOL_ERROR -- failed to load RESET frame; err={:?}", e);
+                    proto_err!(conn: "failed to load RESET frame; err={:?}", e);
                     Connection(Reason::PROTOCOL_ERROR)
                 })?.into()
             },
             Kind::GoAway => {
                 let res = frame::GoAway::load(&bytes[frame::HEADER_LEN..]);
                 res.map_err(|e| {
-                    debug!("connection error PROTOCOL_ERROR -- failed to load GO_AWAY frame; err={:?}", e);
+                    proto_err!(conn: "failed to load GO_AWAY frame; err={:?}", e);
                     Connection(Reason::PROTOCOL_ERROR)
                 })?.into()
             },
@@ -189,7 +189,7 @@ impl<T> FramedRead<T> {
             Kind::Priority => {
                 if head.stream_id() == 0 {
                     // Invalid stream identifier
-                    debug!("connection error PROTOCOL_ERROR -- invalid stream ID 0");
+                    proto_err!(conn: "invalid stream ID 0");
                     return Err(Connection(Reason::PROTOCOL_ERROR));
                 }
 
@@ -199,14 +199,15 @@ impl<T> FramedRead<T> {
                         // A stream cannot depend on itself. An endpoint MUST
                         // treat this as a stream error (Section 5.4.2) of type
                         // `PROTOCOL_ERROR`.
-                        debug!("stream error PROTOCOL_ERROR -- PRIORITY invalid dependency ID");
+                        let id = head.stream_id();
+                        proto_err!(stream: "PRIORITY invalid dependency ID; stream={:?}", id);
                         return Err(Stream {
-                            id: head.stream_id(),
+                            id,
                             reason: Reason::PROTOCOL_ERROR,
                         });
                     },
                     Err(e) => {
-                        debug!("connection error PROTOCOL_ERROR -- failed to load PRIORITY frame; err={:?};", e);
+                        proto_err!(conn: "failed to load PRIORITY frame; err={:?};", e);
                         return Err(Connection(Reason::PROTOCOL_ERROR));
                     }
                 }
@@ -217,14 +218,14 @@ impl<T> FramedRead<T> {
                 let mut partial = match self.partial.take() {
                     Some(partial) => partial,
                     None => {
-                        debug!("connection error PROTOCOL_ERROR -- received unexpected CONTINUATION frame");
+                        proto_err!(conn: "received unexpected CONTINUATION frame");
                         return Err(Connection(Reason::PROTOCOL_ERROR));
                     }
                 };
 
                 // The stream identifiers must match
                 if partial.frame.stream_id() != head.stream_id() {
-                    debug!("connection error PROTOCOL_ERROR -- CONTINUATION frame stream ID does not match previous frame stream ID");
+                    proto_err!(conn: "CONTINUATION frame stream ID does not match previous frame stream ID");
                     return Err(Connection(Reason::PROTOCOL_ERROR));
                 }
 
@@ -249,7 +250,7 @@ impl<T> FramedRead<T> {
                         // we should continue to ignore decoding, or to tell
                         // the attacker to go away.
                         if partial.buf.len() + bytes.len() > self.max_header_list_size {
-                            debug!("connection error COMPRESSION_ERROR -- CONTINUATION frame header block size over ignorable limit");
+                            proto_err!(conn: "CONTINUATION frame header block size over ignorable limit");
                             return Err(Connection(Reason::COMPRESSION_ERROR));
                         }
                     }
@@ -260,14 +261,15 @@ impl<T> FramedRead<T> {
                     Ok(_) => {},
                     Err(frame::Error::Hpack(hpack::DecoderError::NeedMore(_))) if !is_end_headers => {},
                     Err(frame::Error::MalformedMessage) => {
-                        debug!("stream error PROTOCOL_ERROR -- malformed CONTINUATION frame");
+                        let id = head.stream_id(),;
+                        proto_err!(stream: "malformed CONTINUATION frame; stream={:?}");
                         return Err(Stream {
-                            id: head.stream_id(),
+                            id,
                             reason: Reason::PROTOCOL_ERROR,
                         });
                     },
                     Err(e) => {
-                        debug!("connection error PROTOCOL_ERROR -- failed HPACK decoding; err={:?}", e);
+                        proto_err!(conn: "failed HPACK decoding; err={:?}", e);
                         return Err(Connection(Reason::PROTOCOL_ERROR));
                     },
                 }

--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -261,8 +261,8 @@ impl<T> FramedRead<T> {
                     Ok(_) => {},
                     Err(frame::Error::Hpack(hpack::DecoderError::NeedMore(_))) if !is_end_headers => {},
                     Err(frame::Error::MalformedMessage) => {
-                        let id = head.stream_id(),;
-                        proto_err!(stream: "malformed CONTINUATION frame; stream={:?}");
+                        let id = head.stream_id();
+                        proto_err!(stream: "malformed CONTINUATION frame; stream={:?}", id);
                         return Err(Stream {
                             id,
                             reason: Reason::PROTOCOL_ERROR,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,15 @@ extern crate log;
 extern crate string;
 extern crate indexmap;
 
+macro_rules! proto_err {
+    (conn: $($msg:tt)+) => {
+        debug!("connection error PROTOCOL_ERROR -- {};", format_args!($($msg)+))
+    };
+    (stream: $($msg:tt)+) => {
+        debug!("stream error PROTOCOL_ERROR -- {};", format_args!($($msg)+))
+    };
+}
+
 mod error;
 #[cfg_attr(feature = "unstable", allow(missing_docs))]
 mod codec;

--- a/src/proto/peer.rs
+++ b/src/proto/peer.rs
@@ -70,7 +70,7 @@ impl Dyn {
         if self.is_server() {
             // Ensure that the ID is a valid client initiated ID
             if mode.is_push_promise() || !id.is_client_initiated() {
-                trace!("Cannot open stream {:?} - not client initiated, PROTOCOL_ERROR", id);
+                proto_err!(conn: "cannot open stream {:?} - not client initiated", id);
                 return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
             }
 
@@ -78,7 +78,7 @@ impl Dyn {
         } else {
             // Ensure that the ID is a valid server initiated ID
             if !mode.is_push_promise() || !id.is_server_initiated() {
-                trace!("Cannot open stream {:?} - not server initiated, PROTOCOL_ERROR", id);
+                proto_err!(conn: "cannot open stream {:?} - not server initiated", id);
                 return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
             }
 

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -676,7 +676,7 @@ impl Recv {
         if !Self::safe_and_cacheable(req.method()) {
             proto_err!(
                 stream:
-                "recv_push_promise: method {} is not safe and cacheable; promised_id={:?}"
+                "recv_push_promise: method {} is not safe and cacheable; promised_id={:?}",
                 req.method(),
                 promised_id,
             );

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -189,7 +189,10 @@ impl State {
                 self.inner = ReservedRemote;
                 Ok(())
             },
-            _ => Err(RecvError::Connection(Reason::PROTOCOL_ERROR)),
+            state => {
+                warn!("reserve_remote: unexpected state {:?}", state);
+                Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
+            }
         }
     }
 

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -174,7 +174,7 @@ impl State {
             },
             state => {
                 // All other transitions result in a protocol error
-                warn!("recv_open: unexpected state {:?}", state);
+                trace!("recv_open: unexpected state {:?}", state);
                 return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
             },
         };
@@ -190,7 +190,7 @@ impl State {
                 Ok(())
             },
             state => {
-                warn!("reserve_remote: unexpected state {:?}", state);
+                trace!("reserve_remote: unexpected state {:?}", state);
                 Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
             }
         }
@@ -213,7 +213,7 @@ impl State {
                 Ok(())
             },
             state => {
-                warn!("recv_close: unexpected state {:?}", state);
+                trace!("recv_close: unexpected state {:?}", state);
                 Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
             }
         }

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -174,7 +174,7 @@ impl State {
             },
             state => {
                 // All other transitions result in a protocol error
-                trace!("recv_open: unexpected state {:?}", state);
+                proto_err!(conn: "recv_open: in unexpected state {:?}", state);
                 return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
             },
         };
@@ -190,7 +190,7 @@ impl State {
                 Ok(())
             },
             state => {
-                trace!("reserve_remote: unexpected state {:?}", state);
+                proto_err!(conn: "reserve_remote: in unexpected state {:?}", state);
                 Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
             }
         }
@@ -213,7 +213,7 @@ impl State {
                 Ok(())
             },
             state => {
-                trace!("recv_close: unexpected state {:?}", state);
+                proto_err!(conn: "recv_close: in unexpected state {:?}", state);
                 Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
             }
         }

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -172,8 +172,9 @@ impl State {
             } else {
                 HalfClosedLocal(remote)
             },
-            _ => {
+            state => {
                 // All other transitions result in a protocol error
+                warn!("recv_open: unexpected state {:?}", state);
                 return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
             },
         };
@@ -208,7 +209,10 @@ impl State {
                 self.inner = Closed(Cause::EndStream);
                 Ok(())
             },
-            _ => Err(RecvError::Connection(Reason::PROTOCOL_ERROR)),
+            state => {
+                warn!("recv_close: unexpected state {:?}", state);
+                Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
+            }
         }
     }
 
@@ -287,7 +291,7 @@ impl State {
                 trace!("send_close: HalfClosedRemote => Closed");
                 self.inner = Closed(Cause::EndStream);
             },
-            _ => panic!("transition send_close on unexpected state"),
+            state => panic!("send_close: unexpected state {:?}", state),
         }
     }
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -205,6 +205,7 @@ where
             } else {
                 if !frame.is_end_stream() {
                     // TODO: Is this the right error
+                    trace!("recv_headers; trailers frame was not EOS, PROTOCOL_ERROR; stream={:?}", stream.id);
                     return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
                 }
 
@@ -261,6 +262,7 @@ where
         let id = frame.stream_id();
 
         if id.is_zero() {
+            trace!("recv_reset; invalid stream ID 0, PROTOCOL_ERROR");
             return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
         }
 
@@ -343,6 +345,10 @@ where
             // the value they send in the last stream identifier, since the
             // peers might already have retried unprocessed requests on another
             // connection.")
+            trace!(
+                "recv_go_away; last_stream_id ({:?}) > max_stream_id ({:?}), PROTOCOL ERROR",
+                last_stream_id, actions.recv.max_stream_id(),
+            );
             return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
         }
 
@@ -427,7 +433,10 @@ where
                 stream.state.ensure_recv_open()?;
                 stream.key()
             }
-            None => return Err(RecvError::Connection(Reason::PROTOCOL_ERROR)),
+            None => {
+                trace!("recv_push_promise; initiating stream is in an invalid state, PROTOCOL_ERROR");
+                return Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
+            },
         };
 
         // TODO: Streams in the reserved states do not count towards the concurrency

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -205,7 +205,7 @@ where
             } else {
                 if !frame.is_end_stream() {
                     // TODO: Is this the right error
-                    trace!("recv_headers; trailers frame was not EOS, PROTOCOL_ERROR; stream={:?}", stream.id);
+                    proto_err!(conn: "recv_headers: trailers frame was not EOS; stream={:?}", stream.id);
                     return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
                 }
 
@@ -232,7 +232,7 @@ where
                     return Ok(());
                 }
 
-                trace!("recv_data; stream not found: {:?}", id);
+                proto_err!(conn: "recv_data: stream not found; id={:?}", id);
                 return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
             },
         };
@@ -262,7 +262,7 @@ where
         let id = frame.stream_id();
 
         if id.is_zero() {
-            trace!("recv_reset; invalid stream ID 0, PROTOCOL_ERROR");
+            proto_err!(conn: "recv_reset: invalid stream ID 0");
             return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
         }
 
@@ -345,8 +345,8 @@ where
             // the value they send in the last stream identifier, since the
             // peers might already have retried unprocessed requests on another
             // connection.")
-            trace!(
-                "recv_go_away; last_stream_id ({:?}) > max_stream_id ({:?}), PROTOCOL ERROR",
+            proto_err!(conn:
+                "recv_go_away: last_stream_id ({:?}) > max_stream_id ({:?})",
                 last_stream_id, actions.recv.max_stream_id(),
             );
             return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
@@ -434,7 +434,7 @@ where
                 stream.key()
             }
             None => {
-                trace!("recv_push_promise; initiating stream is in an invalid state, PROTOCOL_ERROR");
+                proto_err!(conn: "recv_push_promise: initiating stream is in an invalid state");
                 return Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
             },
         };

--- a/src/server.rs
+++ b/src/server.rs
@@ -1070,7 +1070,7 @@ where
             }
 
             if PREFACE[self.pos..self.pos + n] != buf[..n] {
-                trace!("read_preface; invalid preface, PROTOCOL_ERROR");
+                proto_err!(conn: "read_preface: invalid preface");
                 // TODO: Should this just write the GO_AWAY frame directly?
                 return Err(Reason::PROTOCOL_ERROR.into());
             }
@@ -1273,7 +1273,7 @@ impl proto::Peer for Peer {
             Err(e) => {
                 // TODO: Should there be more specialized handling for different
                 // kinds of errors
-                trace!("request body error: {}, PROTOCOL_ERROR", e);
+                proto_err!(stream: "error building request: {}; stream={:?}", e, stream_id);
                 return Err(RecvError::Stream {
                     id: stream_id,
                     reason: Reason::PROTOCOL_ERROR,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1070,6 +1070,7 @@ where
             }
 
             if PREFACE[self.pos..self.pos + n] != buf[..n] {
+                trace!("read_preface; invalid preface, PROTOCOL_ERROR");
                 // TODO: Should this just write the GO_AWAY frame directly?
                 return Err(Reason::PROTOCOL_ERROR.into());
             }
@@ -1230,6 +1231,7 @@ impl proto::Peer for Peer {
 
         // Specifying :status for a request is a protocol error
         if pseudo.status.is_some() {
+            trace!("malformed headers: :status field on request; PROTOCOL_ERROR");
             return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
         }
 
@@ -1268,9 +1270,10 @@ impl proto::Peer for Peer {
 
         let mut request = match b.body(()) {
             Ok(request) => request,
-            Err(_) => {
+            Err(e) => {
                 // TODO: Should there be more specialized handling for different
                 // kinds of errors
+                trace!("request body error: {}, PROTOCOL_ERROR", e);
                 return Err(RecvError::Stream {
                     id: stream_id,
                     reason: Reason::PROTOCOL_ERROR,


### PR DESCRIPTION
Currently, there are many cases where `h2` will fail a connection or
stream with a PROTOCOL_ERROR, without recording why the protocol error
occurred. Since protocol errors may result from a bug in `h2` or from a
misbehaving peer, it is important to be able to debug the cause of
protocol errors.

This branch adds a log line to almost all cases where a protocol error
occurs. I've tried to make the new log lines consistent with the
existing logging, and in some cases, changed existing log lines to make
them internally consistant with other log lines in that module. I have
_not_ tried to enforce a single style for log lines across all modules,
however, as the debug-level in some modules uses a different style than
the trace logging elsewhere. Presumably this is because it is expected
to be more user-facing.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>