### PR TITLE
Update to bytes v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ members = [
 futures-core = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
-tokio-util = { version = "0.4.0", features = ["codec"] }
+tokio-util = { version = "0.5.0", features = ["codec"] }
 tokio = { version = "0.3", features = ["io-util"] }
-bytes = "0.5.2"
+bytes = "0.6"
 http = "0.2"
 tracing = { version = "0.1.13", default-features = false, features = ["std", "log"] }
 tracing-futures = { version = "0.2", default-features = false, features = ["std-future"]}
@@ -74,3 +74,6 @@ rustls = "0.18"
 tokio-rustls = "0.20.0"
 webpki = "0.21"
 webpki-roots = "0.17"
+
+[patch.crates-io]
+http = { git = "https://github.com/olix0r/http", branch = "ver/bytes-0.6" }

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -3,7 +3,7 @@ use crate::codec::UserError::*;
 use crate::frame::{self, Frame, FrameSize};
 use crate::hpack;
 
-use bytes::{buf::BufMutExt, Buf, BufMut, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -10,7 +10,7 @@ use bytes::{Bytes, BytesMut};
 use std::fmt;
 use std::io::Cursor;
 
-type EncodeBuf<'a> = bytes::buf::ext::Limit<&'a mut BytesMut>;
+type EncodeBuf<'a> = bytes::buf::Limit<&'a mut BytesMut>;
 
 // Minimum MAX_FRAME_SIZE is 16kb, so save some arbitrary space for frame
 // head and other header bits.

--- a/src/hpack/encoder.rs
+++ b/src/hpack/encoder.rs
@@ -1,7 +1,7 @@
 use super::table::{Index, Table};
 use super::{huffman, Header};
 
-use bytes::{buf::ext::Limit, BufMut, BytesMut};
+use bytes::{buf::Limit, BufMut, BytesMut};
 use http::header::{HeaderName, HeaderValue};
 
 type DstBuf<'a> = Limit<&'a mut BytesMut>;

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -6,7 +6,7 @@ use crate::frame::{Reason, StreamId};
 use crate::codec::UserError;
 use crate::codec::UserError::*;
 
-use bytes::buf::ext::{BufExt, Take};
+use bytes::buf::Take;
 use std::io;
 use std::task::{Context, Poll, Waker};
 use std::{cmp, fmt, mem};

--- a/tests/h2-support/Cargo.toml
+++ b/tests/h2-support/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 h2 = { path = "../..", features = ["stream", "unstable"] }
 
-bytes = "0.5"
+bytes = "0.6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "chrono", "ansi"] }
 futures = { version = "0.3", default-features = false }


### PR DESCRIPTION
Currently patches the `http` dependency until https://github.com/hyperium/http/pull/441 is merged.