### PR TITLE
re-enable vectored writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ futures-core = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 tokio-util = { version = "0.5", features = ["codec"] }
-tokio = { version = "0.3.2", features = ["io-util"] }
+tokio = { version = "0.3.4", features = ["io-util"] }
 bytes = "0.6"
 http = "0.2"
 tracing = { version = "0.1.13", default-features = false, features = ["std", "log"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ serde = "1.0.0"
 serde_json = "1.0.0"
 
 # Examples
-tokio = { version = "0.3.2", features = ["rt-multi-thread", "macros", "sync", "net"] }
+tokio = { version = "0.3.4", features = ["rt-multi-thread", "macros", "sync", "net"] }
 env_logger = { version = "0.5.3", default-features = false }
 rustls = "0.18"
 tokio-rustls = "0.20.0"

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -3,12 +3,12 @@ use crate::codec::UserError::*;
 use crate::frame::{self, Frame, FrameSize};
 use crate::hpack;
 
-use bytes::{buf::BufMut, Buf, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use std::io::{self, Cursor};
+use std::io::{self, Cursor, IoSlice};
 
 // A macro to get around a method needing to borrow &mut self
 macro_rules! limited_write_buf {
@@ -39,6 +39,9 @@ pub struct FramedWrite<T, B> {
 
     /// Max frame size, this is specified by the peer
     max_frame_size: FrameSize,
+
+    /// Whether or not the wrapped `AsyncWrite` supports vectored IO.
+    is_write_vectored: bool,
 }
 
 #[derive(Debug)]
@@ -68,6 +71,7 @@ where
     B: Buf,
 {
     pub fn new(inner: T) -> FramedWrite<T, B> {
+        let is_write_vectored = inner.is_write_vectored();
         FramedWrite {
             inner,
             hpack: hpack::Encoder::default(),
@@ -75,6 +79,7 @@ where
             next: None,
             last_data_frame: None,
             max_frame_size: frame::DEFAULT_MAX_FRAME_SIZE,
+            is_write_vectored,
         }
     }
 
@@ -182,26 +187,58 @@ where
 
     /// Flush buffered data to the wire
     pub fn flush(&mut self, cx: &mut Context) -> Poll<io::Result<()>> {
+        const MAX_IOVS: usize = 64;
+
         let span = tracing::trace_span!("FramedWrite::flush");
         let _e = span.enter();
-
+        let mut iovs = if self.is_write_vectored {
+            [IoSlice::new(&[]); MAX_IOVS]
+        } else {
+            []
+        };
         loop {
             while !self.is_empty() {
                 match self.next {
                     Some(Next::Data(ref mut frame)) => {
                         tracing::trace!(queued_data_frame = true);
+                        if self.is_write_vectored {
+                            // If possible, write both our entire remaining
+                            // write buffer _and_ the frame in one
+                            // `poll_write_vectored` call.
+                            let rem = self.buf.remaining();
+                            let mut cnt = if rem > 0 {
+                                self.buf.bytes_vectored(&mut iovs)
+                            } else {
+                                0
+                            };
 
-                        if self.buf.has_remaining() {
-                            let n =
-                                ready!(Pin::new(&mut self.inner).poll_write(cx, self.buf.bytes()))?;
-                            self.buf.advance(n);
-                        }
+                            let buf = frame.payload_mut();
 
-                        let buf = frame.payload_mut();
+                            if buf.has_remaining() {
+                                cnt += buf.bytes_vectored(&mut iovs[cnt..]);
+                            }
 
-                        if !self.buf.has_remaining() && buf.has_remaining() {
-                            let n = ready!(Pin::new(&mut self.inner).poll_write(cx, buf.bytes()))?;
-                            buf.advance(n);
+                            let n = ready!(
+                                Pin::new(&mut self.inner).poll_write_vectored(cx, &iovs[..cnt])
+                            )?;
+
+                            self.buf.advance(std::cmp::min(rem, n));
+                            buf.advance(n.saturating_sub(rem));
+                        } else {
+                            if self.buf.has_remaining() {
+                                let n = ready!(
+                                    Pin::new(&mut self.inner).poll_write(cx, self.buf.bytes())
+                                )?;
+                                self.buf.advance(n);
+                            }
+
+                            let buf = frame.payload_mut();
+
+                            if !self.buf.has_remaining() && buf.has_remaining() {
+                                let n =
+                                    ready!(Pin::new(&mut self.inner).poll_write(cx, buf.bytes()))?;
+                                buf.advance(n);
+                            }
                         }
                     }
                     _ => {

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -191,17 +191,14 @@ where
 
         let span = tracing::trace_span!("FramedWrite::flush");
         let _e = span.enter();
-        let mut iovs = if self.is_write_vectored {
-            [IoSlice::new(&[]); MAX_IOVS]
-        } else {
-            []
-        };
+
         loop {
             while !self.is_empty() {
                 match self.next {
                     Some(Next::Data(ref mut frame)) => {
                         tracing::trace!(queued_data_frame = true);
                         if self.is_write_vectored {
+                            let mut iovs = [IoSlice::new(&[]); MAX_IOVS];
                             // If possible, write both our entire remaining
                             // write buffer _and_ the frame in one
                             // `poll_write_vectored` call.


### PR DESCRIPTION
Tokio's `AsyncWrite` trait once again has support for vectored writes in
Tokio 0.3.4 (see tokio-rs/tokio#3149.

This branch re-enables vectored writes in `h2`.

This change doesn't make all that big of a performance improvement in
Hyper's HTTP/2 benchmarks, but they use a `BytesMut` as the buffer.
With a buffer that turns into more IO vectors in `bytes_vectored`, there
might be a more noticeable performance improvement.

I spent a bit trying to refactor the flush logic to coalesce into fewer
writev calls with more buffers, but the current implementation seems
like about the best we're going to get without a bigger refactor. It's
basically the same as what `h2` did previously, so it's probably fine.