### PR TITLE
Decode debug_data in GOAWAY frames

### DIFF
--- a/src/frame/go_away.rs
+++ b/src/frame/go_away.rs
@@ -1,11 +1,15 @@
+use std::fmt;
+
+use bytes::{BufMut, Bytes};
+
 use crate::frame::{self, Error, Head, Kind, Reason, StreamId};
 
-use bytes::BufMut;
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct GoAway {
     last_stream_id: StreamId,
     error_code: Reason,
+    #[allow(unused)]
+    debug_data: Bytes,
 }
 
 impl GoAway {
@@ -13,6 +17,7 @@ impl GoAway {
         GoAway {
             last_stream_id,
             error_code: reason,
+            debug_data: Bytes::new(),
         }
     }
 
@@ -24,6 +29,11 @@ impl GoAway {
         self.error_code
     }
 
+    #[cfg(feature = "unstable")]
+    pub fn debug_data(&self) -> &[u8] {
+        &self.debug_data
+    }
+
     pub fn load(payload: &[u8]) -> Result<GoAway, Error> {
         if payload.len() < 8 {
             return Err(Error::BadFrameSize);
@@ -31,10 +41,12 @@ impl GoAway {
 
         let (last_stream_id, _) = StreamId::parse(&payload[..4]);
         let error_code = unpack_octets_4!(payload, 4, u32);
+        let debug_data = Bytes::from(&payload[8..]);
 
         Ok(GoAway {
             last_stream_id,
             error_code: error_code.into(),
+            debug_data,
         })
     }
 
@@ -50,5 +62,19 @@ impl GoAway {
 impl<B> From<GoAway> for frame::Frame<B> {
     fn from(src: GoAway) -> Self {
         frame::Frame::GoAway(src)
+    }
+}
+
+impl fmt::Debug for GoAway {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut builder = f.debug_struct("GoAway");
+        builder.field("error_code", &self.error_code);
+        builder.field("last_stream_id", &self.last_stream_id);
+
+        if !self.debug_data.is_empty() {
+            builder.field("debug_data", &self.debug_data);
+        }
+
+        builder.finish()
     }
 }


### PR DESCRIPTION
While this currently doesn't allow *sending* debug data, it can be useful to see when logging *why* a connection is being closed.