### PR TITLE
add `Connection::max_concurrent_send_streams`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1231,6 +1231,13 @@ where
 
     /// Returns the maximum number of concurrent streams that may be initiated
     /// by this client.
+    ///
+    /// This limit is configured by the server peer by sending the
+    /// [`SETTINGS_MAX_CONCURRENT_STREAMS` parameter][settings] in a `SETTINGS`
+    /// frame. This method returns the currently acknowledged value recieved
+    /// from the remote.
+    ///
+    /// [settings]: https://tools.ietf.org/html/rfc7540#section-5.1.2
     pub fn max_concurrent_send_streams(&self) -> usize {
         self.inner.max_send_streams()
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1228,6 +1228,12 @@ where
     pub fn ping_pong(&mut self) -> Option<PingPong> {
         self.inner.take_user_pings().map(PingPong::new)
     }
+
+    /// Returns the maximum number of concurrent streams that may be initiated
+    /// by this client.
+    pub fn max_concurrent_send_streams(&self) -> usize {
+        self.inner.max_send_streams()
+    }
 }
 
 impl<T, B> Future for Connection<T, B>

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -120,6 +120,12 @@ where
         self.settings.send_settings(settings)
     }
 
+    /// Returns the maximum number of concurrent streams that may be initiated
+    /// by this peer.
+    pub(crate) fn max_send_streams(&self) -> usize {
+        self.streams.max_send_streams()
+    }
+
     /// Returns `Ready` when the connection is ready to receive a frame.
     ///
     /// Returns `RecvError` as this may raise errors that are caused by delayed

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -167,6 +167,12 @@ impl Counts {
         }
     }
 
+    /// Returns the maximum number of streams that can be initiated by this
+    /// peer.
+    pub(crate) fn max_send_streams(&self) -> usize {
+        self.max_send_streams
+    }
+
     fn dec_num_streams(&mut self, stream: &mut store::Ptr) {
         assert!(stream.is_counted);
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -836,6 +836,10 @@ where
         Ok(())
     }
 
+    pub(crate) fn max_send_streams(&self) -> usize {
+        self.inner.lock().unwrap().counts.max_send_streams()
+    }
+
     #[cfg(feature = "unstable")]
     pub fn num_active_streams(&self) -> usize {
         let me = self.inner.lock().unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -532,6 +532,13 @@ where
 
     /// Returns the maximum number of concurrent streams that may be initiated
     /// by the server on this connection.
+    ///
+    /// This limit is configured by the client peer by sending the
+    /// [`SETTINGS_MAX_CONCURRENT_STREAMS` parameter][settings] in a `SETTINGS`
+    /// frame. This method returns the currently acknowledged value recieved
+    /// from the remote.
+    ///
+    /// [settings]: https://tools.ietf.org/html/rfc7540#section-5.1.2
     pub fn max_concurrent_send_streams(&self) -> usize {
         self.connection.max_send_streams()
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -529,6 +529,12 @@ where
     pub fn ping_pong(&mut self) -> Option<PingPong> {
         self.connection.take_user_pings().map(PingPong::new)
     }
+
+    /// Returns the maximum number of concurrent streams that may be initiated
+    /// by the server on this connection.
+    pub fn max_concurrent_send_streams(&self) -> usize {
+        self.connection.max_send_streams()
+    }
 }
 
 #[cfg(feature = "stream")]


### PR DESCRIPTION
This PR adds accessors to `client::Connection` and `server::Connection`
that return the send stream concurrency limit on that connection, as
negotiated by the remote peer. This is part of issue #512.

I think we probably ought to expose similar accessors for other
settings, but I thought it was better to add each one in a separate,
focused PR.