### PR TITLE
Send RST_STREAM of STREAM_CLOSED instead of GOAWAY

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -140,17 +140,32 @@ where
 
         let key = match me.store.find_entry(id) {
             Entry::Occupied(e) => e.key(),
-            Entry::Vacant(e) => match me.actions.recv.open(id, Open::Headers, &mut me.counts)? {
-                Some(stream_id) => {
-                    let stream = Stream::new(
-                        stream_id,
-                        me.actions.send.init_window_sz(),
-                        me.actions.recv.init_window_sz(),
+            Entry::Vacant(e) => {
+                // This may be response headers for a stream we've already
+                // forgotten about...
+                if me.actions.may_have_forgotten_stream::<P>(id) {
+                    debug!(
+                        "recv_headers for old stream={:?}, sending STREAM_CLOSED",
+                        id,
                     );
+                    return Err(RecvError::Stream {
+                        id,
+                        reason: Reason::STREAM_CLOSED,
+                    });
+                }
 
-                    e.insert(stream)
-                },
-                None => return Ok(()),
+                match me.actions.recv.open(id, Open::Headers, &mut me.counts)? {
+                    Some(stream_id) => {
+                        let stream = Stream::new(
+                            stream_id,
+                            me.actions.send.init_window_sz(),
+                            me.actions.recv.init_window_sz(),
+                        );
+
+                        e.insert(stream)
+                    },
+                    None => return Ok(()),
+                }
             },
         };
 
@@ -230,6 +245,25 @@ where
                 if id > me.actions.recv.max_stream_id() {
                     trace!("id ({:?}) > max_stream_id ({:?}), ignoring DATA", id, me.actions.recv.max_stream_id());
                     return Ok(());
+                }
+
+                if me.actions.may_have_forgotten_stream::<P>(id) {
+                    debug!(
+                        "recv_data for old stream={:?}, sending STREAM_CLOSED",
+                        id,
+                    );
+
+                    let sz = frame.payload().len();
+                    // This should have been enforced at the codec::FramedRead layer, so
+                    // this is just a sanity check.
+                    assert!(sz <= super::MAX_WINDOW_SIZE as usize);
+                    let sz = sz as WindowSize;
+
+                    me.actions.recv.ignore_data(sz)?;
+                    return Err(RecvError::Stream {
+                        id,
+                        reason: Reason::STREAM_CLOSED,
+                    });
                 }
 
                 proto_err!(conn: "recv_data: stream not found; id={:?}", id);
@@ -670,13 +704,10 @@ where
 
         let key = match me.store.find_entry(id) {
             Entry::Occupied(e) => e.key(),
-            Entry::Vacant(e) => match me.actions.recv.open(id, Open::Headers, &mut me.counts) {
-                Ok(Some(stream_id)) => {
-                    let stream = Stream::new(stream_id, 0, 0);
+            Entry::Vacant(e) => {
+                let stream = Stream::new(id, 0, 0);
 
-                    e.insert(stream)
-                },
-                _ => return,
+                e.insert(stream)
             },
         };
 
@@ -1243,6 +1274,26 @@ impl Actions {
             Err(err.shallow_clone())
         } else {
             Ok(())
+        }
+    }
+
+    /// Check if we possibly could have processed and since forgotten this stream.
+    ///
+    /// If we send a RST_STREAM for a stream, we will eventually "forget" about
+    /// the stream to free up memory. It's possible that the remote peer had
+    /// frames in-flight, and by the time we receive them, our own state is
+    /// gone. We *could* tear everything down by sending a GOAWAY, but it
+    /// is more likely to be latency/memory constraints that caused this,
+    /// and not a bad actor. So be less catastrophic, the spec allows
+    /// us to send another RST_STREAM of STREAM_CLOSED.
+    fn may_have_forgotten_stream<P: Peer>(&self, id: StreamId) -> bool {
+        if id.is_zero() {
+            return false;
+        }
+        if P::is_local_init(id) {
+            self.send.may_have_created_stream(id)
+        } else {
+            self.recv.may_have_created_stream(id)
         }
     }
 

--- a/tests/h2-support/src/frames.rs
+++ b/tests/h2-support/src/frames.rs
@@ -316,6 +316,11 @@ impl Mock<frame::Reset> {
         Mock(frame::Reset::new(id, frame::Reason::CANCEL))
     }
 
+    pub fn stream_closed(self) -> Self {
+        let id = self.0.stream_id();
+        Mock(frame::Reset::new(id, frame::Reason::STREAM_CLOSED))
+    }
+
     pub fn internal_error(self) -> Self {
         let id = self.0.stream_id();
         Mock(frame::Reset::new(id, frame::Reason::INTERNAL_ERROR))

--- a/tests/h2-support/src/future_ext.rs
+++ b/tests/h2-support/src/future_ext.rs
@@ -72,7 +72,7 @@ pub trait FutureExt: Future {
     ///
     /// This allows the executor to poll other futures before trying this one
     /// again.
-    fn yield_once(self) -> Box<Future<Item = Self::Item, Error = Self::Error>>
+    fn yield_once(self) -> Box<dyn Future<Item = Self::Item, Error = Self::Error>>
     where
         Self: Future + Sized + 'static,
     {


### PR DESCRIPTION
In some cases, we may cancel and/or reset a stream, and then proceed to forget it from our store. Normally, we'll add it to an expiring queue to allow any frames that were in-transit to be silently ignored, as per the spec. However, in some cases, such as if many streams are reset, some may end up forgotten before the peer could have reacted. In those cases, we would send a GOAWAY, tearing down the entire connection.

Inspired by other HTTP2 implementations, if we receive a frame for a stream that we *might* have seen before, we now send a RST_STREAM of STREAM_CLOSED, and no longer trash the connection. While this might be more permissive of actual bad peers, in practice this should mostly protect from latency/memory limits that cause the connection to die.