### PR TITLE
Rename unstable-stream feature to stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ edition = "2018"
 
 [features]
 # Enables `futures::Stream` implementations for various types.
-# This is an optional feature due to `Stream` not being stable.
-unstable-stream = []
+stream = []
 
 # Enables **unstable** APIs. Any API exposed by this feature has no backwards
 # compatibility guarantees. In other words, you should not use this feature for
@@ -38,9 +37,9 @@ members = [
 ]
 
 [dependencies]
-futures-core = "0.3"
-futures-sink = "0.3"
-futures-util = { version = "0.3", default-features = false, features = [] }
+futures-core = { version = "0.3", default-features = false }
+futures-sink = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 tokio-util = { version = "0.2", features = ["codec"] }
 tokio = { version = "0.2", features = ["io-util", "sync"] }
 bytes = "0.5.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1319,7 +1319,7 @@ impl PushPromises {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
+#[cfg(feature = "stream")]
 impl futures_core::Stream for PushPromises {
     type Item = Result<PushPromise, crate::Error>;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -519,7 +519,7 @@ where
     }
 }
 
-#[cfg(feature = "unstable-stream")]
+#[cfg(feature = "stream")]
 impl<T, B> futures_core::Stream for Connection<T, B>
 where
     T: AsyncRead + AsyncWrite + Unpin,

--- a/src/share.rs
+++ b/src/share.rs
@@ -7,7 +7,7 @@ use http::HeaderMap;
 
 use crate::PollExt;
 use std::fmt;
-#[cfg(feature = "unstable-stream")]
+#[cfg(feature = "stream")]
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -448,7 +448,7 @@ impl RecvStream {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
+#[cfg(feature = "stream")]
 impl futures_core::Stream for RecvStream {
     type Item = Result<Bytes, crate::Error>;
 

--- a/tests/h2-support/Cargo.toml
+++ b/tests/h2-support/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 
 [dependencies]
-h2 = { path = "../..", features = ["unstable-stream", "unstable"] }
+h2 = { path = "../..", features = ["stream", "unstable"] }
 
 bytes = "0.5"
 env_logger = "0.5.9"


### PR DESCRIPTION
Until 1.0, it's not really fair to call other dependencies "unstable".