### PR TITLE
chore: 2018 edition clean up

### DIFF
--- a/src/hpack/test/fuzz.rs
+++ b/src/hpack/test/fuzz.rs
@@ -79,7 +79,7 @@ impl FuzzHpack {
 
                     frame.resizes.extend(&[low, high]);
                 },
-                1...3 => {
+                1..=3 => {
                     frame.resizes.push(rng.gen_range(128, MAX_CHUNK * 2));
                 },
                 _ => {},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,6 @@
 //! h2 = "0.1"
 //! ```
 //!
-//! Next, add this to your crate:
-//!
-//! ```no_run
-//! extern crate h2;
-//! ```
-//!
 //! # Layout
 //!
 //! The crate is split into [`client`] and [`server`] modules. Types that are


### PR DESCRIPTION
Test fail to build on current nightly due to deprecation warning.