### PR TITLE
Add necessary features for tokio-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 
 [dependencies]
 futures-preview = "0.3.0-alpha.18"
-tokio-io = "0.2.0-alpha.2"
+tokio-io = { version = "0.2.0-alpha.2", features = ["util"] }
 tokio-codec = "0.2.0-alpha.2"
 bytes = "0.4.7"
 http = "0.1.8"


### PR DESCRIPTION
If you remove the dev-dependencies from the `Cargo.toml` (or use this crate as a non-path dependency in a project which doesn't pull in all of Tokio) you will get a build failure like:

```
    Checking h2 v0.2.0-alpha.0 (/Users/nemo157/sources/h2)
error[E0432]: unresolved import `tokio_io::AsyncWriteExt`
   --> src/client.rs:154:39
    |
154 | use tokio_io::{AsyncRead, AsyncWrite, AsyncWriteExt};
    |                                       ^^^^^^^^^^^^^
    |                                       |
    |                                       no `AsyncWriteExt` in the root
    |                                       help: a similar name exists in the module: `AsyncWrite`

error[E0599]: no method named `write_all` found for type `T` in the current scope
    --> src/client.rs:1142:12
     |
1142 |         io.write_all(msg).await?;
     |            ^^^^^^^^^
     |
     = help: items from traits can only be used if the type parameter is bounded by the trait
help: the following traits define an item `write_all`, perhaps you need to restrict type parameter `T` with one of them:
     |
1129 | impl<T: std::io::Write, B> Connection<T, B>
     |      ^^^^^^^^^^^^^^^^^
1129 | impl<T: futures_util::io::AsyncWriteExt, B> Connection<T, B>
     |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is because the `AsyncWriteExt` trait is gated on the `util` feature which is non-default.