### PR TITLE
Ignore 1xx frames

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -254,6 +254,11 @@ impl Headers {
         &mut self.header_block.pseudo
     }
 
+    /// Whether it has status 1xx
+    pub(crate) fn is_informational(&self) -> bool {
+        self.header_block.pseudo.is_informational()
+    }
+
     pub fn fields(&self) -> &HeaderMap {
         &self.header_block.fields
     }
@@ -598,6 +603,12 @@ impl Pseudo {
 
     pub fn set_authority(&mut self, authority: BytesStr) {
         self.authority = Some(authority);
+    }
+
+    /// Whether it has status 1xx
+    pub(crate) fn is_informational(&self) -> bool {
+        self.status
+            .map_or(false, |status| status.is_informational())
     }
 }
 

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -161,7 +161,7 @@ impl Recv {
         counts: &mut Counts,
     ) -> Result<(), RecvHeaderBlockError<Option<frame::Headers>>> {
         tracing::trace!("opening stream; init_window={}", self.init_window_sz);
-        let is_initial = stream.state.recv_open(frame.is_end_stream())?;
+        let is_initial = stream.state.recv_open(&frame)?;
 
         if is_initial {
             // TODO: be smarter about this logic
@@ -226,15 +226,17 @@ impl Recv {
 
         let stream_id = frame.stream_id();
         let (pseudo, fields) = frame.into_parts();
-        let message = counts
-            .peer()
-            .convert_poll_message(pseudo, fields, stream_id)?;
+        if !pseudo.is_informational() {
+            let message = counts
+                .peer()
+                .convert_poll_message(pseudo, fields, stream_id)?;
 
-        // Push the frame onto the stream's recv buffer
-        stream
-            .pending_recv
-            .push_back(&mut self.buffer, Event::Headers(message));
-        stream.notify_recv();
+            // Push the frame onto the stream's recv buffer
+            stream
+                .pending_recv
+                .push_back(&mut self.buffer, Event::Headers(message));
+            stream.notify_recv();
+        }
 
         // Only servers can receive a headers frame that initiates the stream.
         // This is verified in `Streams` before calling this function.


### PR DESCRIPTION
Fixes #515

This ignores (drops) header frames when the status is 1xx. 

Currently it allows multiple 1xx responses in a row. I couldn't find whether this is forbidden, but I've left it allowed, as I can imagine 103 early hints being followed by 100 continue.

There's no API to retrieve the data from the 1xx frames. Such API could look similar to push promises, but the existing push promise implementation is non-trivial, so I'll leave it for later.