### PR TITLE
Update crate to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 keywords = ["http", "async", "non-blocking"]
 categories = ["asynchronous", "web-programming", "network-programming"]
 exclude = ["fixtures/**", "ci/**"]
+edition = "2018"
 
 [badges.travis-ci]
 repository = "hyperium/h2"

--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -1,13 +1,3 @@
-extern crate env_logger;
-extern crate futures;
-extern crate h2;
-extern crate http;
-extern crate rustls;
-extern crate tokio;
-extern crate tokio_rustls;
-extern crate webpki;
-extern crate webpki_roots;
-
 use h2::client;
 
 use futures::*;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,9 +1,3 @@
-extern crate env_logger;
-extern crate futures;
-extern crate h2;
-extern crate http;
-extern crate tokio;
-
 use h2::client;
 use h2::RecvStream;
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,10 +1,3 @@
-extern crate bytes;
-extern crate env_logger;
-extern crate futures;
-extern crate h2;
-extern crate http;
-extern crate tokio;
-
 use h2::server;
 
 use bytes::*;

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,11 +65,6 @@
 //! # Example
 //!
 //! ```rust
-//! extern crate futures;
-//! extern crate h2;
-//! extern crate http;
-//! extern crate tokio;
-//!
 //! use h2::client;
 //!
 //! use futures::*;
@@ -156,13 +151,13 @@
 //! [`Builder`]: struct.Builder.html
 //! [`Error`]: ../struct.Error.html
 
-use {SendStream, RecvStream, ReleaseCapacity, PingPong};
-use codec::{Codec, RecvError, SendError, UserError};
-use frame::{Headers, Pseudo, Reason, Settings, StreamId};
-use proto;
+use crate::{SendStream, RecvStream, ReleaseCapacity, PingPong};
+use crate::codec::{Codec, RecvError, SendError, UserError};
+use crate::frame::{Headers, Pseudo, Reason, Settings, StreamId};
+use crate::proto;
 
 use bytes::{Bytes, IntoBuf};
-use futures::{Async, Future, Poll, Stream};
+use futures::{Async, Future, Poll, Stream, try_ready};
 use http::{uri, HeaderMap, Request, Response, Method, Version};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::io::WriteAll;
