### PR TITLE
add `Connection::max_concurrent_recv_streams`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1242,13 +1242,28 @@ where
     /// by this client.
     ///
     /// This limit is configured by the server peer by sending the
-    /// [`SETTINGS_MAX_CONCURRENT_STREAMS` parameter][settings] in a `SETTINGS`
-    /// frame. This method returns the currently acknowledged value recieved
-    /// from the remote.
+    /// [`SETTINGS_MAX_CONCURRENT_STREAMS` parameter][1] in a `SETTINGS` frame.
+    /// This method returns the currently acknowledged value recieved from the
+    /// remote.
     ///
     /// [settings]: https://tools.ietf.org/html/rfc7540#section-5.1.2
     pub fn max_concurrent_send_streams(&self) -> usize {
         self.inner.max_send_streams()
+    }
+
+    /// Returns the maximum number of concurrent streams that may be initiated
+    /// by the server on this connection.
+    ///
+    /// This returns the value of the [`SETTINGS_MAX_CONCURRENT_STREAMS`
+    /// parameter][1] sent in a `SETTINGS` frame that has been
+    /// acknowledged by the remote peer. The value to be sent is configured by
+    /// the [`Builder::max_concurrent_streams`][2] method before handshaking
+    /// with the remote peer.
+    ///
+    /// [1]: https://tools.ietf.org/html/rfc7540#section-5.1.2
+    /// [2]: ../struct.Builder.html#method.max_concurrent_streams
+    pub fn max_concurrent_recv_streams(&self) -> usize {
+        self.inner.max_recv_streams()
     }
 }
 

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -156,7 +156,7 @@ where
     /// Returns the maximum number of concurrent streams that may be initiated
     /// by the remote peer.
     pub(crate) fn max_recv_streams(&self) -> usize {
-        self.streams.max_recv_streams()
+        self.inner.streams.max_recv_streams()
     }
 
     /// Returns `Ready` when the connection is ready to receive a frame.

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -153,6 +153,12 @@ where
         self.inner.streams.max_send_streams()
     }
 
+    /// Returns the maximum number of concurrent streams that may be initiated
+    /// by the remote peer.
+    pub(crate) fn max_recv_streams(&self) -> usize {
+        self.streams.max_recv_streams()
+    }
+
     /// Returns `Ready` when the connection is ready to receive a frame.
     ///
     /// Returns `RecvError` as this may raise errors that are caused by delayed

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -173,6 +173,12 @@ impl Counts {
         self.max_send_streams
     }
 
+    /// Returns the maximum number of streams that can be initiated by the
+    /// remote peer.
+    pub(crate) fn max_recv_streams(&self) -> usize {
+        self.max_recv_streams
+    }
+
     fn dec_num_streams(&mut self, stream: &mut store::Ptr) {
         assert!(stream.is_counted);
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -943,6 +943,10 @@ where
         self.inner.lock().unwrap().counts.max_send_streams()
     }
 
+    pub(crate) fn max_recv_streams(&self) -> usize {
+        self.inner.lock().unwrap().counts.max_recv_streams()
+    }
+
     #[cfg(feature = "unstable")]
     pub fn num_active_streams(&self) -> usize {
         let me = self.inner.lock().unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -534,13 +534,28 @@ where
     /// by the server on this connection.
     ///
     /// This limit is configured by the client peer by sending the
-    /// [`SETTINGS_MAX_CONCURRENT_STREAMS` parameter][settings] in a `SETTINGS`
-    /// frame. This method returns the currently acknowledged value recieved
-    /// from the remote.
+    /// [`SETTINGS_MAX_CONCURRENT_STREAMS` parameter][1] in a `SETTINGS` frame.
+    /// This method returns the currently acknowledged value recieved from the
+    /// remote.
     ///
-    /// [settings]: https://tools.ietf.org/html/rfc7540#section-5.1.2
+    /// [1]: https://tools.ietf.org/html/rfc7540#section-5.1.2
     pub fn max_concurrent_send_streams(&self) -> usize {
         self.connection.max_send_streams()
+    }
+
+    /// Returns the maximum number of concurrent streams that may be initiated
+    /// by the client on this connection.
+    ///
+    /// This returns the value of the [`SETTINGS_MAX_CONCURRENT_STREAMS`
+    /// parameter][1] sent in a `SETTINGS` frame that has been
+    /// acknowledged by the remote peer. The value to be sent is configured by
+    /// the [`Builder::max_concurrent_streams`][2] method before handshaking
+    /// with the remote peer.
+    ///
+    /// [1]: https://tools.ietf.org/html/rfc7540#section-5.1.2
+    /// [2]: ../struct.Builder.html#method.max_concurrent_streams
+    pub fn max_concurrent_recv_streams(&self) -> usize {
+        self.connection.max_recv_streams()
     }
 }
 


### PR DESCRIPTION
This commit adds accessors to `client::Connection` and
`server::Connection` that return the current value of the
`SETTINGS_MAX_CONCURRENT_STREAMS` limit that has been sent by this peer
and acknowledged by the remote.

This is analogous to the `max_concurrent_send_streams` methods added in
PR #513. These accessors may be somewhat less useful than the ones for
the values negotiated by the remote, since users who care about this
limit are probably setting the builder parameter. However, it seems
worth having for completeness sake --- and it might be useful for
determining whether or not a configured concurrency limit has been acked
yet...

Part of #512