### PR TITLE
Fix panic if remote causes local to reset a stream before opening

### DIFF
--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -544,4 +544,14 @@ impl Send {
             true
         }
     }
+
+    pub(super) fn maybe_reset_next_stream_id(&mut self, id: StreamId) {
+        if let Ok(next_id) = self.next_stream_id {
+            // Peer::is_local_init should have been called beforehand
+            debug_assert_eq!(id.is_server_initiated(), next_id.is_server_initiated());
+            if id >= next_id {
+                self.next_stream_id = id.next_id();
+            }
+        }
+    }
 }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -865,6 +865,24 @@ impl Inner {
         let key = match self.store.find_entry(id) {
             Entry::Occupied(e) => e.key(),
             Entry::Vacant(e) => {
+                // Resetting a stream we don't know about? That could be OK...
+                //
+                // 1. As a server, we just received a request, but that request
+                //    was bad, so we're resetting before even accepting it.
+                //    This is totally fine.
+                //
+                // 2. The remote may have sent us a frame on new stream that
+                //    it's *not* supposed to have done, and thus, we don't know
+                //    the stream. In that case, sending a reset will "open" the
+                //    stream in our store. Maybe that should be a connection
+                //    error instead? At least for now, we need to update what
+                //    our vision of the next stream is.
+                if self.counts.peer().is_local_init(id) {
+                    // We normally would open this stream, so update our
+                    // next-send-id record.
+                    self.actions.send.maybe_reset_next_stream_id(id);
+                }
+
                 let stream = Stream::new(id, 0, 0);
 
                 e.insert(stream)


### PR DESCRIPTION
If the remote sent a frame on a stream it wasn't supposed to (such as a server sending a response on a request stream that hadn't been opened yet), *AND* that frame was malformed such that it triggered a codec error (and thus not reaching the "you're not allowed to open" error), then the stream store state would get out of sync. It would have stored that a stream "existed", but the `next_stream_id` could still suggest that ID when sending a new request. Finally, when trying to store that new request, we'd hit a panic that the stream already existed.

The panic was correct, the stream did already exist. We shouldn't send a request with that "used" stream ID. So this patch makes sure that when sending a reset, if applicable, we update the `next_stream_id`.

It could be argued that we should be converting that reset into a connection error, since the remote shouldn't have send the bad frame in the first place. That'd require more refactoring. And this isn't likely something that is really encountered in practice, but rather something found by fuzzing.

Closes #570 