### PR TITLE
fuzzing: fix build

### DIFF
--- a/src/fuzz_bridge.rs
+++ b/src/fuzz_bridge.rs
@@ -22,7 +22,7 @@ pub mod fuzz_logic {
 
     fn encode(e: &mut hpack::Encoder, hdrs: Vec<hpack::Header<Option<HeaderName>>>) -> BytesMut {
         let mut dst = BytesMut::with_capacity(1024);
-        e.encode(None, &mut hdrs.into_iter(), &mut (&mut dst).limit(1024));
+        e.encode(&mut hdrs.into_iter(), &mut dst);
         dst
     }
 }


### PR DESCRIPTION
The oss-fuzz build has been failing for a while and I noticed it was due to changes in the `encode` function. This fixes it