### PR TITLE
Client limits on concurrent pushed streams

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -134,7 +134,6 @@ where
         ready!(self
             .settings
             .poll_send(cx, &mut self.codec, &mut self.streams))?;
-        ready!(self.streams.send_pending_refusal(cx, &mut self.codec))?;
 
         Poll::Ready(Ok(()))
     }

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -57,6 +57,7 @@ pub(crate) struct Config {
     pub initial_max_send_streams: usize,
     pub reset_stream_duration: Duration,
     pub reset_stream_max: usize,
+    pub remote_reserved_stream_max: usize,
     pub settings: frame::Settings,
 }
 
@@ -89,6 +90,7 @@ where
             local_push_enabled: config.settings.is_push_enabled().unwrap_or(true),
             local_reset_duration: config.reset_stream_duration,
             local_reset_max: config.reset_stream_max,
+            remote_reserved_max: config.remote_reserved_stream_max,
             remote_init_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
             remote_max_initiated: config
                 .settings

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -33,3 +33,4 @@ pub type WindowSize = u32;
 pub const MAX_WINDOW_SIZE: WindowSize = (1 << 31) - 1;
 pub const DEFAULT_RESET_STREAM_MAX: usize = 10;
 pub const DEFAULT_RESET_STREAM_SECS: u64 = 30;
+pub const DEFAULT_RESERVED_STREAM_MAX: usize = 10;

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -59,14 +59,19 @@ impl Counts {
     ///
     /// # Panics
     ///
-    /// Panics on failure as this should have been validated before hand.
-    pub fn inc_num_recv_streams(&mut self, stream: &mut store::Ptr) {
-        assert!(self.can_inc_num_recv_streams());
+    /// Panics if stream is already included in the count.
+    pub fn inc_num_recv_streams(&mut self, stream: &mut store::Ptr) -> Result<(), ()> {
         assert!(!stream.is_counted);
+
+        if !self.can_inc_num_recv_streams() {
+            return Err(());
+        }
 
         // Increment the number of remote initiated streams
         self.num_recv_streams += 1;
         stream.is_counted = true;
+
+        Ok(())
     }
 
     /// Returns true if the send stream concurrency can be incremented

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -53,6 +53,9 @@ pub struct Config {
     /// Maximum number of locally reset streams to keep at a time
     pub local_reset_max: usize,
 
+    /// Maximum number of remote initiated streams
+    pub remote_reserved_max: usize,
+
     /// Initial window size of remote initiated streams
     pub remote_init_window_sz: WindowSize,
 

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -443,6 +443,13 @@ impl State {
             _ => Ok(None),
         }
     }
+
+    pub fn is_reserved_remote(&self) -> bool {
+        match self.inner {
+            ReservedRemote => true,
+            _ => false,
+        }
+    }
 }
 
 impl Default for State {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1239,6 +1239,7 @@ where
                     initial_max_send_streams: 0,
                     reset_stream_duration: self.builder.reset_stream_duration,
                     reset_stream_max: self.builder.reset_stream_max,
+                    remote_reserved_stream_max: 0,
                     settings: self.builder.settings.clone(),
                 },
             );

--- a/tests/h2-tests/tests/push_promise.rs
+++ b/tests/h2-tests/tests/push_promise.rs
@@ -471,6 +471,7 @@ async fn promised_stream_is_reset_if_max_streams_is_exceeded() {
             frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
         )
         .await;
+        srv.send_frame(frames::headers(2).response(404)).await;
         srv.send_frame(
             frames::push_promise(1, 4).request("GET", "https://http2.akamai.com/script.js"),
         )
@@ -479,7 +480,7 @@ async fn promised_stream_is_reset_if_max_streams_is_exceeded() {
             frames::push_promise(1, 6).request("GET", "https://http2.akamai.com/image.png"),
         )
         .await;
-        srv.send_frame(frames::headers(2).response(404)).await;
+        srv.ping_pong([1; 8]).await;
         srv.send_frame(frames::headers(4).response(404)).await;
         srv.recv_frame(frames::reset(4).refused()).await;
         srv.send_frame(frames::data(2, "").eos()).await;


### PR DESCRIPTION
Currently, clients enforce their maximum number of receive streams
in Recv::open, refusing any streams that would push the connection
over their specified limit.  This is called by both:

- `Streams::recv_headers` (on receiving a `HEADER` frame); and
- `Streams::recv_push_promise` (on receiving a `PUSH_PROMISE` frame).

The former goes on to call `Counts::inc_num_recv_streams`, which
will panic if the stream pushes the connection over the limit.
Since the counts remain locked between checking and incrementing,
this is okay.

However, in the latter case, the stream is correctly opened on
receipt of the `PUSH_PROMISE` and placed into "reserved (remote)"
state, which does not count toward the concurrency limit.  Per
Section 5.1.2:

> Streams that are in the "open" state or in either of the
> "half-closed" states count toward the maximum number of streams
> that an endpoint is permitted to open. Streams in any of these
> three states count toward the limit advertised in the
> SETTINGS_MAX_CONCURRENT_STREAMS setting. Streams in either of
> the "reserved" states do not count toward the stream limit.

Then, when `Streams::recv_headears` is invoked on the subsequent
receipt of a `HEADER` frame, the stream is already open and the
concurrency check is not performed.  Consequently, its subsequent
call to `Counts::inc_num_recv_streams` will panic if the limit
will now be exceeded.  This could happen because:

- the limit was reached when the `PUSH_PROMISE` was received
  (causing the stream to be refused) but the server sent the
  `HEADER` before receiving/processing the `RST_STREAM`; or

- the limit was reached after the `PUSH_PROMISE` was received,
  e.g. by `HEADER` frames from other promised streams.

In either case, we should refuse the stream instead of panicking.