### PR TITLE
Clear pending_reset_expiration queue if receiving an EOS frame

### DIFF
--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -219,6 +219,15 @@ impl State {
         }
     }
 
+    /// Forces a LocallyReset stream to be fully Closed.
+    ///
+    /// Should be called when we receive an EOS frame while we were
+    /// ignoring frames to this stream "for some time".
+    pub fn reset_to_close(&mut self) {
+        debug_assert!(self.is_local_reset());
+        self.inner = Closed(Cause::EndStream);
+    }
+
     /// The remote explicitly sent a RST_STREAM.
     ///
     /// # Arguments

--- a/tests/h2-tests/tests/hammer.rs
+++ b/tests/h2-tests/tests/hammer.rs
@@ -1,5 +1,4 @@
 extern crate tokio;
-#[macro_use]
 extern crate h2_support;
 
 use h2_support::prelude::*;
@@ -11,7 +10,7 @@ use std::{net::SocketAddr, thread, sync::{atomic::{AtomicUsize, Ordering}, Arc}}
 struct Server {
     addr: SocketAddr,
     reqs: Arc<AtomicUsize>,
-    join: Option<thread::JoinHandle<()>>,
+    _join: Option<thread::JoinHandle<()>>,
 }
 
 impl Server {
@@ -51,7 +50,7 @@ impl Server {
 
         Self {
             addr,
-            join: Some(join),
+            _join: Some(join),
             reqs
         }
     }


### PR DESCRIPTION
The `pending_reset_expiration` queue keeps locally reset streams around
for "some time" to allow us to ignore frames on those streams, in case
the remote sent them before receiving our RST_STREAM. If we receive a
HEADERS or DATA frame for one of those streams, while still ignoring it,
if the frame has the EOS flag, we can now assume the remote won't send
any more frames on that stream, and can cleanup the queue.

This helps reduce the likelihood of reaching the "max concurrent reset
streams" limit.