### PR TITLE
Remove the obsolent tracing-future dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,7 @@ tokio-util = { version = "0.6", features = ["codec"] }
 tokio = { version = "1", features = ["io-util"] }
 bytes = "1"
 http = "0.2"
-tracing = { version = "0.1.13", default-features = false, features = ["std"] }
-tracing-futures = { version = "0.2", default-features = false, features = ["std-future"]}
+tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 fnv = "1.0.5"
 slab = "0.4.2"
 indexmap = "1.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -149,7 +149,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use std::usize;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 /// Initializes new HTTP/2.0 streams on a connection by sending a request.
 ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -128,7 +128,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use std::{convert, fmt, io, mem};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tracing_futures::{Instrument, Instrumented};
+use tracing::instrument::{Instrument, Instrumented};
 
 /// In progress HTTP/2.0 connection handshake future.
 ///


### PR DESCRIPTION
The `tracing_futures` dependency is no longer needed since `tracing` v0.1.21