### PR TITLE
Allow responses of HEAD requests to have empty DATA frames

### DIFF
--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -286,7 +286,11 @@ impl Stream {
                 Some(val) => *rem = val,
                 None => return Err(()),
             },
-            ContentLength::Head => return Err(()),
+            ContentLength::Head => {
+                if len != 0 {
+                    return Err(());
+                }
+            }
             _ => {}
         }
 

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -1171,6 +1171,50 @@ async fn malformed_response_headers_dont_unlink_stream() {
     join(srv, client).await;
 }
 
+#[tokio::test]
+async fn allow_empty_data_for_head() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .request("HEAD", "https://example.com/")
+                .eos(),
+        )
+        .await;
+        srv.send_frame(
+            frames::headers(1)
+                .response(200)
+                .field("content-length", 100),
+        )
+        .await;
+        srv.send_frame(frames::data(1, "").eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, h2) = client::Builder::new()
+            .handshake::<_, Bytes>(io)
+            .await
+            .unwrap();
+        tokio::spawn(async {
+            h2.await.expect("connection failed");
+        });
+        let request = Request::builder()
+            .method(Method::HEAD)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+        let (response, _) = client.send_request(request, true).unwrap();
+        let (_, mut body) = response.await.unwrap().into_parts();
+        assert_eq!(body.data().await.unwrap().unwrap(), "");
+    };
+
+    join(srv, h2).await;
+}
+
 const SETTINGS: &'static [u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
 const SETTINGS_ACK: &'static [u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc7540#section-8.1.2.6
> A response that is defined to have no payload, as described in [RFC7230], Section 3.3.2, can have a non-zero content-length header field, even though no content is included in DATA frames.

Without this patch, h2 errors with ` recv_data: content-length overflow; stream=StreamId(1); len=0;` when empty DATA frame is received.