### PR TITLE
Refactor errors (fixes #530)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -135,9 +135,9 @@
 //! [`Builder`]: struct.Builder.html
 //! [`Error`]: ../struct.Error.html
 
-use crate::codec::{Codec, RecvError, SendError, UserError};
+use crate::codec::{Codec, SendError, UserError};
 use crate::frame::{Headers, Pseudo, Reason, Settings, StreamId};
-use crate::proto;
+use crate::proto::{self, Error};
 use crate::{FlowControl, PingPong, RecvStream, SendStream};
 
 use bytes::{Buf, Bytes};
@@ -1493,7 +1493,7 @@ impl proto::Peer for Peer {
         pseudo: Pseudo,
         fields: HeaderMap,
         stream_id: StreamId,
-    ) -> Result<Self::Poll, RecvError> {
+    ) -> Result<Self::Poll, Error> {
         let mut b = Response::builder();
 
         b = b.version(Version::HTTP_2);
@@ -1507,10 +1507,7 @@ impl proto::Peer for Peer {
             Err(_) => {
                 // TODO: Should there be more specialized handling for different
                 // kinds of errors
-                return Err(RecvError::Stream {
-                    id: stream_id,
-                    reason: Reason::PROTOCOL_ERROR,
-                });
+                return Err(Error::library_reset(stream_id, Reason::PROTOCOL_ERROR));
             }
         };
 

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -1,26 +1,12 @@
-use crate::frame::{Reason, StreamId};
+use crate::proto::Error;
 
 use std::{error, fmt, io};
-
-/// Errors that are received
-#[derive(Debug)]
-pub enum RecvError {
-    Connection(Reason),
-    Stream { id: StreamId, reason: Reason },
-    Io(io::Error),
-}
 
 /// Errors caused by sending a message
 #[derive(Debug)]
 pub enum SendError {
-    /// User error
+    Connection(Error),
     User(UserError),
-
-    /// Connection error prevents sending.
-    Connection(Reason),
-
-    /// I/O error
-    Io(io::Error),
 }
 
 /// Errors caused by users of the library
@@ -65,47 +51,22 @@ pub enum UserError {
     PeerDisabledServerPush,
 }
 
-// ===== impl RecvError =====
-
-impl From<io::Error> for RecvError {
-    fn from(src: io::Error) -> Self {
-        RecvError::Io(src)
-    }
-}
-
-impl error::Error for RecvError {}
-
-impl fmt::Display for RecvError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        use self::RecvError::*;
-
-        match *self {
-            Connection(ref reason) => reason.fmt(fmt),
-            Stream { ref reason, .. } => reason.fmt(fmt),
-            Io(ref e) => e.fmt(fmt),
-        }
-    }
-}
-
 // ===== impl SendError =====
 
 impl error::Error for SendError {}
 
 impl fmt::Display for SendError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        use self::SendError::*;
-
         match *self {
-            User(ref e) => e.fmt(fmt),
-            Connection(ref reason) => reason.fmt(fmt),
-            Io(ref e) => e.fmt(fmt),
+            Self::Connection(ref e) => e.fmt(fmt),
+            Self::User(ref e) => e.fmt(fmt),
         }
     }
 }
 
 impl From<io::Error> for SendError {
     fn from(src: io::Error) -> Self {
-        SendError::Io(src)
+        Self::Connection(src.into())
     }
 }
 

--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -1,8 +1,8 @@
-use crate::codec::RecvError;
 use crate::frame::{self, Frame, Kind, Reason};
 use crate::frame::{
     DEFAULT_MAX_FRAME_SIZE, DEFAULT_SETTINGS_HEADER_TABLE_SIZE, MAX_MAX_FRAME_SIZE,
 };
+use crate::proto::Error;
 
 use crate::hpack;
 
