### PR TITLE
Fix Error::reason regression

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,9 @@ impl Error {
     /// action taken by the peer (i.e. a protocol error).
     pub fn reason(&self) -> Option<Reason> {
         match self.kind {
-            Kind::Reset(_, reason, _) | Kind::GoAway(_, reason, _) => Some(reason),
+            Kind::Reset(_, reason, _) | Kind::GoAway(_, reason, _) | Kind::Reason(reason) => {
+                Some(reason)
+            }
             _ => None,
         }
     }
@@ -167,3 +169,15 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use crate::Reason;
+
+    #[test]
+    fn error_from_reason() {
+        let err = Error::from(Reason::HTTP_1_1_REQUIRED);
+        assert_eq!(err.reason(), Some(Reason::HTTP_1_1_REQUIRED));
+    }
+}


### PR DESCRIPTION
The `Error::reason()` method regressed by not checking if the internal kind was a user-created error. The second commit fixes this. The first commit was adding a test about `send_reset`, which didn't actually end up being the problem, but we didn't have an explicit test, so included it anyways.

Fixes #561 