### PR TITLE
fixing the akamai example to work with tokio-0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ serde_json = "1.0.0"
 # Akamai example
 tokio = "=0.2.0-alpha.4"
 env_logger = { version = "0.5.3", default-features = false }
-rustls = "0.12"
-tokio-rustls = "0.5.0"
-webpki = "0.18"
-webpki-roots = "0.14"
+rustls = "0.16"
+tokio-rustls = { git = "https://github.com/quininer/tokio-rustls", branch = "tokio-0.2" }
+webpki = "0.21"
+webpki-roots = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,6 @@ serde_json = "1.0.0"
 tokio = "=0.2.0-alpha.4"
 env_logger = { version = "0.5.3", default-features = false }
 rustls = "0.16"
-tokio-rustls = { git = "https://github.com/quininer/tokio-rustls", branch = "tokio-0.2" }
+tokio-rustls = "0.12.0-alpha.2"
 webpki = "0.21"
 webpki-roots = "0.17"

--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -1,21 +1,13 @@
-fn main() {
-    // Enable the below code once tokio_rustls moves to std::future
-}
-
-/*
 use h2::client;
-
-use futures::*;
 use http::{Method, Request};
-
 use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
 
 use rustls::Session;
-use tokio_rustls::ClientConfigExt;
 use webpki::DNSNameRef;
 
-use std::net::ToSocketAddrs;
 use std::error::Error;
+use std::net::ToSocketAddrs;
 
 const ALPN_H2: &str = "h2";
 
@@ -27,7 +19,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let mut c = rustls::ClientConfig::new();
         c.root_store
             .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-        c.alpn_protocols.push(ALPN_H2.to_owned());
+        c.alpn_protocols.push(ALPN_H2.as_bytes().to_owned());
         c
     });
 
@@ -42,28 +34,31 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     let tcp = TcpStream::connect(&addr).await?;
     let dns_name = DNSNameRef::try_from_ascii_str("http2.akamai.com").unwrap();
-    let res = tls_client_config.connect_async(dns_name, tcp).await;
+    let connector = TlsConnector::from(tls_client_config);
+    let res = connector.connect(dns_name, tcp).await;
     let tls = res.unwrap();
     {
         let (_, session) = tls.get_ref();
         let negotiated_protocol = session.get_alpn_protocol();
-        assert_eq!(Some(ALPN_H2), negotiated_protocol.as_ref().map(|x| &**x));
+        assert_eq!(
+            Some(ALPN_H2.as_bytes()),
+            negotiated_protocol.as_ref().map(|x| &**x)
+        );
     }
 
     println!("Starting client handshake");
-    let (mut client, h2) = client::handshake(tls).await?;
+    let (mut client, _h2) = client::handshake(tls).await?;
 
     let request = Request::builder()
-                    .method(Method::GET)
-                    .uri("https://http2.akamai.com/")
-                    .body(())
-                    .unwrap();
+        .method(Method::GET)
+        .uri("https://http2.akamai.com/")
+        .body(())
+        .unwrap();
 
     let (response, _) = client.send_request(request, true).unwrap();
     let (_, mut body) = response.await?.into_parts();
-    while let Some(chunk) = body.next().await {
+    while let Some(chunk) = body.data().await {
         println!("RX: {:?}", chunk?);
     }
     Ok(())
 }
-*/


### PR DESCRIPTION
This PR brings the rustls and webpki current (resolving some version conflicts with ring)  
It also leverages the tokio-0.2 branch to make the akamai example work^H^H^H^Hcompile again. 