### PR TITLE
Send RST_STREAM instead of GOAWAY if stream may have been forgotten

### DIFF
--- a/ci/h2spec.sh
+++ b/ci/h2spec.sh
@@ -3,7 +3,7 @@ LOGFILE="h2server.log"
 
 if ! [ -e "h2spec" ] ; then
     # if we don't already have a h2spec executable, wget it from github
-    wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz
+    wget https://github.com/summerwind/h2spec/releases/download/v2.1.1/h2spec_linux_amd64.tar.gz
     tar xf h2spec_linux_amd64.tar.gz
 fi
 

--- a/tests/h2-support/src/frames.rs
+++ b/tests/h2-support/src/frames.rs
@@ -316,6 +316,11 @@ impl Mock<frame::Reset> {
         Mock(frame::Reset::new(id, frame::Reason::CANCEL))
     }
 
+    pub fn stream_closed(self) -> Self {
+        let id = self.0.stream_id();
+        Mock(frame::Reset::new(id, frame::Reason::STREAM_CLOSED))
+    }
+
     pub fn internal_error(self) -> Self {
         let id = self.0.stream_id();
         Mock(frame::Reset::new(id, frame::Reason::INTERNAL_ERROR))


### PR DESCRIPTION
Re-opening of #375, with an adjustment:

The forgotten check for HEADERS is only done on the client side. The rationale is that the *client* can send a request, and then later a RST_STREAM and then forget about the stream while the server HEADERS were in transit. A *server* however will **never** reset a stream before receiving the request HEADERS.

This distinction is also done in golang-http2, grpc-go, and nghttp2. I'm hopeful this makes h2spec still pass.