### PR TITLE
Fix receiving a GOAWAY frame from updating the max recv ID

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -392,24 +392,10 @@ where
         let send_buffer = &mut *send_buffer;
 
         let last_stream_id = frame.last_stream_id();
+
+        actions.send.recv_go_away(last_stream_id)?;
+
         let err = frame.reason().into();
-
-        if last_stream_id > actions.recv.max_stream_id() {
-            // The remote endpoint sent a `GOAWAY` frame indicating a stream
-            // that we never sent, or that we have already terminated on account
-            // of previous `GOAWAY` frame. In either case, that is illegal.
-            // (When sending multiple `GOAWAY`s, "Endpoints MUST NOT increase
-            // the value they send in the last stream identifier, since the
-            // peers might already have retried unprocessed requests on another
-            // connection.")
-            proto_err!(conn:
-                "recv_go_away: last_stream_id ({:?}) > max_stream_id ({:?})",
-                last_stream_id, actions.recv.max_stream_id(),
-            );
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
-        }
-
-        actions.recv.go_away(last_stream_id);
 
         me.store
             .for_each(|stream| {


### PR DESCRIPTION
Receiving a GOAWAY should update the max *send* ID, it shouldn't affect
the max recv.