### PR TITLE
Remove the ad-hoc header size limit

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -11,11 +11,6 @@ use std::fmt;
 use std::io::Cursor;
 
 type EncodeBuf<'a> = bytes::buf::Limit<&'a mut BytesMut>;
-
-// Minimum MAX_FRAME_SIZE is 16kb, so save some arbitrary space for frame
-// head and other header bits.
-const MAX_HEADER_LENGTH: usize = 1024 * 16 - 100;
-
 /// Header frame
 ///
 /// This could be either a request or a response.
@@ -239,10 +234,6 @@ impl Headers {
 
     pub fn is_over_size(&self) -> bool {
         self.header_block.is_over_size
-    }
-
-    pub(crate) fn has_too_big_field(&self) -> bool {
-        self.header_block.has_too_big_field()
     }
 
     pub fn into_parts(self) -> (Pseudo, HeaderMap) {
@@ -948,46 +939,6 @@ impl HeaderBlock {
                 .iter()
                 .map(|(name, value)| decoded_header_size(name.as_str().len(), value.len()))
                 .sum::<usize>()
-    }
-
-    /// Iterate over all pseudos and headers to see if any individual pair
-    /// would be too large to encode.
-    pub(crate) fn has_too_big_field(&self) -> bool {
-        macro_rules! pseudo_size {
-            ($name:ident) => {{
-                self.pseudo
-                    .$name
-                    .as_ref()
-                    .map(|m| decoded_header_size(stringify!($name).len() + 1, m.as_str().len()))
-                    .unwrap_or(0)
-            }};
-        }
-
-        if pseudo_size!(method) > MAX_HEADER_LENGTH {
-            return true;
-        }
-
-        if pseudo_size!(scheme) > MAX_HEADER_LENGTH {
-            return true;
-        }
-
-        if pseudo_size!(authority) > MAX_HEADER_LENGTH {
-            return true;
-        }
-
-        if pseudo_size!(path) > MAX_HEADER_LENGTH {
-            return true;
-        }
-
-        // skip :status, its never going to be too big
-
-        for (name, value) in &self.fields {
-            if decoded_header_size(name.as_str().len(), value.len()) > MAX_HEADER_LENGTH {
-                return true;
-            }
-        }
-
-        false
     }
 }
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -133,10 +133,6 @@ impl Send {
 
         Self::check_headers(frame.fields())?;
 
-        if frame.has_too_big_field() {
-            return Err(UserError::HeaderTooBig);
-        }
-
         let end_stream = frame.is_end_stream();
 
         // Update the state
@@ -268,10 +264,6 @@ impl Send {
         // TODO: Should this logic be moved into state.rs?
         if !stream.state.is_send_streaming() {
             return Err(UserError::UnexpectedFrameType);
-        }
-
-        if frame.has_too_big_field() {
-            return Err(UserError::HeaderTooBig);
         }
 
         stream.state.send_close();


### PR DESCRIPTION
This limit is hardcoded to be 16KB-100B no matter if the other
peer already advertised that it accepts way larger frame sizes,
this is a problem sometimes for Google Chat's service workers.