### PR TITLE
Explicitly enable the `std` feature of indexmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ http = "0.2"
 tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 fnv = "1.0.5"
 slab = "0.4.2"
-indexmap = { version = "1.0", features = ["std"] }
+indexmap = { version = "1.5.2", features = ["std"] }
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ http = "0.2"
 tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 fnv = "1.0.5"
 slab = "0.4.2"
-indexmap = "1.0"
+indexmap = { version = "1.0", features = ["std"] }
 
 [dev-dependencies]
 


### PR DESCRIPTION
This crate depends on it anyway, and by explicitly turning it on we avoid unreliable platform target detection that causes build failures on some platforms.