@@ -251,10 +246,6 @@ pub struct ReadySendRequest<B: IntoBuf> {
 /// # Examples
 ///
 /// ```
-/// # extern crate bytes;
-/// # extern crate futures;
-/// # extern crate h2;
-/// # extern crate tokio_io;
 /// # use futures::{Future, Stream};
 /// # use futures::future::Executor;
 /// # use tokio_io::*;
@@ -344,8 +335,6 @@ pub struct PushPromises {
 /// # Examples
 ///
 /// ```
-/// # extern crate h2;
-/// # extern crate tokio_io;
 /// # use tokio_io::*;
 /// # use h2::client::*;
 /// #
@@ -408,7 +397,7 @@ where
     /// See [module] level docs for more details.
     ///
     /// [module]: index.html
-    pub fn poll_ready(&mut self) -> Poll<(), ::Error> {
+    pub fn poll_ready(&mut self) -> Poll<(), crate::Error> {
         try_ready!(self.inner.poll_pending_open(self.pending.as_ref()));
         self.pending = None;
         Ok(().into())
@@ -426,9 +415,6 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate futures;
-    /// # extern crate h2;
-    /// # extern crate http;
     /// # use futures::*;
     /// # use h2::client::*;
     /// # use http::*;
@@ -493,9 +479,6 @@ where
     /// Sending a request with no body
     ///
     /// ```rust
-    /// # extern crate futures;
-    /// # extern crate h2;
-    /// # extern crate http;
     /// # use futures::*;
     /// # use h2::client::*;
     /// # use http::*;
@@ -529,9 +512,6 @@ where
     /// Sending a request with a body and trailers
     ///
     /// ```rust
-    /// # extern crate futures;
-    /// # extern crate h2;
-    /// # extern crate http;
     /// # use futures::*;
     /// # use h2::client::*;
     /// # use http::*;
@@ -586,7 +566,7 @@ where
         &mut self,
         request: Request<()>,
         end_of_stream: bool,
-    ) -> Result<(ResponseFuture, SendStream<B>), ::Error> {
+    ) -> Result<(ResponseFuture, SendStream<B>), crate::Error> {
         self.inner
             .send_request(request, end_of_stream, self.pending.as_ref())
             .map_err(Into::into)
@@ -658,7 +638,7 @@ where B: IntoBuf,
       B::Buf: 'static,
 {
     type Item = SendRequest<B>;
-    type Error = ::Error;
+    type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match self.inner {
@@ -683,8 +663,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -726,8 +704,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -762,8 +738,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -797,8 +771,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -838,8 +810,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -888,8 +858,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -930,8 +898,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -976,8 +942,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -1022,8 +986,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// # use std::time::Duration;
@@ -1061,8 +1023,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// # use std::time::Duration;
@@ -1118,8 +1078,6 @@ impl Builder {
     /// Basic usage:
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -1140,8 +1098,6 @@ impl Builder {
     /// type will be `&'static [u8]`.
     ///
     /// ```
-    /// # extern crate h2;
-    /// # extern crate tokio_io;
     /// # use tokio_io::*;
     /// # use h2::client::*;
     /// #
@@ -1193,9 +1149,6 @@ impl Default for Builder {
 /// # Examples
 ///
 /// ```
-/// # extern crate futures;
-/// # extern crate h2;
-/// # extern crate tokio_io;
 /// # use futures::*;
 /// # use tokio_io::*;
 /// # use h2::client;
@@ -1231,7 +1184,7 @@ where
     fn handshake2(io: T, builder: Builder) -> Handshake<T, B> {
         use tokio_io::io;
 
-        debug!("binding client connection");
+        log::debug!("binding client connection");
 
         let msg: &'static [u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
         let handshake = io::write_all(io, msg);
@@ -1283,9 +1236,9 @@ where
     B: IntoBuf,
 {
     type Item = ();
-    type Error = ::Error;
+    type Error = crate::Error;
 
-    fn poll(&mut self) -> Poll<(), ::Error> {
+    fn poll(&mut self) -> Poll<(), crate::Error> {
         self.inner.maybe_close_connection_if_no_streams();
         self.inner.poll().map_err(Into::into)
     }
@@ -1312,15 +1265,15 @@ where
     B::Buf: 'static,
 {
     type Item = (SendRequest<B>, Connection<T, B>);
-    type Error = ::Error;
+    type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let res = self.inner.poll()
-            .map_err(::Error::from);
+            .map_err(crate::Error::from);
 
         let (io, _) = try_ready!(res);
 
-        debug!("client connection bound");
+        log::debug!("client connection bound");
 
         // Create the codec
         let mut codec = Codec::new(io);
@@ -1375,7 +1328,7 @@ where
 
 impl Future for ResponseFuture {
     type Item = Response<RecvStream>;
-    type Error = ::Error;
+    type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let (parts, _) = try_ready!(self.inner.poll_response()).into_parts();
@@ -1391,8 +1344,8 @@ impl ResponseFuture {
     /// # Panics
     ///
     /// If the lock on the stream store has been poisoned.
-    pub fn stream_id(&self) -> ::StreamId {
-        ::StreamId::from_internal(self.inner.stream_id())
+    pub fn stream_id(&self) -> crate::StreamId {
+        crate::StreamId::from_internal(self.inner.stream_id())
     }
     /// Returns a stream of PushPromises
     ///
@@ -1413,7 +1366,7 @@ impl ResponseFuture {
 
 impl Stream for PushPromises {
     type Item = PushPromise;
-    type Error = ::Error;
+    type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         match try_ready!(self.inner.poll_pushed()) {
@@ -1454,7 +1407,7 @@ impl PushPromise {
 
 impl Future for PushedResponseFuture {
     type Item = Response<RecvStream>;
-    type Error = ::Error;
+    type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll()
@@ -1467,7 +1420,7 @@ impl PushedResponseFuture {
     /// # Panics
     ///
     /// If the lock on the stream store has been poisoned.
-    pub fn stream_id(&self) -> ::StreamId {
+    pub fn stream_id(&self) -> crate::StreamId {
         self.inner.stream_id()
     }
 }
@@ -1541,7 +1494,7 @@ impl Peer {
 impl proto::Peer for Peer {
     type Poll = Response<()>;
 
-    fn dyn() -> proto::DynPeer {
+    fn r#dyn() -> proto::DynPeer {
         proto::DynPeer::Client
     }
 

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -1,4 +1,4 @@
-use frame::{Reason, StreamId};
+use crate::frame::{Reason, StreamId};
 
 use std::{error, fmt, io};
 

--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -1,8 +1,8 @@
-use codec::RecvError;
-use frame::{self, Frame, Kind, Reason};
-use frame::{DEFAULT_MAX_FRAME_SIZE, DEFAULT_SETTINGS_HEADER_TABLE_SIZE, MAX_MAX_FRAME_SIZE};
+use crate::codec::RecvError;
+use crate::frame::{self, Frame, Kind, Reason};
+use crate::frame::{DEFAULT_MAX_FRAME_SIZE, DEFAULT_SETTINGS_HEADER_TABLE_SIZE, MAX_MAX_FRAME_SIZE};
 
-use hpack;
+use crate::hpack;
 
 use futures::*;
 
@@ -57,7 +57,7 @@ impl<T> FramedRead<T> {
     fn decode_frame(&mut self, mut bytes: BytesMut) -> Result<Option<Frame>, RecvError> {
         use self::RecvError::*;
 
-        trace!("decoding frame from {}B", bytes.len());
+        log::trace!("decoding frame from {}B", bytes.len());
 
         // Parse the head
         let head = frame::Head::parse(&bytes);
@@ -69,7 +69,7 @@ impl<T> FramedRead<T> {
 
         let kind = head.kind();
 
-        trace!("    -> kind={:?}", kind);
+        log::trace!("    -> kind={:?}", kind);
 
         macro_rules! header_block {
             ($frame:ident, $head:ident, $bytes:ident) => ({
@@ -119,7 +119,7 @@ impl<T> FramedRead<T> {
                 if is_end_headers {
                     frame.into()
                 } else {
-                    trace!("loaded partial header block");
+                    log::trace!("loaded partial header block");
                     // Defer returning the frame
                     self.partial = Some(Partial {
                         frame: Continuable::$frame(frame),
@@ -330,15 +330,15 @@ where
 
     fn poll(&mut self) -> Poll<Option<Frame>, Self::Error> {
         loop {
-            trace!("poll");
+            log::trace!("poll");
             let bytes = match try_ready!(self.inner.poll().map_err(map_err)) {
                 Some(bytes) => bytes,
                 None => return Ok(Async::Ready(None)),
             };
 
-            trace!("poll; bytes={}B", bytes.len());
+            log::trace!("poll; bytes={}B", bytes.len());
             if let Some(frame) = self.decode_frame(bytes)? {
-                debug!("received; frame={:?}", frame);
+                log::debug!("received; frame={:?}", frame);
                 return Ok(Async::Ready(Some(frame)));
             }
         }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -10,7 +10,7 @@ pub use self::error::{RecvError, SendError, UserError};
 use self::framed_read::FramedRead;
 use self::framed_write::FramedWrite;
 
-use frame::{self, Data, Frame};
+use crate::frame::{self, Data, Frame};
 
 use futures::*;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
-use codec::{SendError, UserError};
-use proto;
+use crate::codec::{SendError, UserError};
+use crate::proto;
 
 use std::{error, fmt, io};
 
-pub use frame::Reason;
+pub use crate::frame::Reason;
 
 /// Represents HTTP/2.0 operation errors.
 ///
@@ -77,7 +77,7 @@ impl Error {
 
 impl From<proto::Error> for Error {
     fn from(src: proto::Error) -> Error {
-        use proto::Error::*;
+        use crate::proto::Error::*;
 
         Error {
             kind: match src {

--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut, Bytes};
-use frame::{util, Error, Frame, Head, Kind, StreamId};
+use crate::frame::{util, Error, Frame, Head, Kind, StreamId};
 
 use std::fmt;
 

--- a/src/frame/go_away.rs
+++ b/src/frame/go_away.rs
@@ -1,4 +1,4 @@
-use frame::{self, Error, Head, Kind, Reason, StreamId};
+use crate::frame::{self, Error, Head, Kind, Reason, StreamId};
 
 use bytes::{BufMut};
 
@@ -39,7 +39,7 @@ impl GoAway {
     }
 
     pub fn encode<B: BufMut>(&self, dst: &mut B) {
-        trace!("encoding GO_AWAY; code={:?}", self.error_code);
+        log::trace!("encoding GO_AWAY; code={:?}", self.error_code);
         let head = Head::new(Kind::GoAway, 0, StreamId::zero());
         head.encode(8, dst);
         dst.put_u32_be(self.last_stream_id.into());

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -1,4 +1,4 @@
-use hpack;
+use crate::hpack;
 
 use bytes::Bytes;
 

--- a/src/frame/ping.rs
+++ b/src/frame/ping.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut, IntoBuf};
-use frame::{Error, Frame, Head, Kind, StreamId};
+use crate::frame::{Error, Frame, Head, Kind, StreamId};
 
 const ACK_FLAG: u8 = 0x1;
 
@@ -58,7 +58,7 @@ impl Ping {
 
     /// Builds a `Ping` frame from a raw frame.
     pub fn load(head: Head, bytes: &[u8]) -> Result<Ping, Error> {
-        debug_assert_eq!(head.kind(), ::frame::Kind::Ping);
+        debug_assert_eq!(head.kind(), crate::frame::Kind::Ping);
 
         // PING frames are not associated with any individual stream. If a PING
         // frame is received with a stream identifier field value other than
@@ -92,7 +92,7 @@ impl Ping {
 
     pub fn encode<B: BufMut>(&self, dst: &mut B) {
         let sz = self.payload.len();
-        trace!("encoding PING; ack={} len={}", self.ack, sz);
+        log::trace!("encoding PING; ack={} len={}", self.ack, sz);
 
         let flags = if self.ack { ACK_FLAG } else { 0 };
         let head = Head::new(Kind::Ping, flags, StreamId::zero());

--- a/src/frame/priority.rs
+++ b/src/frame/priority.rs
@@ -1,4 +1,4 @@
-use frame::*;
+use crate::frame::*;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Priority {

--- a/src/frame/reset.rs
+++ b/src/frame/reset.rs
@@ -1,4 +1,4 @@
-use frame::{self, Error, Head, Kind, Reason, StreamId};
+use crate::frame::{self, Error, Head, Kind, Reason, StreamId};
 
 use bytes::{BufMut};
 
@@ -38,7 +38,7 @@ impl Reset {
     }
 
     pub fn encode<B: BufMut>(&self, dst: &mut B) {
-        trace!(
+        log::trace!(
             "encoding RESET; id={:?} code={:?}",
             self.stream_id,
             self.error_code

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};
-use frame::{util, Error, Frame, FrameSize, Head, Kind, StreamId};
+use crate::frame::{util, Error, Frame, FrameSize, Head, Kind, StreamId};
 
 #[derive(Clone, Default, Eq, PartialEq)]
 pub struct Settings {
@@ -110,7 +110,7 @@ impl Settings {
     pub fn load(head: Head, payload: &[u8]) -> Result<Settings, Error> {
         use self::Setting::*;
 
-        debug_assert_eq!(head.kind(), ::frame::Kind::Settings);
+        debug_assert_eq!(head.kind(), crate::frame::Kind::Settings);
 
         if !head.stream_id().is_zero() {
             return Err(Error::InvalidStreamId);
@@ -131,7 +131,7 @@ impl Settings {
 
         // Ensure the payload length is correct, each setting is 6 bytes long.
         if payload.len() % 6 != 0 {
-            debug!("invalid settings payload length; len={:?}", payload.len());
+            log::debug!("invalid settings payload length; len={:?}", payload.len());
             return Err(Error::InvalidPayloadAckSettings);
         }
 
@@ -187,13 +187,13 @@ impl Settings {
         let head = Head::new(Kind::Settings, self.flags.into(), StreamId::zero());
         let payload_len = self.payload_len();
 
-        trace!("encoding SETTINGS; len={}", payload_len);
+        log::trace!("encoding SETTINGS; len={}", payload_len);
 
         head.encode(payload_len, dst);
 
         // Encode the settings
         self.for_each(|setting| {
-            trace!("encoding setting; val={:?}", setting);
+            log::trace!("encoding setting; val={:?}", setting);
             setting.encode(dst)
         });
     }

--- a/src/frame/window_update.rs
+++ b/src/frame/window_update.rs
@@ -1,4 +1,4 @@
-use frame::{self, Error, Head, Kind, StreamId};
+use crate::frame::{self, Error, Head, Kind, StreamId};
 
 use bytes::{BufMut};
 
@@ -28,7 +28,7 @@ impl WindowUpdate {
 
     /// Builds a `WindowUpdate` frame from a raw frame.
     pub fn load(head: Head, payload: &[u8]) -> Result<WindowUpdate, Error> {
-        debug_assert_eq!(head.kind(), ::frame::Kind::WindowUpdate);
+        debug_assert_eq!(head.kind(), crate::frame::Kind::WindowUpdate);
         if payload.len() != 4 {
             return Err(Error::BadFrameSize);
         }
@@ -48,7 +48,7 @@ impl WindowUpdate {
     }
 
     pub fn encode<B: BufMut>(&self, dst: &mut B) {
-        trace!("encoding WINDOW_UPDATE; id={:?}", self.stream_id);
+        log::trace!("encoding WINDOW_UPDATE; id={:?}", self.stream_id);
         let head = Head::new(Kind::WindowUpdate, 0, self.stream_id);
         head.encode(4, dst);
         dst.put_u32_be(self.size_increment);

--- a/src/hpack/decoder.rs
+++ b/src/hpack/decoder.rs
@@ -1,5 +1,5 @@
 use super::{huffman, Header};
-use frame;
+use crate::frame;
 
 use bytes::{Buf, Bytes, BytesMut};
 use http::header;
@@ -180,7 +180,7 @@ impl Decoder {
             self.last_max_update = size;
         }
 
-        trace!("decode");
+        log::trace!("decode");
 
         while let Some(ty) = peek_u8(src) {
             // At this point we are always at the beginning of the next block
@@ -188,14 +188,14 @@ impl Decoder {
             // determined from the first byte.
             match Representation::load(ty)? {
                 Indexed => {
-                    trace!("    Indexed; rem={:?}", src.remaining());
+                    log::trace!("    Indexed; rem={:?}", src.remaining());
                     can_resize = false;
                     let entry = self.decode_indexed(src)?;
                     consume(src);
                     f(entry);
                 },
                 LiteralWithIndexing => {
-                    trace!("    LiteralWithIndexing; rem={:?}", src.remaining());
+                    log::trace!("    LiteralWithIndexing; rem={:?}", src.remaining());
                     can_resize = false;
                     let entry = self.decode_literal(src, true)?;
 
@@ -206,14 +206,14 @@ impl Decoder {
                     f(entry);
                 },
                 LiteralWithoutIndexing => {
-                    trace!("    LiteralWithoutIndexing; rem={:?}", src.remaining());
+                    log::trace!("    LiteralWithoutIndexing; rem={:?}", src.remaining());
                     can_resize = false;
                     let entry = self.decode_literal(src, false)?;
                     consume(src);
                     f(entry);
                 },
                 LiteralNeverIndexed => {
-                    trace!("    LiteralNeverIndexed; rem={:?}", src.remaining());
+                    log::trace!("    LiteralNeverIndexed; rem={:?}", src.remaining());
                     can_resize = false;
                     let entry = self.decode_literal(src, false)?;
                     consume(src);
@@ -223,7 +223,7 @@ impl Decoder {
                     f(entry);
                 },
                 SizeUpdate => {
-                    trace!("    SizeUpdate; rem={:?}", src.remaining());
+                    log::trace!("    SizeUpdate; rem={:?}", src.remaining());
                     if !can_resize {
                         return Err(DecoderError::InvalidMaxDynamicSize);
                     }
@@ -245,7 +245,7 @@ impl Decoder {
             return Err(DecoderError::InvalidMaxDynamicSize);
         }
 
-        debug!(
+        log::debug!(
             "Decoder changed max table size from {} to {}",
             self.table.size(),
             new_size
@@ -299,7 +299,7 @@ impl Decoder {
         let len = decode_int(buf, 7)?;
 
         if len > buf.remaining() {
-            trace!(
+            log::trace!(
                 "decode_string underflow; len={}; remaining={}",
                 len,
                 buf.remaining()
@@ -788,7 +788,7 @@ fn from_static(s: &'static str) -> String<Bytes> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use hpack::Header;
+    use crate::hpack::Header;
 
     #[test]
     fn test_peek_u8() {

--- a/src/hpack/encoder.rs
+++ b/src/hpack/encoder.rs
@@ -413,7 +413,7 @@ fn encode_int_one_byte(value: usize, prefix_bits: usize) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use hpack::Header;
+    use crate::hpack::Header;
     use http::*;
 
     #[test]

--- a/src/hpack/huffman/mod.rs
+++ b/src/hpack/huffman/mod.rs
@@ -1,7 +1,7 @@
 mod table;
 
 use self::table::{DECODE_TABLE, ENCODE_TABLE};
-use hpack::{DecoderError, EncoderError};
+use crate::hpack::{DecoderError, EncoderError};
 
 use bytes::{BufMut, BytesMut};
 

--- a/src/hpack/test/fixture.rs
+++ b/src/hpack/test/fixture.rs
@@ -1,12 +1,8 @@
-extern crate bytes;
-extern crate hex;
-extern crate serde_json;
+use crate::hpack::{Decoder, Encoder, Header};
 
-use hpack::{Decoder, Encoder, Header};
-
-use self::bytes::BytesMut;
-use self::hex::FromHex;
-use self::serde_json::Value;
+use bytes::BytesMut;
+use hex::FromHex;
+use serde_json::Value;
 
 use std::fs::File;
 use std::io::Cursor;

--- a/src/hpack/test/fuzz.rs
+++ b/src/hpack/test/fuzz.rs
@@ -1,15 +1,10 @@
-extern crate bytes;
-extern crate env_logger;
-extern crate quickcheck;
-extern crate rand;
-
-use hpack::{Decoder, Encode, Encoder, Header};
+use crate::hpack::{Decoder, Encode, Encoder, Header};
 
 use http::header::{HeaderName, HeaderValue};
 
-use self::bytes::{Bytes, BytesMut};
-use self::quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
-use self::rand::{Rng, SeedableRng, StdRng};
+use bytes::{Bytes, BytesMut};
+use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
+use rand::{Rng, SeedableRng, StdRng};
 
 use std::io::Cursor;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,35 +88,12 @@
 #![deny(missing_debug_implementations, missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
-#[macro_use]
-extern crate futures;
-
-#[macro_use]
-extern crate tokio_io;
-
-// HTTP types
-extern crate http;
-
-// Buffer utilities
-extern crate bytes;
-
-// Hash function used for HPACK encoding and tracking stream states.
-extern crate fnv;
-
-extern crate byteorder;
-extern crate slab;
-
-#[macro_use]
-extern crate log;
-extern crate string;
-extern crate indexmap;
-
 macro_rules! proto_err {
     (conn: $($msg:tt)+) => {
-        debug!("connection error PROTOCOL_ERROR -- {};", format_args!($($msg)+))
+        log::debug!("connection error PROTOCOL_ERROR -- {};", format_args!($($msg)+))
     };
     (stream: $($msg:tt)+) => {
-        debug!("stream error PROTOCOL_ERROR -- {};", format_args!($($msg)+))
+        log::debug!("stream error PROTOCOL_ERROR -- {};", format_args!($($msg)+))
     };
 }
 
@@ -137,8 +114,8 @@ pub mod client;
 pub mod server;
 mod share;
 
-pub use error::{Error, Reason};
-pub use share::{SendStream, StreamId, RecvStream, ReleaseCapacity, PingPong, Ping, Pong};
+pub use crate::error::{Error, Reason};
+pub use crate::share::{SendStream, StreamId, RecvStream, ReleaseCapacity, PingPong, Ping, Pong};
 
 #[cfg(feature = "unstable")]
 pub use codec::{Codec, RecvError, SendError, UserError};

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -1,5 +1,5 @@
-use codec::{RecvError, SendError};
-use frame::Reason;
+use crate::codec::{RecvError, SendError};
+use crate::frame::Reason;
 
 use std::io;
 

--- a/src/proto/go_away.rs
+++ b/src/proto/go_away.rs
@@ -1,5 +1,5 @@
-use codec::Codec;
-use frame::{self, Reason, StreamId};
+use crate::codec::Codec;
+use crate::frame::{self, Reason, StreamId};
 
 use bytes::Buf;
 use futures::{Async, Poll};

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -13,13 +13,13 @@ pub(crate) use self::ping_pong::UserPings;
 pub(crate) use self::streams::{StreamRef, OpaqueStreamRef, Streams};
 pub(crate) use self::streams::{PollReset, Prioritized, Open};
 
-use codec::Codec;
+use crate::codec::Codec;
 
 use self::go_away::GoAway;
 use self::ping_pong::PingPong;
 use self::settings::Settings;
 
-use frame::{self, Frame};
+use crate::frame::{self, Frame};
 
 use futures::{task, Async, Poll};
 use futures::task::Task;

--- a/src/proto/peer.rs
+++ b/src/proto/peer.rs
@@ -1,7 +1,7 @@
-use codec::RecvError;
-use error::Reason;
-use frame::{Pseudo, StreamId};
-use proto::Open;
+use crate::codec::RecvError;
+use crate::error::Reason;
+use crate::frame::{Pseudo, StreamId};
+use crate::proto::Open;
 
 use http::{HeaderMap, Request, Response};
 
@@ -12,7 +12,7 @@ pub(crate) trait Peer {
     /// Message type polled from the transport
     type Poll: fmt::Debug;
 
-    fn dyn() -> Dyn;
+    fn r#dyn() -> Dyn;
 
     fn is_server() -> bool;
 
@@ -57,10 +57,10 @@ impl Dyn {
         &self, pseudo: Pseudo, fields: HeaderMap, stream_id: StreamId
     ) -> Result<PollMessage, RecvError> {
         if self.is_server() {
-            ::server::Peer::convert_poll_message(pseudo, fields, stream_id)
+            crate::server::Peer::convert_poll_message(pseudo, fields, stream_id)
                 .map(PollMessage::Server)
         } else {
-            ::client::Peer::convert_poll_message(pseudo, fields, stream_id)
+            crate::client::Peer::convert_poll_message(pseudo, fields, stream_id)
                 .map(PollMessage::Client)
         }
     }

--- a/src/proto/ping_pong.rs
+++ b/src/proto/ping_pong.rs
@@ -1,6 +1,6 @@
-use codec::Codec;
-use frame::Ping;
-use proto::{self, PingPayload};
+use crate::codec::Codec;
+use crate::frame::Ping;
+use crate::proto::{self, PingPayload};
 
 use bytes::Buf;
 use futures::{Async, Poll};
@@ -107,7 +107,7 @@ impl PingPong {
                         &Ping::SHUTDOWN,
                         "pending_ping should be for shutdown",
                     );
-                    trace!("recv PING SHUTDOWN ack");
+                    log::trace!("recv PING SHUTDOWN ack");
                     return ReceivedPing::Shutdown;
                 }
 
@@ -117,7 +117,7 @@ impl PingPong {
 
             if let Some(ref users) = self.user_pings {
                 if ping.payload() == &Ping::USER && users.receive_pong() {
-                    trace!("recv PING USER ack");
+                    log::trace!("recv PING USER ack");
                     return ReceivedPing::Unknown;
                 }
             }
@@ -125,7 +125,7 @@ impl PingPong {
             // else we were acked a ping we didn't send?
             // The spec doesn't require us to do anything about this,
             // so for resiliency, just ignore it for now.
-            warn!("recv PING ack that we never sent: {:?}", ping);
+            log::warn!("recv PING ack that we never sent: {:?}", ping);
             ReceivedPing::Unknown
         } else {
             // Save the ping's payload to be sent as an acknowledgement.

--- a/src/proto/settings.rs
+++ b/src/proto/settings.rs
@@ -1,6 +1,6 @@
-use codec::RecvError;
-use frame;
-use proto::*;
+use crate::codec::RecvError;
+use crate::frame;
+use crate::proto::*;
 
 #[derive(Debug)]
 pub(crate) struct Settings {
@@ -19,7 +19,7 @@ impl Settings {
 
     pub fn recv_settings(&mut self, frame: frame::Settings) {
         if frame.is_ack() {
-            debug!("received remote settings ack");
+            log::debug!("received remote settings ack");
         // TODO: handle acks
         } else {
             assert!(self.pending.is_none());
@@ -38,11 +38,11 @@ impl Settings {
         C: Buf,
         P: Peer,
     {
-        trace!("send_pending_ack; pending={:?}", self.pending);
+        log::trace!("send_pending_ack; pending={:?}", self.pending);
 
         if let Some(ref settings) = self.pending {
             if !dst.poll_ready()?.is_ready() {
-                trace!("failed to send ACK");
+                log::trace!("failed to send ACK");
                 return Ok(Async::NotReady);
             }
 
@@ -54,7 +54,7 @@ impl Settings {
                 .ok()
                 .expect("invalid settings frame");
 
-            trace!("ACK sent; applying settings");
+            log::trace!("ACK sent; applying settings");
 
             if let Some(val) = settings.max_frame_size() {
                 dst.set_max_send_frame_size(val as usize);

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -133,7 +133,7 @@ impl Counts {
 
     // TODO: move this to macro?
     pub fn transition_after(&mut self, mut stream: store::Ptr, is_reset_counted: bool) {
-        trace!("transition_after; stream={:?}; state={:?}; is_closed={:?}; \
+        log::trace!("transition_after; stream={:?}; state={:?}; is_closed={:?}; \
                pending_send_empty={:?}; buffered_send_data={}; \
                num_recv={}; num_send={}",
                stream.id,
@@ -153,7 +153,7 @@ impl Counts {
             }
 
             if stream.is_counted {
-                trace!("dec_num_streams; stream={:?}", stream.id);
+                log::trace!("dec_num_streams; stream={:?}", stream.id);
                 // Decrement the number of active streams.
                 self.dec_num_streams(&mut stream);
             }

--- a/src/proto/streams/flow_control.rs
+++ b/src/proto/streams/flow_control.rs
@@ -1,5 +1,5 @@
-use frame::Reason;
-use proto::{WindowSize, MAX_WINDOW_SIZE};
+use crate::frame::Reason;
+use crate::proto::{WindowSize, MAX_WINDOW_SIZE};
 
 use std::fmt;
 
@@ -120,7 +120,7 @@ impl FlowControl {
             return Err(Reason::FLOW_CONTROL_ERROR);
         }
 
-        trace!(
+        log::trace!(
             "inc_window; sz={}; old={}; new={}",
             sz,
             self.window_size,
@@ -136,7 +136,7 @@ impl FlowControl {
     /// This is called after receiving a SETTINGS frame with a lower
     /// INITIAL_WINDOW_SIZE value.
     pub fn dec_window(&mut self, sz: WindowSize) {
-        trace!(
+        log::trace!(
             "dec_window; sz={}; window={}, available={}",
             sz,
             self.window_size,
@@ -149,7 +149,7 @@ impl FlowControl {
     /// Decrements the window reflecting data has actually been sent. The caller
     /// must ensure that the window has capacity.
     pub fn send_data(&mut self, sz: WindowSize) {
-        trace!(
+        log::trace!(
             "send_data; sz={}; window={}; available={}",
             sz,
             self.window_size,

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -24,8 +24,8 @@ use self::state::State;
 use self::store::Store;
 use self::stream::Stream;
 
-use frame::{StreamId, StreamIdOverflow};
-use proto::*;
+use crate::frame::{StreamId, StreamIdOverflow};
+use crate::proto::*;
 
 use bytes::Bytes;
 use std::time::Duration;

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -1,12 +1,13 @@
 use super::*;
 use super::store::Resolve;
 
-use frame::{Reason, StreamId};
+use crate::frame::{Reason, StreamId};
 
-use codec::UserError;
-use codec::UserError::*;
+use crate::codec::UserError;
+use crate::codec::UserError::*;
 
 use bytes::buf::Take;
+use futures::try_ready;
 
 use std::{cmp, fmt, mem};
 use std::io;
@@ -85,7 +86,7 @@ impl Prioritize {
 
         flow.assign_capacity(config.remote_init_window_sz);
 
-        trace!("Prioritize::new; flow={:?}", flow);
+        log::trace!("Prioritize::new; flow={:?}", flow);
 
         Prioritize {
             pending_send: store::Queue::new(),
@@ -113,7 +114,7 @@ impl Prioritize {
     pub fn schedule_send(&mut self, stream: &mut store::Ptr, task: &mut Option<Task>) {
         // If the stream is waiting to be opened, nothing more to do.
         if !stream.is_pending_open {
-            trace!("schedule_send; {:?}", stream.id);
+            log::trace!("schedule_send; {:?}", stream.id);
             // Queue the stream
             self.pending_send.push(stream);
 
@@ -159,7 +160,7 @@ impl Prioritize {
         // Update the buffered data counter
         stream.buffered_send_data += sz;
 
-        trace!(
+        log::trace!(
             "send_data; sz={}; buffered={}; requested={}",
             sz,
             stream.buffered_send_data,
@@ -180,7 +181,7 @@ impl Prioritize {
             self.reserve_capacity(0, stream, counts);
         }
 
-        trace!(
+        log::trace!(
             "send_data (2); available={}; buffered={}",
             stream.send_flow.available(),
             stream.buffered_send_data
@@ -216,7 +217,7 @@ impl Prioritize {
         capacity: WindowSize,
         stream: &mut store::Ptr,
         counts: &mut Counts) {
-        trace!(
+        log::trace!(
             "reserve_capacity; stream={:?}; requested={:?}; effective={:?}; curr={:?}",
             stream.id,
             capacity,
@@ -268,7 +269,7 @@ impl Prioritize {
         inc: WindowSize,
         stream: &mut store::Ptr,
     ) -> Result<(), Reason> {
-        trace!(
+        log::trace!(
             "recv_stream_window_update; stream={:?}; state={:?}; inc={}; flow={:?}",
             stream.id,
             stream.state,
@@ -328,7 +329,7 @@ impl Prioritize {
     pub fn clear_pending_capacity(&mut self, store: &mut Store, counts: &mut Counts) {
         while let Some(stream) = self.pending_capacity.pop(store) {
             counts.transition(stream, |_, stream| {
-                trace!("clear_pending_capacity; stream={:?}", stream.id);
+                log::trace!("clear_pending_capacity; stream={:?}", stream.id);
             })
         }
     }
@@ -341,7 +342,7 @@ impl Prioritize {
     where
         R: Resolve,
     {
-        trace!("assign_connection_capacity; inc={}", inc);
+        log::trace!("assign_connection_capacity; inc={}", inc);
 
         self.flow.assign_capacity(inc);
 
@@ -385,7 +386,7 @@ impl Prioritize {
             stream.send_flow.window_size() - stream.send_flow.available().as_size(),
         );
 
-        trace!(
+        log::trace!(
             "try_assign_capacity; stream={:?}, requested={}; additional={}; buffered={}; window={}; conn={}",
             stream.id,
             total_requested,
@@ -418,7 +419,7 @@ impl Prioritize {
             // TODO: Should prioritization factor into this?
             let assign = cmp::min(conn_available, additional);
 
-            trace!(
+            log::trace!(
                 "  assigning; stream={:?}, capacity={}",
                 stream.id,
                 assign,
@@ -431,7 +432,7 @@ impl Prioritize {
             self.flow.claim_capacity(assign);
         }
 
-        trace!(
+        log::trace!(
             "try_assign_capacity(2); available={}; requested={}; buffered={}; has_unavailable={:?}",
             stream.send_flow.available(),
             stream.requested_send_capacity,
@@ -500,14 +501,14 @@ impl Prioritize {
         // The max frame length
         let max_frame_len = dst.max_send_frame_size();
 
-        trace!("poll_complete");
+        log::trace!("poll_complete");
 
         loop {
             self.schedule_pending_open(store, counts);
 
             match self.pop_frame(buffer, store, max_frame_len, counts) {
                 Some(frame) => {
-                    trace!("writing frame={:?}", frame);
+                    log::trace!("writing frame={:?}", frame);
 
                     debug_assert_eq!(self.in_flight_data_frame, InFlightData::Nothing);
                     if let Frame::Data(ref frame) = frame {
@@ -553,11 +554,11 @@ impl Prioritize {
     where
         B: Buf,
     {
-        trace!("try reclaim frame");
+        log::trace!("try reclaim frame");
 
         // First check if there are any data chunks to take back
         if let Some(frame) = dst.take_last_data_frame() {
-            trace!(
+            log::trace!(
                 "  -> reclaimed; frame={:?}; sz={}",
                 frame,
                 frame.payload().inner.get_ref().remaining()
@@ -569,7 +570,7 @@ impl Prioritize {
             match mem::replace(&mut self.in_flight_data_frame, InFlightData::Nothing) {
                 InFlightData::Nothing => panic!("wasn't expecting a frame to reclaim"),
                 InFlightData::Drop => {
-                    trace!("not reclaiming frame for cancelled stream");
+                    log::trace!("not reclaiming frame for cancelled stream");
                     return false;
                 }
                 InFlightData::DataFrame(k) => {
@@ -617,11 +618,11 @@ impl Prioritize {
     }
 
     pub fn clear_queue<B>(&mut self, buffer: &mut Buffer<Frame<B>>, stream: &mut store::Ptr) {
-        trace!("clear_queue; stream={:?}", stream.id);
+        log::trace!("clear_queue; stream={:?}", stream.id);
 
         // TODO: make this more efficient?
         while let Some(frame) = stream.pending_send.pop_front(buffer) {
-            trace!("dropping; frame={:?}", frame);
+            log::trace!("dropping; frame={:?}", frame);
         }
 
         stream.buffered_send_data = 0;
@@ -658,12 +659,12 @@ impl Prioritize {
     where
         B: Buf,
     {
-        trace!("pop_frame");
+        log::trace!("pop_frame");
 
         loop {
             match self.pending_send.pop(store) {
                 Some(mut stream) => {
-                    trace!("pop_frame; stream={:?}; stream.state={:?}",
+                    log::trace!("pop_frame; stream={:?}; stream.state={:?}",
                         stream.id, stream.state);
 
                     // It's possible that this stream, besides having data to send,
@@ -673,7 +674,7 @@ impl Prioritize {
                     // To be safe, we just always ask the stream.
                     let is_pending_reset = stream.is_pending_reset_expiration();
 
-                    trace!(" --> stream={:?}; is_pending_reset={:?};",
+                    log::trace!(" --> stream={:?}; is_pending_reset={:?};",
                         stream.id, is_pending_reset);
 
                     let frame = match stream.pending_send.pop_front(buffer) {
@@ -683,7 +684,7 @@ impl Prioritize {
                             let stream_capacity = stream.send_flow.available();
                             let sz = frame.payload().remaining();
 
-                            trace!(
+                            log::trace!(
                                 " --> data frame; stream={:?}; sz={}; eos={:?}; window={}; \
                                  available={}; requested={}; buffered={};",
                                 frame.stream_id(),
@@ -698,7 +699,7 @@ impl Prioritize {
                             // Zero length data frames always have capacity to
                             // be sent.
                             if sz > 0 && stream_capacity == 0 {
-                                trace!(
+                                log::trace!(
                                     " --> stream capacity is 0; requested={}",
                                     stream.requested_send_capacity
                                 );
@@ -730,10 +731,10 @@ impl Prioritize {
                             // capacity at this point.
                             debug_assert!(len <= self.flow.window_size());
 
-                            trace!(" --> sending data frame; len={}", len);
+                            log::trace!(" --> sending data frame; len={}", len);
 
                             // Update the flow control
-                            trace!(" -- updating stream flow --");
+                            log::trace!(" -- updating stream flow --");
                             stream.send_flow.send_data(len);
 
                             // Decrement the stream's buffered data counter
@@ -746,7 +747,7 @@ impl Prioritize {
                             // line.
                             self.flow.assign_capacity(len);
 
-                            trace!(" -- updating connection flow --");
+                            log::trace!(" -- updating connection flow --");
                             self.flow.send_data(len);
 
                             // Wrap the frame's data payload to ensure that the
@@ -784,7 +785,7 @@ impl Prioritize {
                                 // had data buffered to be sent, but all the frames are cleared
                                 // in clear_queue(). Instead of doing O(N) traversal through queue
                                 // to remove, lets just ignore the stream here.
-                                trace!("removing dangling stream from pending_send");
+                                log::trace!("removing dangling stream from pending_send");
                                 // Since this should only happen as a consequence of `clear_queue`,
                                 // we must be in a closed state of some kind.
                                 debug_assert!(stream.state.is_closed());
@@ -794,7 +795,7 @@ impl Prioritize {
                         }
                     };
 
-                    trace!("pop_frame; frame={:?}", frame);
+                    log::trace!("pop_frame; frame={:?}", frame);
 
                     if cfg!(debug_assertions) && stream.state.is_idle() {
                         debug_assert!(stream.id > self.last_opened_id);
@@ -819,11 +820,11 @@ impl Prioritize {
     }
 
     fn schedule_pending_open(&mut self, store: &mut Store, counts: &mut Counts) {
-        trace!("schedule_pending_open");
+        log::trace!("schedule_pending_open");
         // check for any pending open streams
         while counts.can_inc_num_send_streams() {
             if let Some(mut stream) = self.pending_open.pop(store) {
-                trace!("schedule_pending_open; stream={:?}", stream.id);
+                log::trace!("schedule_pending_open; stream={:?}", stream.id);
 
                 counts.inc_num_send_streams(&mut stream);
                 self.pending_send.push(&mut stream);

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -1,9 +1,9 @@
 use std::io;
 
-use codec::{RecvError, UserError};
-use codec::UserError::*;
-use frame::Reason;
-use proto::{self, PollReset};
+use crate::codec::{RecvError, UserError};
+use crate::codec::UserError::*;
+use crate::frame::Reason;
+use crate::proto::{self, PollReset};
 
 use self::Inner::*;
 use self::Peer::*;
@@ -203,12 +203,12 @@ impl State {
                 local, ..
             } => {
                 // The remote side will continue to receive data.
-                trace!("recv_close: Open => HalfClosedRemote({:?})", local);
+                log::trace!("recv_close: Open => HalfClosedRemote({:?})", local);
                 self.inner = HalfClosedRemote(local);
                 Ok(())
             },
             HalfClosedLocal(..) => {
-                trace!("recv_close: HalfClosedLocal => Closed");
+                log::trace!("recv_close: HalfClosedLocal => Closed");
                 self.inner = Closed(Cause::EndStream);
                 Ok(())
             },
@@ -244,7 +244,7 @@ impl State {
             // previous state with the received RST_STREAM, so that the queue
             // will be cleared by `Prioritize::pop_frame`.
             state => {
-                trace!(
+                log::trace!(
                     "recv_reset; reason={:?}; state={:?}; queued={:?}",
                     reason, state, queued
                 );
@@ -256,12 +256,12 @@ impl State {
 
     /// We noticed a protocol error.
     pub fn recv_err(&mut self, err: &proto::Error) {
-        use proto::Error::*;
+        use crate::proto::Error::*;
 
         match self.inner {
             Closed(..) => {},
             _ => {
-                trace!("recv_err; err={:?}", err);
+                log::trace!("recv_err; err={:?}", err);
                 self.inner = Closed(match *err {
                     Proto(reason) => Cause::LocallyReset(reason),
                     Io(..) => Cause::Io,
@@ -274,7 +274,7 @@ impl State {
         match self.inner {
             Closed(..) => {},
             s => {
-                trace!("recv_eof; state={:?}", s);
+                log::trace!("recv_eof; state={:?}", s);
                 self.inner = Closed(Cause::Io);
             }
         }
@@ -287,11 +287,11 @@ impl State {
                 remote, ..
             } => {
                 // The remote side will continue to receive data.
-                trace!("send_close: Open => HalfClosedLocal({:?})", remote);
+                log::trace!("send_close: Open => HalfClosedLocal({:?})", remote);
                 self.inner = HalfClosedLocal(remote);
             },
             HalfClosedRemote(..) => {
-                trace!("send_close: HalfClosedRemote => Closed");
+                log::trace!("send_close: HalfClosedRemote => Closed");
                 self.inner = Closed(Cause::EndStream);
             },
             state => panic!("send_close: unexpected state {:?}", state),
@@ -418,7 +418,7 @@ impl State {
     }
 
     /// Returns a reason if the stream has been reset.
-    pub(super) fn ensure_reason(&self, mode: PollReset) -> Result<Option<Reason>, ::Error> {
+    pub(super) fn ensure_reason(&self, mode: PollReset) -> Result<Option<Reason>, crate::Error> {
         match self.inner {
             Closed(Cause::Proto(reason)) |
             Closed(Cause::LocallyReset(reason)) |

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -244,10 +244,10 @@ where
     ///
     /// If the stream is already contained by the list, return `false`.
     pub fn push(&mut self, stream: &mut store::Ptr) -> bool {
-        trace!("Queue::push");
+        log::trace!("Queue::push");
 
         if N::is_queued(stream) {
-            trace!(" -> already queued");
+            log::trace!(" -> already queued");
             return false;
         }
 
@@ -259,7 +259,7 @@ where
         // Queue the stream
         match self.indices {
             Some(ref mut idxs) => {
-                trace!(" -> existing entries");
+                log::trace!(" -> existing entries");
 
                 // Update the current tail node to point to `stream`
                 let key = stream.key();
@@ -269,7 +269,7 @@ where
                 idxs.tail = stream.key();
             },
             None => {
-                trace!(" -> first entry");
+                log::trace!(" -> first entry");
                 self.indices = Some(store::Indices {
                     head: stream.key(),
                     tail: stream.key(),

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -246,12 +246,12 @@ impl Stream {
         self.send_capacity_inc = true;
         self.send_flow.assign_capacity(capacity);
 
-        trace!("  assigned capacity to stream; available={}; buffered={}; id={:?}",
+        log::trace!("  assigned capacity to stream; available={}; buffered={}; id={:?}",
                self.send_flow.available(), self.buffered_send_data, self.id);
 
         // Only notify if the capacity exceeds the amount of buffered data
         if self.send_flow.available() > self.buffered_send_data {
-            trace!("  notifying task");
+            log::trace!("  notifying task");
             self.notify_send();
         }
     }

--- a/tests/h2-fuzz/Cargo.toml
+++ b/tests/h2-fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "h2-fuzz"
 version = "0.0.0"
 publish = false
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 h2 = { path = "../.." }

--- a/tests/h2-fuzz/src/main.rs
+++ b/tests/h2-fuzz/src/main.rs
@@ -1,11 +1,3 @@
-extern crate futures;
-extern crate tokio_io;
-#[macro_use]
-extern crate honggfuzz;
-extern crate env_logger;
-extern crate h2;
-extern crate http;
-
 use futures::prelude::*;
 use futures::{executor, future, task};
 use http::{Method, Request};
@@ -155,7 +147,7 @@ fn run(script: &[u8]) -> Result<(), h2::Error> {
 fn main() {
     env_logger::init();
     loop {
-        fuzz!(|data: &[u8]| {
+        honggfuzz::fuzz!(|data: &[u8]| {
             eprintln!("{:?}", run(data));
         });
     }

--- a/tests/h2-support/Cargo.toml
+++ b/tests/h2-support/Cargo.toml
@@ -2,6 +2,7 @@
 name = "h2-support"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+edition = "2018"
 
 [dependencies]
 h2 = { path = "../..", features = ["unstable"] }

--- a/tests/h2-support/src/assert.rs
+++ b/tests/h2-support/src/assert.rs
@@ -10,7 +10,7 @@ macro_rules! assert_closed {
 macro_rules! assert_headers {
     ($frame:expr) => {{
         match $frame {
-            ::h2::frame::Frame::Headers(v) => v,
+            h2::frame::Frame::Headers(v) => v,
             f => panic!("expected HEADERS; actual={:?}", f),
         }
     }}
@@ -20,7 +20,7 @@ macro_rules! assert_headers {
 macro_rules! assert_data {
     ($frame:expr) => {{
         match $frame {
-            ::h2::frame::Frame::Data(v) => v,
+            h2::frame::Frame::Data(v) => v,
             f => panic!("expected DATA; actual={:?}", f),
         }
     }}
@@ -30,7 +30,7 @@ macro_rules! assert_data {
 macro_rules! assert_ping {
     ($frame:expr) => {{
         match $frame {
-            ::h2::frame::Frame::Ping(v) => v,
+            h2::frame::Frame::Ping(v) => v,
             f => panic!("expected PING; actual={:?}", f),
         }
     }}
@@ -40,7 +40,7 @@ macro_rules! assert_ping {
 macro_rules! assert_settings {
     ($frame:expr) => {{
         match $frame {
-            ::h2::frame::Frame::Settings(v) => v,
+            h2::frame::Frame::Settings(v) => v,
             f => panic!("expected SETTINGS; actual={:?}", f),
         }
     }}

--- a/tests/h2-support/src/lib.rs
+++ b/tests/h2-support/src/lib.rs
@@ -1,17 +1,7 @@
 //! Utilities to support tests.
 
-pub extern crate bytes;
-pub extern crate env_logger;
 #[macro_use]
-pub extern crate futures;
-pub extern crate h2;
-pub extern crate http;
-pub extern crate string;
-#[macro_use]
-pub extern crate tokio_io;
-
-#[macro_use]
-mod assert;
+pub mod assert;
 
 pub mod raw;
 
@@ -25,8 +15,8 @@ pub mod util;
 mod client_ext;
 mod future_ext;
 
-pub use client_ext::{SendRequestExt};
-pub use future_ext::{FutureExt, Unwrap};
+pub use crate::client_ext::{SendRequestExt};
+pub use crate::future_ext::{FutureExt, Unwrap};
 
 pub type WindowSize = usize;
 pub const DEFAULT_WINDOW_SIZE: WindowSize = (1 << 16) - 1;

--- a/tests/h2-support/src/mock.rs
+++ b/tests/h2-support/src/mock.rs
@@ -1,4 +1,4 @@
-use {frames, FutureExt, SendFrame};
+use crate::{frames, FutureExt, SendFrame};
 
 use h2::{self, RecvError, SendError};
 use h2::frame::{self, Frame};
@@ -22,7 +22,7 @@ pub struct Mock {
 
 #[derive(Debug)]
 pub struct Handle {
-    codec: ::Codec<Pipe>,
+    codec: crate::Codec<Pipe>,
 }
 
 #[derive(Debug)]
@@ -92,7 +92,7 @@ pub fn new_with_write_capacity(cap: usize) -> (Mock, Handle) {
 
 impl Handle {
     /// Get a mutable reference to inner Codec.
-    pub fn codec_mut(&mut self) -> &mut ::Codec<Pipe> {
+    pub fn codec_mut(&mut self) -> &mut crate::Codec<Pipe> {
         &mut self.codec
     }
 
@@ -276,7 +276,7 @@ impl io::Write for Handle {
 impl AsyncWrite for Handle {
     fn shutdown(&mut self) -> Poll<(), io::Error> {
         use std::io::Write;
-        try_nb!(self.flush());
+        tokio_io::try_nb!(self.flush());
         Ok(().into())
     }
 }
@@ -359,7 +359,7 @@ impl io::Write for Mock {
 impl AsyncWrite for Mock {
     fn shutdown(&mut self) -> Poll<(), io::Error> {
         use std::io::Write;
-        try_nb!(self.flush());
+        tokio_io::try_nb!(self.flush());
         Ok(().into())
     }
 }
@@ -426,7 +426,7 @@ impl io::Write for Pipe {
 impl AsyncWrite for Pipe {
     fn shutdown(&mut self) -> Poll<(), io::Error> {
         use std::io::Write;
-        try_nb!(self.flush());
+        tokio_io::try_nb!(self.flush());
         Ok(().into())
     }
 }
@@ -519,7 +519,7 @@ pub trait HandleFutureExt {
                         .write_buf(&mut buf)
                         .map_err(|e| panic!("write err={:?}", e));
 
-                    try_ready!(res);
+                    futures::try_ready!(res);
                 }
 
                 Ok(handle.take().unwrap().into())

--- a/tests/h2-support/src/prelude.rs
+++ b/tests/h2-support/src/prelude.rs
@@ -1,11 +1,11 @@
 
 // Re-export H2 crate
-pub use super::h2;
+pub use h2;
 
-pub use self::h2::*;
-pub use self::h2::client;
-pub use self::h2::frame::StreamId;
-pub use self::h2::server;
+pub use h2::*;
+pub use h2::client;
+pub use h2::frame::StreamId;
+pub use h2::server;
 
 // Re-export mock
 pub use super::mock::{self, HandleFutureExt};
@@ -22,11 +22,16 @@ pub use super::util;
 // Re-export some type defines
 pub use super::{Codec, SendFrame};
 
+// Re-export macros
+pub use super::{assert_ping, assert_data, assert_headers, assert_closed,
+                raw_codec, poll_frame, poll_err};
+
 // Re-export useful crates
-pub use super::{bytes, env_logger, futures, http, mock_io, tokio_io};
+pub use {bytes, env_logger, futures, http, tokio_io};
+pub use super::mock_io;
 
 // Re-export primary future types
-pub use self::futures::{Future, IntoFuture, Sink, Stream};
+pub use futures::{Future, IntoFuture, Sink, Stream};
 
 // And our Future extensions
 pub use super::future_ext::{FutureExt, Unwrap};
@@ -35,9 +40,9 @@ pub use super::future_ext::{FutureExt, Unwrap};
 pub use super::client_ext::{SendRequestExt};
 
 // Re-export HTTP types
-pub use self::http::{uri, HeaderMap, Method, Request, Response, StatusCode, Version};
+pub use http::{uri, HeaderMap, Method, Request, Response, StatusCode, Version};
 
-pub use self::bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
+pub use bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
 
 pub use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -53,7 +58,7 @@ pub trait MockH2 {
     fn handshake(&mut self) -> &mut Self;
 }
 
-impl MockH2 for mock_io::Builder {
+impl MockH2 for super::mock_io::Builder {
     fn handshake(&mut self) -> &mut Self {
         self.write(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
             // Settings frame

--- a/tests/h2-support/src/util.rs
+++ b/tests/h2-support/src/util.rs
@@ -1,6 +1,6 @@
 use h2;
 
-use super::string::{String, TryFrom};
+use string::{String, TryFrom};
 use bytes::Bytes;
 use futures::{Async, Future, Poll};
 
@@ -44,7 +44,7 @@ impl Future for WaitForCapacity {
     type Error = ();
 
     fn poll(&mut self) -> Poll<Self::Item, ()> {
-        let _ = try_ready!(self.stream().poll_capacity().map_err(|_| panic!()));
+        let _ = futures::try_ready!(self.stream().poll_capacity().map_err(|_| panic!()));
 
         let act = self.stream().capacity();
 

--- a/tests/h2-tests/Cargo.toml
+++ b/tests/h2-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "h2-tests"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -1,12 +1,8 @@
-#[macro_use]
-extern crate log;
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 #[test]
 fn handshake() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -15,7 +11,7 @@ fn handshake() {
 
     let (_client, h2) = client::handshake(mock).wait().unwrap();
 
-    trace!("hands have been shook");
+    log::trace!("hands have been shook");
 
     // At this point, the connection should be closed
     h2.wait().unwrap();
@@ -23,7 +19,7 @@ fn handshake() {
 
 #[test]
 fn client_other_thread() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -60,7 +56,7 @@ fn client_other_thread() {
 
 #[test]
 fn recv_invalid_server_stream_id() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -84,7 +80,7 @@ fn recv_invalid_server_stream_id() {
         .body(())
         .unwrap();
 
-    info!("sending request");
+    log::info!("sending request");
     let (response, _) = client.send_request(request, true).unwrap();
 
     // The connection errors
@@ -96,7 +92,7 @@ fn recv_invalid_server_stream_id() {
 
 #[test]
 fn request_stream_id_overflows() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
 
@@ -159,7 +155,7 @@ fn request_stream_id_overflows() {
 
 #[test]
 fn client_builder_max_concurrent_streams() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -199,7 +195,7 @@ fn client_builder_max_concurrent_streams() {
 
 #[test]
 fn request_over_max_concurrent_streams_errors() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
 
@@ -284,7 +280,7 @@ fn request_over_max_concurrent_streams_errors() {
 
 #[test]
 fn send_request_poll_ready_when_connection_error() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
 
@@ -362,7 +358,7 @@ fn send_request_poll_ready_when_connection_error() {
 
 #[test]
 fn send_reset_notifies_recv_stream() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
 
@@ -426,7 +422,7 @@ fn send_reset_notifies_recv_stream() {
 
 #[test]
 fn http_11_request_without_scheme_or_authority() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -461,7 +457,7 @@ fn http_11_request_without_scheme_or_authority() {
 
 #[test]
 fn http_2_request_without_scheme_or_authority() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -501,7 +497,7 @@ fn request_with_h1_version() {}
 
 #[test]
 fn request_with_connection_headers() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     // can't assert full handshake, since client never sends a request, and
@@ -544,7 +540,7 @@ fn request_with_connection_headers() {
 
 #[test]
 fn connection_close_notifies_response_future() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -587,7 +583,7 @@ fn connection_close_notifies_response_future() {
 
 #[test]
 fn connection_close_notifies_client_poll_ready() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -637,7 +633,7 @@ fn connection_close_notifies_client_poll_ready() {
 
 #[test]
 fn sending_request_on_closed_connection() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -702,7 +698,7 @@ fn sending_request_on_closed_connection() {
 
 #[test]
 fn recv_too_big_headers() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -779,7 +775,7 @@ fn recv_too_big_headers() {
 
 #[test]
 fn pending_send_request_gets_reset_by_peer_properly() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let payload = [0; (frame::DEFAULT_INITIAL_WINDOW_SIZE * 2) as usize];
@@ -842,7 +838,7 @@ fn pending_send_request_gets_reset_by_peer_properly() {
 
 #[test]
 fn request_without_path() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -870,7 +866,7 @@ fn request_without_path() {
 
 #[test]
 fn request_options_with_star() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     // Note the lack of trailing slash.
@@ -913,7 +909,7 @@ fn notify_on_send_capacity() {
     // stream, the client is notified.
     use std::sync::mpsc;
 
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let (done_tx, done_rx) = futures::sync::oneshot::channel();
@@ -999,7 +995,7 @@ fn notify_on_send_capacity() {
 
 #[test]
 fn send_stream_poll_reset() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv
@@ -1039,7 +1035,7 @@ fn send_stream_poll_reset() {
 fn drop_pending_open() {
     // This test checks that a stream queued for pending open behaves correctly when its
     // client drops.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let (init_tx, init_rx) = futures::sync::oneshot::channel();
@@ -1130,7 +1126,7 @@ fn malformed_response_headers_dont_unlink_stream() {
     // This test checks that receiving malformed headers frame on a stream with
     // no remaining references correctly resets the stream, without prematurely
     // unlinking it.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let (drop_tx, drop_rx) = futures::sync::oneshot::channel();

--- a/tests/h2-tests/tests/codec_read.rs
+++ b/tests/h2-tests/tests/codec_read.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 use std::error::Error;
@@ -135,7 +132,7 @@ fn read_headers_empty_payload() {}
 
 #[test]
 fn read_continuation_frames() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let large = build_large_headers();
@@ -191,7 +188,7 @@ fn read_continuation_frames() {
 
 #[test]
 fn update_max_frame_len_at_rest() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     // TODO: add test for updating max frame length in flight as well?
     let mut codec = raw_codec! {
         read => [

--- a/tests/h2-tests/tests/codec_write.rs
+++ b/tests/h2-tests/tests/codec_write.rs
@@ -1,12 +1,10 @@
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 #[test]
 fn write_continuation_frames() {
     // An invalid dependency ID results in a stream level error. The hpack
     // payload should still be decoded.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let large = build_large_headers();

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -1,12 +1,10 @@
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 // In this case, the stream & connection both have capacity, but capacity is not
 // explicitly requested.
 #[test]
 fn send_data_without_requesting_capacity() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = [0; 1024];
 
@@ -52,7 +50,7 @@ fn send_data_without_requesting_capacity() {
 
 #[test]
 fn release_capacity_sends_window_update() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = vec![0u8; 16_384];
 
@@ -126,7 +124,7 @@ fn release_capacity_sends_window_update() {
 
 #[test]
 fn release_capacity_of_small_amount_does_not_send_window_update() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = [0; 16];
 
@@ -190,7 +188,7 @@ fn expand_window_calls_are_coalesced() {}
 
 #[test]
 fn recv_data_overflows_connection_window() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
 
@@ -257,7 +255,7 @@ fn recv_data_overflows_connection_window() {
 #[test]
 fn recv_data_overflows_stream_window() {
     // this tests for when streams have smaller windows than their connection
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
 
@@ -324,7 +322,7 @@ fn recv_window_update_causes_overflow() {
 
 #[test]
 fn stream_error_release_connection_capacity() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -395,7 +393,7 @@ fn stream_error_release_connection_capacity() {
 
 #[test]
 fn stream_close_by_data_frame_releases_capacity() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
@@ -466,7 +464,7 @@ fn stream_close_by_data_frame_releases_capacity() {
 
 #[test]
 fn stream_close_by_trailers_frame_releases_capacity() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
@@ -543,7 +541,7 @@ fn stream_close_by_trailers_frame_releases_capacity() {
 
 #[test]
 fn stream_close_by_send_reset_frame_releases_capacity() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -595,7 +593,7 @@ fn stream_close_by_recv_reset_frame_releases_capacity() {}
 
 #[test]
 fn recv_window_update_on_stream_closed_by_data_frame() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let h2 = client::handshake(io)
@@ -644,7 +642,7 @@ fn recv_window_update_on_stream_closed_by_data_frame() {
 
 #[test]
 fn reserved_capacity_assigned_in_multi_window_updates() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let h2 = client::handshake(io)
@@ -725,11 +723,11 @@ fn reserved_capacity_assigned_in_multi_window_updates() {
 
 #[test]
 fn connection_notified_on_released_capacity() {
-    use futures::sync::oneshot;
+    use crate::futures::sync::oneshot;
     use std::sync::mpsc;
     use std::thread;
 
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     // We're going to run the connection on a thread in order to isolate task
@@ -832,7 +830,7 @@ fn connection_notified_on_released_capacity() {
 
 #[test]
 fn recv_settings_removes_available_capacity() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -890,7 +888,7 @@ fn recv_settings_removes_available_capacity() {
 
 #[test]
 fn recv_settings_keeps_assigned_capacity() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let (sent_settings, sent_settings_rx) = futures::sync::oneshot::channel();
@@ -947,7 +945,7 @@ fn recv_settings_keeps_assigned_capacity() {
 
 #[test]
 fn recv_no_init_window_then_receive_some_init_window() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -1012,7 +1010,7 @@ fn settings_lowered_capacity_returns_capacity_to_connection() {
     use std::sync::mpsc;
     use std::thread;
 
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
     let (tx1, rx1) = mpsc::channel();
     let (tx2, rx2) = mpsc::channel();
@@ -1130,7 +1128,7 @@ fn settings_lowered_capacity_returns_capacity_to_connection() {
 
 #[test]
 fn client_increase_target_window_size() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -1152,7 +1150,7 @@ fn client_increase_target_window_size() {
 
 #[test]
 fn increase_target_window_size_after_using_some() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -1204,7 +1202,7 @@ fn increase_target_window_size_after_using_some() {
 
 #[test]
 fn decrease_target_window_size() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -1252,7 +1250,7 @@ fn decrease_target_window_size() {
 
 #[test]
 fn server_target_window_size() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client.assert_server_handshake()
@@ -1273,7 +1271,7 @@ fn server_target_window_size() {
 #[test]
 fn recv_settings_increase_window_size_after_using_some() {
     // See https://github.com/hyperium/h2/issues/208
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let new_win_size = 16_384 * 4; // 1 bigger than default
@@ -1318,7 +1316,7 @@ fn recv_settings_increase_window_size_after_using_some() {
 #[test]
 fn reserve_capacity_after_peer_closes() {
     // See https://github.com/hyperium/h2/issues/300
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -1357,7 +1355,7 @@ fn reserve_capacity_after_peer_closes() {
 fn reset_stream_waiting_for_capacity() {
     // This tests that receiving a reset on a stream that has some available
     // connection-level window reassigns that window to another stream.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
 
@@ -1419,7 +1417,7 @@ fn reset_stream_waiting_for_capacity() {
 
 #[test]
 fn data_padding() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let mut body = Vec::new();

--- a/tests/h2-tests/tests/hammer.rs
+++ b/tests/h2-tests/tests/hammer.rs
@@ -1,9 +1,5 @@
-extern crate tokio;
-#[macro_use]
-extern crate h2_support;
-
 use h2_support::prelude::*;
-use h2_support::futures::{Async, Poll};
+use futures::{Async, Poll};
 
 use tokio::net::{TcpListener, TcpStream};
 use std::{net::SocketAddr, thread, sync::{atomic::{AtomicUsize, Ordering}, Arc}};

--- a/tests/h2-tests/tests/ping_pong.rs
+++ b/tests/h2-tests/tests/ping_pong.rs
@@ -1,11 +1,9 @@
-#[macro_use]
-extern crate h2_support;
-
 use h2_support::prelude::*;
+use h2_support::assert_ping;
 
 #[test]
 fn recv_single_ping() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (m, mock) = mock::new();
 
     // Create the handshake
@@ -41,7 +39,7 @@ fn recv_single_ping() {
 
 #[test]
 fn recv_multiple_pings() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client.assert_server_handshake()
@@ -65,7 +63,7 @@ fn recv_multiple_pings() {
 
 #[test]
 fn pong_has_highest_priority() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let data = Bytes::from(vec![0; 16_384]);
@@ -111,7 +109,7 @@ fn pong_has_highest_priority() {
 
 #[test]
 fn user_ping_pong() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -160,7 +158,7 @@ fn user_ping_pong() {
 
 #[test]
 fn user_notifies_when_connection_closes() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()

--- a/tests/h2-tests/tests/prioritization.rs
+++ b/tests/h2-tests/tests/prioritization.rs
@@ -1,12 +1,9 @@
-#[macro_use]
-extern crate h2_support;
-
 use h2_support::{DEFAULT_WINDOW_SIZE};
 use h2_support::prelude::*;
 
 #[test]
 fn single_stream_send_large_body() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = [0; 1024];
 
@@ -69,7 +66,7 @@ fn single_stream_send_large_body() {
 
 #[test]
 fn multiple_streams_with_payload_greater_than_default_window() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = vec![0; 16384*5-1];
 
@@ -132,7 +129,7 @@ fn multiple_streams_with_payload_greater_than_default_window() {
 
 #[test]
 fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = vec![0; 32_768];
 
@@ -199,7 +196,7 @@ fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
 
 #[test]
 fn single_stream_send_body_greater_than_default_window() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = vec![0; 16384*5-1];
 
@@ -292,7 +289,7 @@ fn single_stream_send_body_greater_than_default_window() {
 
 #[test]
 fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let payload = vec![0; 32_768];
 
@@ -358,7 +355,7 @@ fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
 
 #[test]
 fn send_data_receive_window_update() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (m, mock) = mock::new();
 
     let h2 = client::handshake(m)

--- a/tests/h2-tests/tests/push_promise.rs
+++ b/tests/h2-tests/tests/push_promise.rs
@@ -1,10 +1,8 @@
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 #[test]
 fn recv_push_works() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()
@@ -56,7 +54,7 @@ fn recv_push_works() {
 #[test]
 fn pushed_streams_arent_dropped_too_early() {
     // tests that by default, received push promises work
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()
@@ -110,7 +108,7 @@ fn pushed_streams_arent_dropped_too_early() {
 
 #[test]
 fn recv_push_when_push_disabled_is_conn_error() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()
@@ -163,7 +161,7 @@ fn recv_push_when_push_disabled_is_conn_error() {
 
 #[test]
 fn pending_push_promises_reset_when_dropped() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let srv = srv.assert_client_handshake()
@@ -206,7 +204,7 @@ fn pending_push_promises_reset_when_dropped() {
 
 #[test]
 fn recv_push_promise_over_max_header_list_size() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -257,7 +255,7 @@ fn recv_push_promise_over_max_header_list_size() {
 #[test]
 fn recv_invalid_push_promise_headers_is_stream_protocol_error() {
     // Unsafe method or content length is stream protocol error
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()
@@ -317,7 +315,7 @@ fn recv_push_promise_with_wrong_authority_is_stream_error() {
 
 #[test]
 fn recv_push_promise_skipped_stream_id() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()
@@ -367,7 +365,7 @@ fn recv_push_promise_skipped_stream_id() {
 
 #[test]
 fn recv_push_promise_dup_stream_id() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -1,7 +1,5 @@
 #![deny(warnings)]
 
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 const SETTINGS: &'static [u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
@@ -9,7 +7,7 @@ const SETTINGS_ACK: &'static [u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 
 #[test]
 fn read_preface_in_multiple_frames() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .read(b"PRI * HTTP/2.0")
@@ -27,7 +25,7 @@ fn read_preface_in_multiple_frames() {
 
 #[test]
 fn server_builder_set_max_concurrent_streams() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -77,7 +75,7 @@ fn server_builder_set_max_concurrent_streams() {
 
 #[test]
 fn serve_request() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -114,7 +112,7 @@ fn accept_with_pending_connections_after_socket_close() {}
 
 #[test]
 fn recv_invalid_authority() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let bad_auth = util::byte_str("not:a/good authority");
@@ -141,7 +139,7 @@ fn recv_invalid_authority() {
 
 #[test]
 fn recv_connection_header() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let req = |id, name, val| {
@@ -176,7 +174,7 @@ fn recv_connection_header() {
 
 #[test]
 fn sends_reset_cancel_when_req_body_is_dropped() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -209,7 +207,7 @@ fn sends_reset_cancel_when_req_body_is_dropped() {
 
 #[test]
 fn abrupt_shutdown() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -255,7 +253,7 @@ fn abrupt_shutdown() {
 
 #[test]
 fn graceful_shutdown() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -341,7 +339,7 @@ fn graceful_shutdown() {
 
 #[test]
 fn sends_reset_cancel_when_res_body_is_dropped() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -399,7 +397,7 @@ fn sends_reset_cancel_when_res_body_is_dropped() {
 
 #[test]
 fn too_big_headers_sends_431() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -436,7 +434,7 @@ fn too_big_headers_sends_431() {
 
 #[test]
 fn too_big_headers_sends_reset_after_431_if_not_eos() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -472,7 +470,7 @@ fn too_big_headers_sends_reset_after_431_if_not_eos() {
 
 #[test]
 fn poll_reset() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -518,7 +516,7 @@ fn poll_reset() {
 
 #[test]
 fn poll_reset_io_error() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -560,7 +558,7 @@ fn poll_reset_io_error() {
 
 #[test]
 fn poll_reset_after_send_response_is_user_error() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -614,7 +612,7 @@ fn poll_reset_after_send_response_is_user_error() {
 fn server_error_on_unclean_shutdown() {
     use std::io::Write;
 
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, mut client) = mock::new();
 
     let srv = server::Builder::new()
@@ -628,7 +626,7 @@ fn server_error_on_unclean_shutdown() {
 
 #[test]
 fn request_without_authority() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client

--- a/tests/h2-tests/tests/stream_states.rs
+++ b/tests/h2-tests/tests/stream_states.rs
@@ -1,9 +1,5 @@
 #![deny(warnings)]
 
-#[macro_use]
-extern crate log;
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 #[test]
@@ -30,7 +26,7 @@ fn send_recv_headers_only() {
         .body(())
         .unwrap();
 
-    info!("sending request");
+    log::info!("sending request");
     let (response, _) = client.send_request(request, true).unwrap();
 
     let resp = h2.run(response).unwrap();
@@ -72,7 +68,7 @@ fn send_recv_data() {
         .body(())
         .unwrap();
 
-    info!("sending request");
+    log::info!("sending request");
     let (response, mut stream) = client.send_request(request, false).unwrap();
 
     // Reserve send capacity
@@ -129,7 +125,7 @@ fn send_headers_recv_data_single_frame() {
         .body(())
         .unwrap();
 
-    info!("sending request");
+    log::info!("sending request");
     let (response, _) = client.send_request(request, true).unwrap();
 
     let resp = h2.run(response).unwrap();
@@ -153,7 +149,7 @@ fn send_headers_recv_data_single_frame() {
 
 #[test]
 fn closed_streams_are_released() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
@@ -198,7 +194,7 @@ fn closed_streams_are_released() {
 
 #[test]
 fn errors_if_recv_frame_exceeds_max_frame_size() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, mut srv) = mock::new();
 
     let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
@@ -246,7 +242,7 @@ fn errors_if_recv_frame_exceeds_max_frame_size() {
 
 #[test]
 fn configure_max_frame_size() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, mut srv) = mock::new();
 
     let h2 = client::Builder::new()
@@ -290,7 +286,7 @@ fn configure_max_frame_size() {
 
 #[test]
 fn recv_goaway_finishes_processed_streams() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -347,7 +343,7 @@ fn recv_goaway_finishes_processed_streams() {
 
 #[test]
 fn recv_next_stream_id_updated_by_malformed_headers() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, client) = mock::new();
 
 
@@ -385,7 +381,7 @@ fn recv_next_stream_id_updated_by_malformed_headers() {
 
 #[test]
 fn skipped_stream_ids_are_implicitly_closed() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv
@@ -424,7 +420,7 @@ fn skipped_stream_ids_are_implicitly_closed() {
 
 #[test]
 fn send_rst_stream_allows_recv_data() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -470,7 +466,7 @@ fn send_rst_stream_allows_recv_data() {
 
 #[test]
 fn send_rst_stream_allows_recv_trailers() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -512,7 +508,7 @@ fn send_rst_stream_allows_recv_trailers() {
 
 #[test]
 fn rst_stream_expires() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -561,7 +557,7 @@ fn rst_stream_expires() {
 
 #[test]
 fn rst_stream_max() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -627,7 +623,7 @@ fn rst_stream_max() {
 
 #[test]
 fn reserved_state_recv_window_update() {
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -715,11 +711,11 @@ fn rst_while_closing() {
     // Test to reproduce panic in issue #246 --- receipt of a RST_STREAM frame
     // on a stream in the Half Closed (remote) state with a queued EOS causes
     // a panic.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     // Rendevous when we've queued a trailers frame
-    let (tx, rx) = ::futures::sync::oneshot::channel();
+    let (tx, rx) = crate::futures::sync::oneshot::channel();
 
     let srv = srv.assert_client_handshake()
         .unwrap()
@@ -786,13 +782,13 @@ fn rst_with_buffered_data() {
     // the data is fully flushed. Given that resetting a stream requires
     // clearing all associated state for that stream, this test ensures that the
     // buffered up frame is correctly handled.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     // This allows the settings + headers frame through
     let (io, srv) = mock::new_with_write_capacity(73);
 
     // Synchronize the client / server on response
-    let (tx, rx) = ::futures::sync::oneshot::channel();
+    let (tx, rx) = crate::futures::sync::oneshot::channel();
 
     let srv = srv.assert_client_handshake()
         .unwrap()
@@ -851,13 +847,13 @@ fn err_with_buffered_data() {
     // the data is fully flushed. Given that resetting a stream requires
     // clearing all associated state for that stream, this test ensures that the
     // buffered up frame is correctly handled.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     // This allows the settings + headers frame through
     let (io, srv) = mock::new_with_write_capacity(73);
 
     // Synchronize the client / server on response
-    let (tx, rx) = ::futures::sync::oneshot::channel();
+    let (tx, rx) = crate::futures::sync::oneshot::channel();
 
     let srv = srv.assert_client_handshake()
         .unwrap()
@@ -915,13 +911,13 @@ fn send_err_with_buffered_data() {
     // the data is fully flushed. Given that resetting a stream requires
     // clearing all associated state for that stream, this test ensures that the
     // buffered up frame is correctly handled.
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
 
     // This allows the settings + headers frame through
     let (io, srv) = mock::new_with_write_capacity(73);
 
     // Synchronize the client / server on response
-    let (tx, rx) = ::futures::sync::oneshot::channel();
+    let (tx, rx) = crate::futures::sync::oneshot::channel();
 
     let srv = srv.assert_client_handshake()
         .unwrap()
@@ -961,7 +957,7 @@ fn send_err_with_buffered_data() {
             stream.send_data(body.into(), true).unwrap();
 
             // Hack to drive the connection, trying to flush data
-            ::futures::future::lazy(|| {
+            crate::futures::future::lazy(|| {
                 conn.poll().unwrap();
                 Ok::<_, ()>(())
             }).wait().unwrap();
@@ -987,7 +983,7 @@ fn send_err_with_buffered_data() {
 #[test]
 fn srv_window_update_on_lower_stream_id() {
     // See https://github.com/hyperium/h2/issues/208
-    let _ = ::env_logger::try_init();
+    let _ = env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()

--- a/tests/h2-tests/tests/trailers.rs
+++ b/tests/h2-tests/tests/trailers.rs
@@ -1,7 +1,3 @@
-#[macro_use]
-extern crate log;
-extern crate h2_support;
-
 use h2_support::prelude::*;
 
 #[test]
@@ -31,7 +27,7 @@ fn recv_trailers_only() {
         .body(())
         .unwrap();
 
-    info!("sending request");
+    log::info!("sending request");
     let (response, _) = client.send_request(request, true).unwrap();
 
     let response = h2.run(response).unwrap();
@@ -79,7 +75,7 @@ fn send_trailers_immediately() {
         .body(())
         .unwrap();
 
-    info!("sending request");
+    log::info!("sending request");
     let (response, mut stream) = client.send_request(request, false).unwrap();
 
     let mut trailers = HeaderMap::new();

--- a/util/genfixture/Cargo.toml
+++ b/util/genfixture/Cargo.toml
@@ -3,6 +3,7 @@ name = "genfixture"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 walkdir = "1.0.0"

--- a/util/genfixture/src/main.rs
+++ b/util/genfixture/src/main.rs
@@ -1,6 +1,4 @@
-extern crate walkdir;
-
-use self::walkdir::WalkDir;
+use walkdir::WalkDir;
 
 use std::env;
 use std::path::Path;

--- a/util/genhuff/Cargo.toml
+++ b/util/genhuff/Cargo.toml
@@ -3,5 +3,6 @@ name = "genhuff"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This PR moves the crate (and all sub-crates) to Rust 2018. This should make moving to `std::future` in the (hopefully near) future simpler.

Macros were a bit painful to handle, I explicitly namespaced logging macros (`warn!` => `log::warn!`), because I didn't want to import all the logging macros globally in each file nor enumerate the used macros. For the `futures` and `tokio_io` macros in respective files I imported them globally to keep the code using them unchanged (it was just one macro in each case, so it was simple - `try_nb` and `try_ready`).

For crate imports, `crate::` is used everywhere (instead of `super`), to keep it consistent (this was done using `rustfix`). There are a few needless crate imports instead of direct usages (`crate::futures`) in the integration tests - this was generatd because of reexports in the `h2_support` prelude. I can remove them if you want, but it should work anyway.

Let me know if you want me to make any changes and/or if you want to accept this at all :-)