### PR TITLE
Include a payload for h2-initiated BrokenPipe errors

### DIFF
--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -68,12 +68,6 @@ impl fmt::Display for Error {
     }
 }
 
-impl From<io::ErrorKind> for Error {
-    fn from(src: io::ErrorKind) -> Self {
-        Error::Io(src.into(), None)
-    }
-}
-
 impl From<io::Error> for Error {
     fn from(src: io::Error) -> Self {
         Error::Io(src.kind(), src.get_ref().map(|inner| inner.to_string()))

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -303,7 +303,10 @@ impl State {
             Closed(..) => {}
             ref state => {
                 tracing::trace!("recv_eof; state={:?}", state);
-                self.inner = Closed(Cause::Error(io::ErrorKind::BrokenPipe.into()));
+                self.inner = Closed(Cause::Error(Error::Io(
+                    io::ErrorKind::BrokenPipe,
+                    Some("remote abruptly closed connection".to_owned()),
+                )));
             }
         }
     }


### PR DESCRIPTION
"broken pipe" is not very useful when debugging, especially when other parts of the system could also be returning "broken pipe".