### PR TITLE
Return an error instead of panicking when stuck in a CONTINUATION loop

### DIFF
--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -247,6 +247,9 @@ where
                             // If *only* the CONTINUATION frame header was
                             // written, and *no* header fields, we're stuck
                             // in a loop...
+                            tracing::warn!(
+                                "CONTINUATION frame write loop; header value too big to encode"
+                            );
                             return Poll::Ready(Err(std::io::Error::new(
                                 std::io::ErrorKind::InvalidInput,
                                 UserError::HeaderTooBig,

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -247,7 +247,10 @@ where
                             // If *only* the CONTINUATION frame header was
                             // written, and *no* header fields, we're stuck
                             // in a loop...
-                            panic!("CONTINUATION frame write loop; header value too big to encode");
+                            return Poll::Ready(Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidInput,
+                                UserError::HeaderTooBig,
+                            )));
                         }
 
                         self.next = Some(Next::Continuation(continuation));


### PR DESCRIPTION
A short term mitigation for https://github.com/hyperium/h2/issues/485.

It is not rare a large header can trigger such a CONTINUATION loop.
While the stream cannot recover from this issue, returning an error
instead of panicking makes the impact radius under better control.