### PR TITLE
 Replace deprecated compare_and_swap with compare_exchange

### DIFF
--- a/src/proto/ping_pong.rs
+++ b/src/proto/ping_pong.rs
@@ -211,12 +211,16 @@ impl ReceivedPing {
 
 impl UserPings {
     pub(crate) fn send_ping(&self) -> Result<(), Option<proto::Error>> {
-        let prev = self.0.state.compare_exchange(
-            USER_STATE_EMPTY,        // current
-            USER_STATE_PENDING_PING, // new
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ).unwrap_or_else(|v| v);
+        let prev = self
+            .0
+            .state
+            .compare_exchange(
+                USER_STATE_EMPTY,        // current
+                USER_STATE_PENDING_PING, // new
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .unwrap_or_else(|v| v);
 
         match prev {
             USER_STATE_EMPTY => {
@@ -235,12 +239,16 @@ impl UserPings {
         // Must register before checking state, in case state were to change
         // before we could register, and then the ping would just be lost.
         self.0.pong_task.register(cx.waker());
-        let prev = self.0.state.compare_exchange(
-            USER_STATE_RECEIVED_PONG, // current
-            USER_STATE_EMPTY,         // new
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ).unwrap_or_else(|v| v);
+        let prev = self
+            .0
+            .state
+            .compare_exchange(
+                USER_STATE_RECEIVED_PONG, // current
+                USER_STATE_EMPTY,         // new
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .unwrap_or_else(|v| v);
 
         match prev {
             USER_STATE_RECEIVED_PONG => Poll::Ready(Ok(())),
@@ -254,12 +262,16 @@ impl UserPings {
 
 impl UserPingsRx {
     fn receive_pong(&self) -> bool {
-        let prev = self.0.state.compare_exchange(
-            USER_STATE_PENDING_PONG,  // current
-            USER_STATE_RECEIVED_PONG, // new
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ).unwrap_or_else(|v| v);
+        let prev = self
+            .0
+            .state
+            .compare_exchange(
+                USER_STATE_PENDING_PONG,  // current
+                USER_STATE_RECEIVED_PONG, // new
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .unwrap_or_else(|v| v);
 
         if prev == USER_STATE_PENDING_PONG {
             self.0.pong_task.wake();

--- a/src/proto/ping_pong.rs
+++ b/src/proto/ping_pong.rs
@@ -211,11 +211,12 @@ impl ReceivedPing {
 
 impl UserPings {
     pub(crate) fn send_ping(&self) -> Result<(), Option<proto::Error>> {
-        let prev = self.0.state.compare_and_swap(
+        let prev = self.0.state.compare_exchange(
             USER_STATE_EMPTY,        // current
             USER_STATE_PENDING_PING, // new
             Ordering::AcqRel,
-        );
+            Ordering::Acquire,
+        ).unwrap_or_else(|v| v);
 
         match prev {
             USER_STATE_EMPTY => {
@@ -234,11 +235,12 @@ impl UserPings {
         // Must register before checking state, in case state were to change
         // before we could register, and then the ping would just be lost.
         self.0.pong_task.register(cx.waker());
-        let prev = self.0.state.compare_and_swap(
+        let prev = self.0.state.compare_exchange(
             USER_STATE_RECEIVED_PONG, // current
             USER_STATE_EMPTY,         // new
             Ordering::AcqRel,
-        );
+            Ordering::Acquire,
+        ).unwrap_or_else(|v| v);
 
         match prev {
             USER_STATE_RECEIVED_PONG => Poll::Ready(Ok(())),
@@ -252,11 +254,12 @@ impl UserPings {
 
 impl UserPingsRx {
     fn receive_pong(&self) -> bool {
-        let prev = self.0.state.compare_and_swap(
+        let prev = self.0.state.compare_exchange(
             USER_STATE_PENDING_PONG,  // current
             USER_STATE_RECEIVED_PONG, // new
             Ordering::AcqRel,
-        );
+            Ordering::Acquire,
+        ).unwrap_or_else(|v| v);
 
         if prev == USER_STATE_PENDING_PONG {
             self.0.pong_task.wake();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1371,7 +1371,7 @@ impl proto::Peer for Peer {
                     reason: Reason::PROTOCOL_ERROR,
                 });
             }}
-        };
+        }
 
         b = b.version(Version::HTTP_2);
 


### PR DESCRIPTION
The `compare_and_swap` method on atomics is now deprecated in favor
of `compare_exchange`.

Since the author of #510 closed that PR, this is just #510 with rustfmt run.

I also removed an unnecessary trailing semicolon that the latest rust
compiler now complains about.