### PR TITLE
Do not use `Instant::now` when zero reset streams are configured.

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -866,13 +866,15 @@ impl Recv {
     }
 
     pub fn clear_expired_reset_streams(&mut self, store: &mut Store, counts: &mut Counts) {
-        let now = Instant::now();
-        let reset_duration = self.reset_duration;
-        while let Some(stream) = self.pending_reset_expired.pop_if(store, |stream| {
-            let reset_at = stream.reset_at.expect("reset_at must be set if in queue");
-            now - reset_at > reset_duration
-        }) {
-            counts.transition_after(stream, true);
+        if !self.pending_reset_expired.is_empty() {
+            let now = Instant::now();
+            let reset_duration = self.reset_duration;
+            while let Some(stream) = self.pending_reset_expired.pop_if(store, |stream| {
+                let reset_at = stream.reset_at.expect("reset_at must be set if in queue");
+                now - reset_at > reset_duration
+            }) {
+                counts.transition_after(stream, true);
+            }
         }
     }
 

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -304,6 +304,10 @@ where
         None
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_none()
+    }
+
     pub fn pop_if<'a, R, F>(&mut self, store: &'a mut R, f: F) -> Option<store::Ptr<'a>>
     where
         R: Resolve,


### PR DESCRIPTION
This allows to use `h2` on wasm platforms which lack an `Instant::now` implementation by setting the number of streams to 0 with: `h2::client::Builder::max_concurrent_reset_streams`.

Resolves #511