### PR TITLE
[wip] Add an API to track and wait on the amount of data in h2's internal buffers.

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -731,6 +731,7 @@ impl Prioritize {
                             debug_assert!(stream.buffered_send_data >= len);
                             stream.buffered_send_data -= len;
                             stream.requested_send_capacity -= len;
+                            stream.notify_buffered_send_data();
 
                             // Assign the capacity back to the connection that
                             // was just consumed from the stream in the previous

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1082,6 +1082,26 @@ impl<B> StreamRef<B> {
         me.actions.send.poll_capacity(cx, &mut stream)
     }
 
+    /// Returns the stream's current send buffer size.
+    pub fn buffered_data(&self) -> usize {
+        let mut me = self.opaque.inner.lock().unwrap();
+        let me = &mut *me;
+
+        let mut stream = me.store.resolve(self.opaque.key);
+
+        me.actions.send.buffered_data(&mut stream)
+    }
+
+    /// Request to be notified when the stream's buffered data falls below `bytes`
+    pub fn poll_buffered_data(&mut self, cx: &Context, bytes: usize) -> Poll<Option<Result<usize, UserError>>> {
+        let mut me = self.opaque.inner.lock().unwrap();
+        let me = &mut *me;
+
+        let mut stream = me.store.resolve(self.opaque.key);
+
+        me.actions.send.poll_buffered_data(cx, &mut stream, bytes)
+    }
+
     /// Request to be notified for if a `RST_STREAM` is received for this stream.
     pub(crate) fn poll_reset(
         &mut self,

--- a/src/share.rs
+++ b/src/share.rs
@@ -316,6 +316,21 @@ impl<B: Buf> SendStream<B> {
             .map_err_(Into::into)
     }
 
+    /// Returns the number of bytes of data currently queued for send on this stream.
+    pub fn buffered_data(&self) -> usize {
+        self.inner.buffered_data()
+    }
+
+    /// Requests to be notified when the amount of data buffered on this stream
+    /// falls below `bytes`.
+    ///
+    /// Returns `None` if the stream is no longer sending.
+    pub fn poll_buffered_data(&mut self, cx: &mut Context, bytes: usize) -> Poll<Option<Result<usize, crate::Error>>> {
+        self.inner
+            .poll_buffered_data(cx, bytes)
+            .map_err_(Into::into)
+    }
+
     /// Sends a single data frame to the remote peer.
     ///
     /// This function may be called repeatedly as long as `end_of_stream` is set


### PR DESCRIPTION
This is my stab at #448. Does this seem like a reasonable API?

I guess that technically this still isn't fully accurate in that data could be buffered inside of the `Codec`. Not sure if that's a big deal though.