### PR TITLE
Fix trailers without EOS flag to be a stream instead of connection error

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -204,9 +204,13 @@ where
                 }
             } else {
                 if !frame.is_end_stream() {
-                    // TODO: Is this the right error
-                    proto_err!(conn: "recv_headers: trailers frame was not EOS; stream={:?}", stream.id);
-                    return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+                    // Receiving trailers that don't set EOS is a "malformed"
+                    // message. Malformed messages are a stream error.
+                    proto_err!(stream: "recv_headers: trailers frame was not EOS; stream={:?}", stream.id);
+                    return Err(RecvError::Stream {
+                        id: stream.id,
+                        reason: Reason::PROTOCOL_ERROR,
+                    });
                 }
 
                 actions.recv.recv_trailers(frame, stream)


### PR DESCRIPTION
[Trailers without EOS](https://httpwg.org/specs/rfc7540.html#HttpSequence):

> An endpoint that receives a HEADERS frame without the END_STREAM flag set after receiving a final (non-informational) status code MUST treat the corresponding request or response as malformed (Section 8.1.2.6).

[Malformed messages](https://httpwg.org/specs/rfc7540.html#malformed):

> Malformed requests or responses that are detected MUST be treated as a stream error (Section 5.4.2) of type PROTOCOL_ERROR.