### PR TITLE
Export the default value for the max number of reset streams.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ mod share;
 pub mod fuzz_bridge;
 
 pub use crate::error::{Error, Reason};
+pub use crate::proto::DEFAULT_RESET_STREAM_MAX;
 pub use crate::share::{FlowControl, Ping, PingPong, Pong, RecvStream, SendStream, StreamId};
 
 #[cfg(feature = "unstable")]

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -31,5 +31,6 @@ pub type WindowSize = u32;
 
 // Constants
 pub const MAX_WINDOW_SIZE: WindowSize = (1 << 31) - 1;
+/// Default value for the maximum number of concurrent locally reset streams.
 pub const DEFAULT_RESET_STREAM_MAX: usize = 10;
 pub const DEFAULT_RESET_STREAM_SECS: u64 = 30;


### PR DESCRIPTION
To be used in https://github.com/hyperium/hyper/pull/2535.