### PR TITLE
Change store debug_assert to only run in tests

### DIFF
--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -204,6 +204,12 @@ impl Store {
     }
 }
 
+// While running h2 unit/integration tests, enable this debug assertion.
+//
+// In practice, we don't need to ensure this. But the integration tests
+// help to make sure we've cleaned up in cases where we could (like, the
+// runtime isn't suddenly dropping the task for unknown reasons).
+#[cfg(feature = "unstable")]
 impl Drop for Store {
     fn drop(&mut self) {
         use std::thread;


### PR DESCRIPTION
I don't believe this is ensuring anything truly important, it's just checking that we try our best to clean up all the streams. In some cases (like the connection task being canceled), there's nothing we can do, so don't panic in users' applications.

@carllerche you added this assert, so sanity check please.

Closes #417 