@@ -98,8 +98,7 @@ fn decode_frame(
     max_header_list_size: usize,
     partial_inout: &mut Option<Partial>,
     mut bytes: BytesMut,
-) -> Result<Option<Frame>, RecvError> {
-    use self::RecvError::*;
+) -> Result<Option<Frame>, Error> {
     let span = tracing::trace_span!("FramedRead::decode_frame", offset = bytes.len());
     let _e = span.enter();
 
@@ -110,7 +109,7 @@ fn decode_frame(
 
     if partial_inout.is_some() && head.kind() != Kind::Continuation {
         proto_err!(conn: "expected CONTINUATION, got {:?}", head.kind());
-        return Err(Connection(Reason::PROTOCOL_ERROR));
+        return Err(Error::library_go_away(Reason::PROTOCOL_ERROR).into());
     }
 
     let kind = head.kind();
@@ -131,14 +130,11 @@ fn decode_frame(
                     // A stream cannot depend on itself. An endpoint MUST
                     // treat this as a stream error (Section 5.4.2) of type
                     // `PROTOCOL_ERROR`.
-                    return Err(Stream {
-                        id: $head.stream_id(),
-                        reason: Reason::PROTOCOL_ERROR,
-                    });
+                    return Err(Error::library_reset($head.stream_id(), Reason::PROTOCOL_ERROR));
                 },
                 Err(e) => {
                     proto_err!(conn: "failed to load frame; err={:?}", e);
-                    return Err(Connection(Reason::PROTOCOL_ERROR));
+                    return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
                 }
             };
 
@@ -151,14 +147,11 @@ fn decode_frame(
                 Err(frame::Error::MalformedMessage) => {
                     let id = $head.stream_id();
                     proto_err!(stream: "malformed header block; stream={:?}", id);
-                    return Err(Stream {
-                        id,
-                        reason: Reason::PROTOCOL_ERROR,
-                    });
+                    return Err(Error::library_reset(id, Reason::PROTOCOL_ERROR));
                 },
                 Err(e) => {
                     proto_err!(conn: "failed HPACK decoding; err={:?}", e);
-                    return Err(Connection(Reason::PROTOCOL_ERROR));
+                    return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
                 }
             }
 
@@ -183,7 +176,7 @@ fn decode_frame(
 
             res.map_err(|e| {
                 proto_err!(conn: "failed to load SETTINGS frame; err={:?}", e);
-                Connection(Reason::PROTOCOL_ERROR)
+                Error::library_go_away(Reason::PROTOCOL_ERROR)
             })?
             .into()
         }
@@ -192,7 +185,7 @@ fn decode_frame(
 
             res.map_err(|e| {
                 proto_err!(conn: "failed to load PING frame; err={:?}", e);
-                Connection(Reason::PROTOCOL_ERROR)
+                Error::library_go_away(Reason::PROTOCOL_ERROR)
             })?
             .into()
         }
@@ -201,7 +194,7 @@ fn decode_frame(
 
             res.map_err(|e| {
                 proto_err!(conn: "failed to load WINDOW_UPDATE frame; err={:?}", e);
-                Connection(Reason::PROTOCOL_ERROR)
+                Error::library_go_away(Reason::PROTOCOL_ERROR)
             })?
             .into()
         }
@@ -212,7 +205,7 @@ fn decode_frame(
             // TODO: Should this always be connection level? Probably not...
             res.map_err(|e| {
                 proto_err!(conn: "failed to load DATA frame; err={:?}", e);
-                Connection(Reason::PROTOCOL_ERROR)
+                Error::library_go_away(Reason::PROTOCOL_ERROR)
             })?
             .into()
         }
@@ -221,7 +214,7 @@ fn decode_frame(
             let res = frame::Reset::load(head, &bytes[frame::HEADER_LEN..]);
             res.map_err(|e| {
                 proto_err!(conn: "failed to load RESET frame; err={:?}", e);
-                Connection(Reason::PROTOCOL_ERROR)
+                Error::library_go_away(Reason::PROTOCOL_ERROR)
             })?
             .into()
         }
@@ -229,7 +222,7 @@ fn decode_frame(
             let res = frame::GoAway::load(&bytes[frame::HEADER_LEN..]);
             res.map_err(|e| {
                 proto_err!(conn: "failed to load GO_AWAY frame; err={:?}", e);
-                Connection(Reason::PROTOCOL_ERROR)
+                Error::library_go_away(Reason::PROTOCOL_ERROR)
             })?
             .into()
         }
@@ -238,7 +231,7 @@ fn decode_frame(
             if head.stream_id() == 0 {
                 // Invalid stream identifier
                 proto_err!(conn: "invalid stream ID 0");
-                return Err(Connection(Reason::PROTOCOL_ERROR));
+                return Err(Error::library_go_away(Reason::PROTOCOL_ERROR).into());
             }
 
             match frame::Priority::load(head, &bytes[frame::HEADER_LEN..]) {
@@ -249,14 +242,11 @@ fn decode_frame(
                     // `PROTOCOL_ERROR`.
                     let id = head.stream_id();
                     proto_err!(stream: "PRIORITY invalid dependency ID; stream={:?}", id);
-                    return Err(Stream {
-                        id,
-                        reason: Reason::PROTOCOL_ERROR,
-                    });
+                    return Err(Error::library_reset(id, Reason::PROTOCOL_ERROR));
                 }
                 Err(e) => {
                     proto_err!(conn: "failed to load PRIORITY frame; err={:?};", e);
-                    return Err(Connection(Reason::PROTOCOL_ERROR));
+                    return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
                 }
             }
         }
@@ -267,14 +257,14 @@ fn decode_frame(
                 Some(partial) => partial,
                 None => {
                     proto_err!(conn: "received unexpected CONTINUATION frame");
-                    return Err(Connection(Reason::PROTOCOL_ERROR));
+                    return Err(Error::library_go_away(Reason::PROTOCOL_ERROR).into());
                 }
             };
 
             // The stream identifiers must match
             if partial.frame.stream_id() != head.stream_id() {
                 proto_err!(conn: "CONTINUATION frame stream ID does not match previous frame stream ID");
-                return Err(Connection(Reason::PROTOCOL_ERROR));
+                return Err(Error::library_go_away(Reason::PROTOCOL_ERROR).into());
             }
 
             // Extend the buf
@@ -297,7 +287,7 @@ fn decode_frame(
                     // the attacker to go away.
                     if partial.buf.len() + bytes.len() > max_header_list_size {
                         proto_err!(conn: "CONTINUATION frame header block size over ignorable limit");
-                        return Err(Connection(Reason::COMPRESSION_ERROR));
+                        return Err(Error::library_go_away(Reason::COMPRESSION_ERROR).into());
                     }
                 }
                 partial.buf.extend_from_slice(&bytes[frame::HEADER_LEN..]);
@@ -312,14 +302,11 @@ fn decode_frame(
                 Err(frame::Error::MalformedMessage) => {
                     let id = head.stream_id();
                     proto_err!(stream: "malformed CONTINUATION frame; stream={:?}", id);
-                    return Err(Stream {
-                        id,
-                        reason: Reason::PROTOCOL_ERROR,
-                    });
+                    return Err(Error::library_reset(id, Reason::PROTOCOL_ERROR));
                 }
                 Err(e) => {
                     proto_err!(conn: "failed HPACK decoding; err={:?}", e);
-                    return Err(Connection(Reason::PROTOCOL_ERROR));
+                    return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
                 }
             }
 
@@ -343,7 +330,7 @@ impl<T> Stream for FramedRead<T>
 where
     T: AsyncRead + Unpin,
 {
-    type Item = Result<Frame, RecvError>;
+    type Item = Result<Frame, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let span = tracing::trace_span!("FramedRead::poll_next");
@@ -371,11 +358,11 @@ where
     }
 }
 
