### PR TITLE
Adjust client::Handshake's PhantomData since it doesn't own a buffer

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -190,7 +190,7 @@ use std::usize;
 pub struct Handshake<T, B = Bytes> {
     builder: Builder,
     inner: WriteAll<T, &'static [u8]>,
-    _marker: PhantomData<B>,
+    _marker: PhantomData<fn(B)>,
 }
 
 /// Initializes new HTTP/2.0 streams on a connection by sending a request.


### PR DESCRIPTION
With this change, `Handshake` can now implement auto traits even if `B` doesn't (like `Send` or `Unpin`).