### PR TITLE
Move "sync" tokio feature to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ futures-core = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 tokio-util = { version = "0.3.1", features = ["codec"] }
-tokio = { version = "0.2", features = ["io-util", "sync"] }
+tokio = { version = "0.2", features = ["io-util"] }
 bytes = "0.5.2"
 http = "0.2"
 log = "0.4.1"
@@ -65,7 +65,7 @@ serde = "1.0.0"
 serde_json = "1.0.0"
 
 # Examples
-tokio = { version = "0.2", features = ["dns", "macros", "rt-core", "tcp"] }
+tokio = { version = "0.2", features = ["dns", "macros", "rt-core", "sync", "tcp"] }
 env_logger = { version = "0.5.3", default-features = false }
 rustls = "0.16"
 tokio-rustls = "0.12.0"


### PR DESCRIPTION
This doesn't really have any effect unless you use `cargo -Zfeatures=dev_dep`, but `tokio::sync` is only used in tests.