-fn map_err(err: io::Error) -> RecvError {
+fn map_err(err: io::Error) -> Error {
     if let io::ErrorKind::InvalidData = err.kind() {
         if let Some(custom) = err.get_ref() {
             if custom.is::<LengthDelimitedCodecError>() {
-                return RecvError::Connection(Reason::FRAME_SIZE_ERROR);
+                return Error::library_go_away(Reason::FRAME_SIZE_ERROR);
             }
         }
     }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -2,12 +2,13 @@ mod error;
 mod framed_read;
 mod framed_write;
 
-pub use self::error::{RecvError, SendError, UserError};
+pub use self::error::{SendError, UserError};
 
 use self::framed_read::FramedRead;
 use self::framed_write::FramedWrite;
 
 use crate::frame::{self, Data, Frame};
+use crate::proto::Error;
 
 use bytes::Buf;
 use futures_core::Stream;
@@ -155,7 +156,7 @@ impl<T, B> Stream for Codec<T, B>
 where
     T: AsyncRead + Unpin,
 {
-    type Item = Result<Frame, RecvError>;
+    type Item = Result<Frame, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::new(&mut self.inner).poll_next(cx)

--- a/src/frame/go_away.rs
+++ b/src/frame/go_away.rs
@@ -29,8 +29,7 @@ impl GoAway {
         self.error_code
     }
 
-    #[cfg(feature = "unstable")]
-    pub fn debug_data(&self) -> &[u8] {
+    pub fn debug_data(&self) -> &Bytes {
         &self.debug_data
     }
 

--- a/src/frame/reset.rs
+++ b/src/frame/reset.rs
@@ -2,7 +2,7 @@ use crate::frame::{self, Error, Head, Kind, Reason, StreamId};
 
 use bytes::BufMut;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Reset {
     stream_id: StreamId,
     error_code: Reason,

--- a/src/hpack/encoder.rs
+++ b/src/hpack/encoder.rs
@@ -10,12 +10,6 @@ pub struct Encoder {
     size_update: Option<SizeUpdate>,
 }
 
-#[derive(Debug)]
-pub struct EncodeState {
-    index: Index,
-    value: Option<HeaderValue>,
-}
-
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum SizeUpdate {
     One(usize),

--- a/src/hpack/mod.rs
+++ b/src/hpack/mod.rs
@@ -8,5 +8,5 @@ mod table;
 mod test;
 
 pub use self::decoder::{Decoder, DecoderError, NeedMore};
-pub use self::encoder::{EncodeState, Encoder};
+pub use self::encoder::Encoder;
 pub use self::header::{BytesStr, Header};

--- a/src/hpack/test/fuzz.rs
+++ b/src/hpack/test/fuzz.rs
@@ -8,7 +8,6 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use std::io::Cursor;
 
-const MIN_CHUNK: usize = 16;
 const MAX_CHUNK: usize = 2 * 1024;
 
 #[test]
@@ -36,17 +35,8 @@ fn hpack_fuzz_seeded() {
 
 #[derive(Debug, Clone)]
 struct FuzzHpack {
-    // The magic seed that makes the test case reproducible
-    seed: [usize; 4],
-
     // The set of headers to encode / decode
     frames: Vec<HeaderFrame>,
-
-    // The list of chunk sizes to do it in
-    chunks: Vec<usize>,
-
-    // Number of times reduced
-    reduced: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -128,19 +118,7 @@ impl FuzzHpack {
             frames.push(frame);
         }
 
-        // Now, generate the buffer sizes used to encode
-        let mut chunks = vec![];
-
-        for _ in 0..rng.gen_range(0, 100) {
-            chunks.push(rng.gen_range(MIN_CHUNK, MAX_CHUNK));
-        }
-
-        FuzzHpack {
-            seed: seed,
-            frames: frames,
-            chunks: chunks,
-            reduced: 0,
-        }
+        FuzzHpack { frames }
     }
 
     fn run(self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,13 @@ macro_rules! ready {
 mod codec;
 mod error;
 mod hpack;
+
+#[cfg(not(feature = "unstable"))]
 mod proto;
+
+#[cfg(feature = "unstable")]
+#[allow(missing_docs)]
+pub mod proto;
 
 #[cfg(not(feature = "unstable"))]
 mod frame;
@@ -125,7 +131,7 @@ pub use crate::error::{Error, Reason};
 pub use crate::share::{FlowControl, Ping, PingPong, Pong, RecvStream, SendStream, StreamId};
 
 #[cfg(feature = "unstable")]
-pub use codec::{Codec, RecvError, SendError, UserError};
+pub use codec::{Codec, SendError, UserError};
 
 use std::task::Poll;
 

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -1,6 +1,6 @@
-use crate::codec::{RecvError, UserError};
+use crate::codec::UserError;
 use crate::frame::{Reason, StreamId};
-use crate::{client, frame, proto, server};
+use crate::{client, frame, server};
 
 use crate::frame::DEFAULT_INITIAL_WINDOW_SIZE;
 use crate::proto::*;
@@ -40,7 +40,7 @@ where
     ///
     /// This exists separately from State in order to support
     /// graceful shutdown.
-    error: Option<Reason>,
+    error: Option<frame::GoAway>,
 
     /// Pending GOAWAY frames to write.
     go_away: GoAway,
@@ -68,7 +68,7 @@ struct DynConnection<'a, B: Buf = Bytes> {
 
     streams: DynStreams<'a, B>,
 
-    error: &'a mut Option<Reason>,
+    error: &'a mut Option<frame::GoAway>,
 
     ping_pong: &'a mut PingPong,
 }
@@ -88,10 +88,10 @@ enum State {
     Open,
 
     /// The codec must be flushed
-    Closing(Reason),
+    Closing(Reason, Initiator),
 
     /// In a closed state
-    Closed(Reason),
+    Closed(Reason, Initiator),
 }
 
 impl<T, P, B> Connection<T, P, B>
@@ -161,9 +161,9 @@ where
 
     /// Returns `Ready` when the connection is ready to receive a frame.
     ///
-    /// Returns `RecvError` as this may raise errors that are caused by delayed
+    /// Returns `Error` as this may raise errors that are caused by delayed
     /// processing of received frames.
-    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), RecvError>> {
+    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Error>> {
         let _e = self.inner.span.enter();
         let span = tracing::trace_span!("poll_ready");
         let _e = span.enter();
@@ -191,26 +191,24 @@ where
         self.inner.as_dyn().go_away_from_user(e)
     }
 
-    fn take_error(&mut self, ours: Reason) -> Poll<Result<(), proto::Error>> {
-        let reason = if let Some(theirs) = self.inner.error.take() {
-            match (ours, theirs) {
-                // If either side reported an error, return that
-                // to the user.
-                (Reason::NO_ERROR, err) | (err, Reason::NO_ERROR) => err,
-                // If both sides reported an error, give their
-                // error back to th user. We assume our error
-                // was a consequence of their error, and less
-                // important.
-                (_, theirs) => theirs,
-            }
-        } else {
-            ours
-        };
+    fn take_error(&mut self, ours: Reason, initiator: Initiator) -> Result<(), Error> {
+        let (debug_data, theirs) = self
+            .inner
+            .error
+            .take()
+            .as_ref()
+            .map_or((Bytes::new(), Reason::NO_ERROR), |frame| {
+                (frame.debug_data().clone(), frame.reason())
+            });
 
-        if reason == Reason::NO_ERROR {
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Ready(Err(proto::Error::Proto(reason)))
+        match (ours, theirs) {
+            (Reason::NO_ERROR, Reason::NO_ERROR) => return Ok(()),
+            (ours, Reason::NO_ERROR) => Err(Error::GoAway(Bytes::new(), ours, initiator)),
+            // If both sides reported an error, give their
+            // error back to th user. We assume our error
+            // was a consequence of their error, and less
+            // important.
+            (_, theirs) => Err(Error::remote_go_away(debug_data, theirs)),
         }
     }
 
@@ -229,7 +227,7 @@ where
     }
 
     /// Advances the internal state of the connection.
-    pub fn poll(&mut self, cx: &mut Context) -> Poll<Result<(), proto::Error>> {
+    pub fn poll(&mut self, cx: &mut Context) -> Poll<Result<(), Error>> {
         // XXX(eliza): cloning the span is unfortunately necessary here in
         // order to placate the borrow checker — `self` is mutably borrowed by
         // `poll2`, which means that we can't borrow `self.span` to enter it.
@@ -268,20 +266,22 @@ where
 
                     self.inner.as_dyn().handle_poll2_result(result)?
                 }
-                State::Closing(reason) => {
+                State::Closing(reason, initiator) => {
                     tracing::trace!("connection closing after flush");
                     // Flush/shutdown the codec
                     ready!(self.codec.shutdown(cx))?;
 
                     // Transition the state to error
-                    self.inner.state = State::Closed(reason);
+                    self.inner.state = State::Closed(reason, initiator);
                 }
-                State::Closed(reason) => return self.take_error(reason),
+                State::Closed(reason, initiator) => {
+                    return Poll::Ready(self.take_error(reason, initiator));
+                }
             }
         }
     }
 
-    fn poll2(&mut self, cx: &mut Context) -> Poll<Result<(), RecvError>> {
+    fn poll2(&mut self, cx: &mut Context) -> Poll<Result<(), Error>> {
         // This happens outside of the loop to prevent needing to do a clock
         // check and then comparison of the queue possibly multiple times a
         // second (and thus, the clock wouldn't have changed enough to matter).
@@ -300,7 +300,7 @@ where
                         // the same error back to the user.
                         return Poll::Ready(Ok(()));
                     } else {
-                        return Poll::Ready(Err(RecvError::Connection(reason)));
+                        return Poll::Ready(Err(Error::library_go_away(reason)));
                     }
                 }
                 // Only NO_ERROR should be waiting for idle
@@ -384,42 +384,45 @@ where
         self.go_away.go_away_from_user(frame);
 
         // Notify all streams of reason we're abruptly closing.
-        self.streams.recv_err(&proto::Error::Proto(e));
+        self.streams.handle_error(Error::user_go_away(e));
     }
 
-    fn handle_poll2_result(&mut self, result: Result<(), RecvError>) -> Result<(), Error> {
-        use crate::codec::RecvError::*;
+    fn handle_poll2_result(&mut self, result: Result<(), Error>) -> Result<(), Error> {
         match result {
             // The connection has shutdown normally
             Ok(()) => {
-                *self.state = State::Closing(Reason::NO_ERROR);
+                *self.state = State::Closing(Reason::NO_ERROR, Initiator::Library);
                 Ok(())
             }
             // Attempting to read a frame resulted in a connection level
             // error. This is handled by setting a GOAWAY frame followed by
             // terminating the connection.
-            Err(Connection(e)) => {
+            Err(Error::GoAway(debug_data, reason, initiator)) => {
+                let e = Error::GoAway(debug_data, reason, initiator);
                 tracing::debug!(error = ?e, "Connection::poll; connection error");
 
                 // We may have already sent a GOAWAY for this error,
                 // if so, don't send another, just flush and close up.
-                if let Some(reason) = self.go_away.going_away_reason() {
-                    if reason == e {
-                        tracing::trace!("    -> already going away");
-                        *self.state = State::Closing(e);
-                        return Ok(());
-                    }
+                if self
+                    .go_away
+                    .going_away()
+                    .map_or(false, |frame| frame.reason() == reason)
+                {
+                    tracing::trace!("    -> already going away");
+                    *self.state = State::Closing(reason, initiator);
+                    return Ok(());
                 }
 
                 // Reset all active streams
-                self.streams.recv_err(&e.into());
-                self.go_away_now(e);
+                self.streams.handle_error(e);
+                self.go_away_now(reason);
                 Ok(())
             }
             // Attempting to read a frame resulted in a stream level error.
             // This is handled by resetting the frame then trying to read
             // another frame.
-            Err(Stream { id, reason }) => {
+            Err(Error::Reset(id, reason, initiator)) => {
+                debug_assert_eq!(initiator, Initiator::Library);
                 tracing::trace!(?id, ?reason, "stream error");
                 self.streams.send_reset(id, reason);
                 Ok(())
@@ -428,12 +431,12 @@ where
             // active streams must be reset.
             //
             // TODO: Are I/O errors recoverable?
-            Err(Io(e)) => {
+            Err(Error::Io(e, inner)) => {
                 tracing::debug!(error = ?e, "Connection::poll; IO error");
-                let e = e.into();
+                let e = Error::Io(e, inner);
 
                 // Reset all active streams
-                self.streams.recv_err(&e);
+                self.streams.handle_error(e.clone());
 
                 // Return the error
                 Err(e)
@@ -441,7 +444,7 @@ where
         }
     }
 
-    fn recv_frame(&mut self, frame: Option<Frame>) -> Result<ReceivedFrame, RecvError> {
+    fn recv_frame(&mut self, frame: Option<Frame>) -> Result<ReceivedFrame, Error> {
         use crate::frame::Frame::*;
         match frame {
             Some(Headers(frame)) => {
@@ -471,7 +474,7 @@ where
                 // until they are all EOS. Once they are, State should
                 // transition to GoAway.
                 self.streams.recv_go_away(&frame)?;
-                *self.error = Some(frame.reason());
+                *self.error = Some(frame);
             }
             Some(Ping(frame)) => {
                 tracing::trace!(?frame, "recv PING");

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -1,53 +1,87 @@
-use crate::codec::{RecvError, SendError};
-use crate::frame::Reason;
+use crate::codec::SendError;
+use crate::frame::{Reason, StreamId};
 
+use bytes::Bytes;
+use std::fmt;
 use std::io;
 
 /// Either an H2 reason  or an I/O error
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Error {
-    Proto(Reason),
-    Io(io::Error),
+    Reset(StreamId, Reason, Initiator),
+    GoAway(Bytes, Reason, Initiator),
+    Io(io::ErrorKind, Option<String>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Initiator {
+    User,
+    Library,
+    Remote,
 }
 
 impl Error {
-    /// Clone the error for internal purposes.
-    ///
-    /// `io::Error` is not `Clone`, so we only copy the `ErrorKind`.
-    pub(super) fn shallow_clone(&self) -> Error {
+    pub(crate) fn is_local(&self) -> bool {
         match *self {
-            Error::Proto(reason) => Error::Proto(reason),
-            Error::Io(ref io) => Error::Io(io::Error::from(io.kind())),
+            Self::Reset(_, _, initiator) | Self::GoAway(_, _, initiator) => initiator.is_local(),
+            Self::Io(..) => true,
+        }
+    }
+
+    pub(crate) fn user_go_away(reason: Reason) -> Self {
+        Self::GoAway(Bytes::new(), reason, Initiator::User)
+    }
+
+    pub(crate) fn library_reset(stream_id: StreamId, reason: Reason) -> Self {
+        Self::Reset(stream_id, reason, Initiator::Library)
+    }
+
+    pub(crate) fn library_go_away(reason: Reason) -> Self {
+        Self::GoAway(Bytes::new(), reason, Initiator::Library)
+    }
+
+    pub(crate) fn remote_reset(stream_id: StreamId, reason: Reason) -> Self {
+        Self::Reset(stream_id, reason, Initiator::Remote)
+    }
+
+    pub(crate) fn remote_go_away(debug_data: Bytes, reason: Reason) -> Self {
+        Self::GoAway(debug_data, reason, Initiator::Remote)
+    }
+}
+
+impl Initiator {
+    fn is_local(&self) -> bool {
+        match *self {
+            Self::User | Self::Library => true,
+            Self::Remote => false,
         }
     }
 }
 
-impl From<Reason> for Error {
-    fn from(src: Reason) -> Self {
-        Error::Proto(src)
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Reset(_, reason, _) | Self::GoAway(_, reason, _) => reason.fmt(fmt),
+            Self::Io(_, Some(ref inner)) => inner.fmt(fmt),
+            Self::Io(kind, None) => io::Error::from(kind).fmt(fmt),
+        }
+    }
+}
+
+impl From<io::ErrorKind> for Error {
+    fn from(src: io::ErrorKind) -> Self {
+        Error::Io(src.into(), None)
     }
 }
 
 impl From<io::Error> for Error {
     fn from(src: io::Error) -> Self {
-        Error::Io(src)
-    }
-}
-
-impl From<Error> for RecvError {
-    fn from(src: Error) -> RecvError {
-        match src {
-            Error::Proto(reason) => RecvError::Connection(reason),
-            Error::Io(e) => RecvError::Io(e),
-        }
+        Error::Io(src.kind(), src.get_ref().map(|inner| inner.to_string()))
     }
 }
 
 impl From<Error> for SendError {
-    fn from(src: Error) -> SendError {
-        match src {
-            Error::Proto(reason) => SendError::Connection(reason),
-            Error::Io(e) => SendError::Io(e),
-        }
+    fn from(src: Error) -> Self {
+        Self::Connection(src)
     }
 }

--- a/src/proto/go_away.rs
+++ b/src/proto/go_away.rs
@@ -31,7 +31,7 @@ pub(super) struct GoAway {
 /// well, and we wouldn't want to save that here to accidentally dump in logs,
 /// or waste struct space.)
 #[derive(Debug)]
-struct GoingAway {
+pub(crate) struct GoingAway {
     /// Stores the highest stream ID of a GOAWAY that has been sent.
     ///
     /// It's illegal to send a subsequent GOAWAY with a higher ID.
@@ -98,9 +98,9 @@ impl GoAway {
         self.is_user_initiated
     }
 
-    /// Return the last Reason we've sent.
-    pub fn going_away_reason(&self) -> Option<Reason> {
-        self.going_away.as_ref().map(|g| g.reason)
+    /// Returns the going away info, if any.
+    pub fn going_away(&self) -> Option<&GoingAway> {
+        self.going_away.as_ref()
     }
 
     /// Returns if the connection should close now, or wait until idle.
@@ -141,12 +141,18 @@ impl GoAway {
 
             return Poll::Ready(Some(Ok(reason)));
         } else if self.should_close_now() {
-            return match self.going_away_reason() {
+            return match self.going_away().map(|going_away| going_away.reason) {
                 Some(reason) => Poll::Ready(Some(Ok(reason))),
                 None => Poll::Ready(None),
             };
         }
 
         Poll::Ready(None)
+    }
+}
+
+impl GoingAway {
+    pub(crate) fn reason(&self) -> Reason {
+        self.reason
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -7,7 +7,7 @@ mod settings;
 mod streams;
 
 pub(crate) use self::connection::{Config, Connection};
-pub(crate) use self::error::Error;
+pub use self::error::{Error, Initiator};
 pub(crate) use self::peer::{Dyn as DynPeer, Peer};
 pub(crate) use self::ping_pong::UserPings;
 pub(crate) use self::streams::{DynStreams, OpaqueStreamRef, StreamRef, Streams};

--- a/src/proto/peer.rs
+++ b/src/proto/peer.rs
@@ -1,7 +1,6 @@
-use crate::codec::RecvError;
 use crate::error::Reason;
 use crate::frame::{Pseudo, StreamId};
-use crate::proto::Open;
+use crate::proto::{Error, Open};
 
 use http::{HeaderMap, Request, Response};
 
@@ -21,7 +20,7 @@ pub(crate) trait Peer {
         pseudo: Pseudo,
         fields: HeaderMap,
         stream_id: StreamId,
-    ) -> Result<Self::Poll, RecvError>;
+    ) -> Result<Self::Poll, Error>;
 
     fn is_local_init(id: StreamId) -> bool {
         assert!(!id.is_zero());
@@ -61,7 +60,7 @@ impl Dyn {
         pseudo: Pseudo,
         fields: HeaderMap,
         stream_id: StreamId,
-    ) -> Result<PollMessage, RecvError> {
+    ) -> Result<PollMessage, Error> {
         if self.is_server() {
             crate::server::Peer::convert_poll_message(pseudo, fields, stream_id)
                 .map(PollMessage::Server)
@@ -72,12 +71,12 @@ impl Dyn {
     }
 
     /// Returns true if the remote peer can initiate a stream with the given ID.
-    pub fn ensure_can_open(&self, id: StreamId, mode: Open) -> Result<(), RecvError> {
+    pub fn ensure_can_open(&self, id: StreamId, mode: Open) -> Result<(), Error> {
         if self.is_server() {
             // Ensure that the ID is a valid client initiated ID
             if mode.is_push_promise() || !id.is_client_initiated() {
                 proto_err!(conn: "cannot open stream {:?} - not client initiated", id);
-                return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+                return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
             }
 
             Ok(())
@@ -85,7 +84,7 @@ impl Dyn {
             // Ensure that the ID is a valid server initiated ID
             if !mode.is_push_promise() || !id.is_server_initiated() {
                 proto_err!(conn: "cannot open stream {:?} - not server initiated", id);
-                return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+                return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
             }
 
             Ok(())

--- a/src/proto/settings.rs
+++ b/src/proto/settings.rs
@@ -1,4 +1,4 @@
-use crate::codec::{RecvError, UserError};
+use crate::codec::UserError;
 use crate::error::Reason;
 use crate::frame;
 use crate::proto::*;
@@ -40,7 +40,7 @@ impl Settings {
         frame: frame::Settings,
         codec: &mut Codec<T, B>,
         streams: &mut Streams<C, P>,
-    ) -> Result<(), RecvError>
+    ) -> Result<(), Error>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
@@ -68,7 +68,7 @@ impl Settings {
                     // We haven't sent any SETTINGS frames to be ACKed, so
                     // this is very bizarre! Remote is either buggy or malicious.
                     proto_err!(conn: "received unexpected settings ack");
-                    Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
+                    Err(Error::library_go_away(Reason::PROTOCOL_ERROR))
                 }
             }
         } else {
@@ -97,7 +97,7 @@ impl Settings {
         cx: &mut Context,
         dst: &mut Codec<T, B>,
         streams: &mut Streams<C, P>,
-    ) -> Poll<Result<(), RecvError>>
+    ) -> Poll<Result<(), Error>>
     where
         T: AsyncWrite + Unpin,
         B: Buf,

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -791,7 +791,10 @@ impl Prioritize {
                         }),
                         None => {
                             if let Some(reason) = stream.state.get_scheduled_reset() {
-                                stream.state.set_reset(reason);
+                                let stream_id = stream.id;
+                                stream
+                                    .state
+                                    .set_reset(stream_id, reason, Initiator::Library);
 
                                 let frame = frame::Reset::new(stream.id, reason);
                                 Frame::Reset(frame)

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -1,7 +1,7 @@
 use super::*;
-use crate::codec::{RecvError, UserError};
-use crate::frame::{PushPromiseHeaderError, Reason, DEFAULT_INITIAL_WINDOW_SIZE};
-use crate::{frame, proto};
+use crate::codec::UserError;
+use crate::frame::{self, PushPromiseHeaderError, Reason, DEFAULT_INITIAL_WINDOW_SIZE};
+use crate::proto::{self, Error};
 use std::task::Context;
 
 use http::{HeaderMap, Request, Response};
@@ -68,7 +68,7 @@ pub(super) enum Event {
 #[derive(Debug)]
 pub(super) enum RecvHeaderBlockError<T> {
     Oversize(T),
-    State(RecvError),
+    State(Error),
 }
 
 #[derive(Debug)]
@@ -124,7 +124,7 @@ impl Recv {
         id: StreamId,
         mode: Open,
         counts: &mut Counts,
-    ) -> Result<Option<StreamId>, RecvError> {
+    ) -> Result<Option<StreamId>, Error> {
         assert!(self.refused.is_none());
 
         counts.peer().ensure_can_open(id, mode)?;
@@ -132,7 +132,7 @@ impl Recv {
         let next_id = self.next_stream_id()?;
         if id < next_id {
             proto_err!(conn: "id ({:?}) < next_id ({:?})", id, next_id);
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+            return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
         }
 
         self.next_stream_id = id.next_id();
@@ -176,11 +176,7 @@ impl Recv {
                     Ok(v) => v,
                     Err(()) => {
                         proto_err!(stream: "could not parse content-length; stream={:?}", stream.id);
-                        return Err(RecvError::Stream {
-                            id: stream.id,
-                            reason: Reason::PROTOCOL_ERROR,
-                        }
-                        .into());
+                        return Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR).into());
                     }
                 };
 
@@ -312,16 +308,13 @@ impl Recv {
         &mut self,
         frame: frame::Headers,
         stream: &mut store::Ptr,
-    ) -> Result<(), RecvError> {
+    ) -> Result<(), Error> {
         // Transition the state
         stream.state.recv_close()?;
 
         if stream.ensure_content_length_zero().is_err() {
             proto_err!(stream: "recv_trailers: content-length is not zero; stream={:?};",  stream.id);
-            return Err(RecvError::Stream {
-                id: stream.id,
-                reason: Reason::PROTOCOL_ERROR,
-            });
+            return Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR));
         }
 
         let trailers = frame.into_fields();
@@ -455,7 +448,7 @@ impl Recv {
         &mut self,
         settings: &frame::Settings,
         store: &mut Store,
-    ) -> Result<(), RecvError> {
+    ) -> Result<(), proto::Error> {
         let target = if let Some(val) = settings.initial_window_size() {
             val
         } else {
@@ -502,7 +495,7 @@ impl Recv {
                 stream
                     .recv_flow
                     .inc_window(inc)
-                    .map_err(RecvError::Connection)?;
+                    .map_err(proto::Error::library_go_away)?;
                 stream.recv_flow.assign_capacity(inc);
                 Ok(())
             })
@@ -520,11 +513,7 @@ impl Recv {
         stream.pending_recv.is_empty()
     }
 
-    pub fn recv_data(
-        &mut self,
-        frame: frame::Data,
-        stream: &mut store::Ptr,
-    ) -> Result<(), RecvError> {
+    pub fn recv_data(&mut self, frame: frame::Data, stream: &mut store::Ptr) -> Result<(), Error> {
         let sz = frame.payload().len();
 
         // This should have been enforced at the codec::FramedRead layer, so
@@ -542,7 +531,7 @@ impl Recv {
             // Receiving a DATA frame when not expecting one is a protocol
             // error.
             proto_err!(conn: "unexpected DATA frame; stream={:?}", stream.id);
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+            return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
         }
 
         tracing::trace!(
@@ -557,7 +546,7 @@ impl Recv {
                 "recv_data; frame ignored on locally reset {:?} for some time",
                 stream.id,
             );
-            return self.ignore_data(sz);
+            return Ok(self.ignore_data(sz)?);
         }
 
         // Ensure that there is enough capacity on the connection before acting
@@ -573,10 +562,7 @@ impl Recv {
             // So, for violating the **stream** window, we can send either a
             // stream or connection error. We've opted to send a stream
             // error.
-            return Err(RecvError::Stream {
-                id: stream.id,
-                reason: Reason::FLOW_CONTROL_ERROR,
-            });
+            return Err(Error::library_reset(stream.id, Reason::FLOW_CONTROL_ERROR));
         }
 
         if stream.dec_content_length(frame.payload().len()).is_err() {
@@ -585,10 +571,7 @@ impl Recv {
                 stream.id,
                 frame.payload().len(),
             );
-            return Err(RecvError::Stream {
-                id: stream.id,
-                reason: Reason::PROTOCOL_ERROR,
-            });
+            return Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR));
         }
 
         if frame.is_end_stream() {
@@ -598,15 +581,12 @@ impl Recv {
                     stream.id,
                     frame.payload().len(),
                 );
-                return Err(RecvError::Stream {
-                    id: stream.id,
-                    reason: Reason::PROTOCOL_ERROR,
-                });
+                return Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR));
             }
 
             if stream.state.recv_close().is_err() {
                 proto_err!(conn: "recv_data: failed to transition to closed state; stream={:?}", stream.id);
-                return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+                return Err(Error::library_go_away(Reason::PROTOCOL_ERROR).into());
             }
         }
 
@@ -625,7 +605,7 @@ impl Recv {
         Ok(())
     }
 
-    pub fn ignore_data(&mut self, sz: WindowSize) -> Result<(), RecvError> {
+    pub fn ignore_data(&mut self, sz: WindowSize) -> Result<(), Error> {
         // Ensure that there is enough capacity on the connection...
         self.consume_connection_window(sz)?;
 
@@ -641,14 +621,14 @@ impl Recv {
         Ok(())
     }
 
-    pub fn consume_connection_window(&mut self, sz: WindowSize) -> Result<(), RecvError> {
+    pub fn consume_connection_window(&mut self, sz: WindowSize) -> Result<(), Error> {
         if self.flow.window_size() < sz {
             tracing::debug!(
                 "connection error FLOW_CONTROL_ERROR -- window_size ({:?}) < sz ({:?});",
                 self.flow.window_size(),
                 sz,
             );
-            return Err(RecvError::Connection(Reason::FLOW_CONTROL_ERROR));
+            return Err(Error::library_go_away(Reason::FLOW_CONTROL_ERROR));
         }
 
         // Update connection level flow control
@@ -663,7 +643,7 @@ impl Recv {
         &mut self,
         frame: frame::PushPromise,
         stream: &mut store::Ptr,
-    ) -> Result<(), RecvError> {
+    ) -> Result<(), Error> {
         stream.state.reserve_remote()?;
         if frame.is_over_size() {
             // A frame is over size if the decoded header block was bigger than
@@ -682,10 +662,10 @@ impl Recv {
                  headers frame is over size; promised_id={:?};",
                 frame.promised_id(),
             );
-            return Err(RecvError::Stream {
-                id: frame.promised_id(),
-                reason: Reason::REFUSED_STREAM,
-            });
+            return Err(Error::library_reset(
+                frame.promised_id(),
+                Reason::REFUSED_STREAM,
+            ));
         }
 
         let promised_id = frame.promised_id();
@@ -708,10 +688,7 @@ impl Recv {
                     promised_id,
                 ),
             }
-            return Err(RecvError::Stream {
-                id: promised_id,
-                reason: Reason::PROTOCOL_ERROR,
-            });
+            return Err(Error::library_reset(promised_id, Reason::PROTOCOL_ERROR));
         }
 
         use super::peer::PollMessage::*;
@@ -741,18 +718,16 @@ impl Recv {
     /// Handle remote sending an explicit RST_STREAM.
     pub fn recv_reset(&mut self, frame: frame::Reset, stream: &mut Stream) {
         // Notify the stream
-        stream
-            .state
-            .recv_reset(frame.reason(), stream.is_pending_send);
+        stream.state.recv_reset(frame, stream.is_pending_send);
 
         stream.notify_send();
         stream.notify_recv();
     }
 
-    /// Handle a received error
-    pub fn recv_err(&mut self, err: &proto::Error, stream: &mut Stream) {
+    /// Handle a connection-level error
+    pub fn handle_error(&mut self, err: &proto::Error, stream: &mut Stream) {
         // Receive an error
-        stream.state.recv_err(err);
+        stream.state.handle_error(err);
 
         // If a receiver is waiting, notify it
         stream.notify_send();
@@ -783,11 +758,11 @@ impl Recv {
         self.max_stream_id
     }
 
-    pub fn next_stream_id(&self) -> Result<StreamId, RecvError> {
+    pub fn next_stream_id(&self) -> Result<StreamId, Error> {
         if let Ok(id) = self.next_stream_id {
             Ok(id)
         } else {
-            Err(RecvError::Connection(Reason::PROTOCOL_ERROR))
+            Err(Error::library_go_away(Reason::PROTOCOL_ERROR))
         }
     }
 
@@ -802,10 +777,10 @@ impl Recv {
     }
 
     /// Returns true if the remote peer can reserve a stream with the given ID.
-    pub fn ensure_can_reserve(&self) -> Result<(), RecvError> {
+    pub fn ensure_can_reserve(&self) -> Result<(), Error> {
         if !self.is_push_enabled {
             proto_err!(conn: "recv_push_promise: push is disabled");
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+            return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
         }
 
         Ok(())
@@ -1092,8 +1067,8 @@ impl Open {
 
 // ===== impl RecvHeaderBlockError =====
 
-impl<T> From<RecvError> for RecvHeaderBlockError<T> {
-    fn from(err: RecvError) -> Self {
+impl<T> From<Error> for RecvHeaderBlockError<T> {
+    fn from(err: Error) -> Self {
         RecvHeaderBlockError::State(err)
     }
 }

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -77,12 +77,6 @@ pub(crate) enum Open {
     Headers,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct Indices {
-    head: store::Key,
-    tail: store::Key,
-}
-
 impl Recv {
     pub fn new(peer: peer::Dyn, config: &Config) -> Self {
         let next_stream_id = if peer.is_server() { 1 } else { 2 };

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,9 +115,9 @@
 //! [`SendStream`]: ../struct.SendStream.html
 //! [`TcpListener`]: https://docs.rs/tokio-core/0.1/tokio_core/net/struct.TcpListener.html
 
-use crate::codec::{Codec, RecvError, UserError};
+use crate::codec::{Codec, UserError};
 use crate::frame::{self, Pseudo, PushPromiseHeaderError, Reason, Settings, StreamId};
-use crate::proto::{self, Config, Prioritized};
+use crate::proto::{self, Config, Error, Prioritized};
 use crate::{FlowControl, PingPong, RecvStream, SendStream};
 
 use bytes::{Buf, Bytes};
@@ -1202,7 +1202,7 @@ where
             if &PREFACE[self.pos..self.pos + n] != buf.filled() {
                 proto_err!(conn: "read_preface: invalid preface");
                 // TODO: Should this just write the GO_AWAY frame directly?
-                return Poll::Ready(Err(Reason::PROTOCOL_ERROR.into()));
+                return Poll::Ready(Err(Error::library_go_away(Reason::PROTOCOL_ERROR).into()));
             }
 
             self.pos += n;
@@ -1388,7 +1388,7 @@ impl proto::Peer for Peer {
         pseudo: Pseudo,
         fields: HeaderMap,
         stream_id: StreamId,
-    ) -> Result<Self::Poll, RecvError> {
+    ) -> Result<Self::Poll, Error> {
         use http::{uri, Version};
 
         let mut b = Request::builder();
@@ -1396,10 +1396,7 @@ impl proto::Peer for Peer {
         macro_rules! malformed {
             ($($arg:tt)*) => {{
                 tracing::debug!($($arg)*);
-                return Err(RecvError::Stream {
-                    id: stream_id,
-                    reason: Reason::PROTOCOL_ERROR,
-                });
+                return Err(Error::library_reset(stream_id, Reason::PROTOCOL_ERROR));
             }}
         }
 
@@ -1416,7 +1413,7 @@ impl proto::Peer for Peer {
         // Specifying :status for a request is a protocol error
         if pseudo.status.is_some() {
             tracing::trace!("malformed headers: :status field on request; PROTOCOL_ERROR");
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+            return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
         }
 
         // Convert the URI
@@ -1483,10 +1480,7 @@ impl proto::Peer for Peer {
                 // TODO: Should there be more specialized handling for different
                 // kinds of errors
                 proto_err!(stream: "error building request: {}; stream={:?}", e, stream_id);
-                return Err(RecvError::Stream {
-                    id: stream_id,
-                    reason: Reason::PROTOCOL_ERROR,
-                });
+                return Err(Error::library_reset(stream_id, Reason::PROTOCOL_ERROR));
             }
         };
 

--- a/tests/h2-support/src/mock.rs
+++ b/tests/h2-support/src/mock.rs
@@ -1,7 +1,8 @@
 use crate::SendFrame;
 
 use h2::frame::{self, Frame};
-use h2::{self, RecvError, SendError};
+use h2::proto::Error;
+use h2::{self, SendError};
 
 use futures::future::poll_fn;
 use futures::{ready, Stream, StreamExt};
@@ -284,7 +285,7 @@ impl Handle {
 }
 
 impl Stream for Handle {
-    type Item = Result<Frame, RecvError>;
+    type Item = Result<Frame, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::new(&mut self.codec).poll_next(cx)

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -410,7 +410,11 @@ async fn send_reset_notifies_recv_stream() {
         };
         let rx = async {
             let mut body = res.into_body();
-            body.next().await.unwrap().expect_err("RecvBody");
+            let err = body.next().await.unwrap().expect_err("RecvBody");
+            assert_eq!(
+                err.to_string(),
+                "stream error sent by user: refused stream before processing any application logic"
+            );
         };
 
         // a FuturesUnordered is used on purpose!
@@ -672,7 +676,7 @@ async fn sending_request_on_closed_connection() {
         };
 
         let poll_err = poll_fn(|cx| client.poll_ready(cx)).await.unwrap_err();
-        let msg = "protocol error: unspecific protocol error detected";
+        let msg = "connection error detected: unspecific protocol error detected";
         assert_eq!(poll_err.to_string(), msg);
 
         let request = Request::builder()

--- a/tests/h2-tests/tests/codec_read.rs
+++ b/tests/h2-tests/tests/codec_read.rs
@@ -236,7 +236,7 @@ async fn read_goaway_with_debug_data() {
     let data = poll_frame!(GoAway, codec);
     assert_eq!(data.reason(), Reason::ENHANCE_YOUR_CALM);
     assert_eq!(data.last_stream_id(), 1);
-    assert_eq!(data.debug_data(), b"too_many_pings");
+    assert_eq!(&**data.debug_data(), b"too_many_pings");
 
     assert_closed!(codec);
 }

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -217,7 +217,7 @@ async fn recv_data_overflows_connection_window() {
             let err = res.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                "protocol error: flow-control protocol violated"
+                "connection error detected: flow-control protocol violated"
             );
         };
 
@@ -227,7 +227,7 @@ async fn recv_data_overflows_connection_window() {
             let err = res.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                "protocol error: flow-control protocol violated"
+                "connection error detected: flow-control protocol violated"
             );
         };
         join(conn, req).await;
@@ -278,7 +278,7 @@ async fn recv_data_overflows_stream_window() {
             let err = res.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                "protocol error: flow-control protocol violated"
+                "stream error detected: flow-control protocol violated"
             );
         };
 
@@ -358,7 +358,7 @@ async fn stream_error_release_connection_capacity() {
                 .expect_err("body");
             assert_eq!(
                 err.to_string(),
-                "protocol error: unspecific protocol error detected"
+                "stream error detected: unspecific protocol error detected"
             );
             cap.release_capacity(to_release).expect("release_capacity");
         };

--- a/tests/h2-tests/tests/push_promise.rs
+++ b/tests/h2-tests/tests/push_promise.rs
@@ -164,7 +164,7 @@ async fn recv_push_when_push_disabled_is_conn_error() {
             let err = res.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                "protocol error: unspecific protocol error detected"
+                "connection error detected: unspecific protocol error detected"
             );
         };
 
@@ -174,7 +174,7 @@ async fn recv_push_when_push_disabled_is_conn_error() {
             let err = res.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                "protocol error: unspecific protocol error detected"
+                "connection error detected: unspecific protocol error detected"
             );
         };
 
@@ -380,8 +380,16 @@ async fn recv_push_promise_skipped_stream_id() {
             .unwrap();
 
         let req = async move {
-            let res = client.send_request(request, true).unwrap().0.await;
-            assert!(res.is_err());
+            let err = client
+                .send_request(request, true)
+                .unwrap()
+                .0
+                .await
+                .unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "connection error detected: unspecific protocol error detected"
+            );
         };
 
         // client should see a protocol error
@@ -390,7 +398,7 @@ async fn recv_push_promise_skipped_stream_id() {
             let err = res.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                "protocol error: unspecific protocol error detected"
+                "connection error detected: unspecific protocol error detected"
             );
         };
 
@@ -435,7 +443,11 @@ async fn recv_push_promise_dup_stream_id() {
 
         let req = async move {
             let res = client.send_request(request, true).unwrap().0.await;
-            assert!(res.is_err());
+            let err = res.unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "connection error detected: unspecific protocol error detected"
+            );
         };
 
         // client should see a protocol error
@@ -444,7 +456,7 @@ async fn recv_push_promise_dup_stream_id() {
             let err = res.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                "protocol error: unspecific protocol error detected"
+                "connection error detected: unspecific protocol error detected"
             );
         };
 

--- a/tests/h2-tests/tests/stream_states.rs
+++ b/tests/h2-tests/tests/stream_states.rs
@@ -207,13 +207,19 @@ async fn errors_if_recv_frame_exceeds_max_frame_size() {
             let body = resp.into_parts().1;
             let res = util::concat(body).await;
             let err = res.unwrap_err();
-            assert_eq!(err.to_string(), "protocol error: frame with invalid size");
+            assert_eq!(
+                err.to_string(),
+                "connection error detected: frame with invalid size"
+            );
         };
 
         // client should see a conn error
         let conn = async move {
             let err = h2.await.unwrap_err();
-            assert_eq!(err.to_string(), "protocol error: frame with invalid size");
+            assert_eq!(
+                err.to_string(),
+                "connection error detected: frame with invalid size"
+            );
         };
         join(conn, req).await;
     };
@@ -321,7 +327,10 @@ async fn recv_goaway_finishes_processed_streams() {
         // this request will trigger a goaway
         let req2 = async move {
             let err = client.get("https://example.com/").await.unwrap_err();
-            assert_eq!(err.to_string(), "protocol error: not a result of an error");
+            assert_eq!(
+                err.to_string(),
+                "connection error received: not a result of an error"
+            );
         };
 
         join3(async move { h2.await.expect("client") }, req1, req2).await;


### PR DESCRIPTION
h2::Error now knows whether protocol errors happened because the user
sent them, because it was received from the remote peer, or because
the library itself emitted an error because it detected a protocol
violation.

It also keeps track of whether it came from a RST_STREAM or GO_AWAY
frame, and in the case of the latter, it includes the additional
debug data if any.