### PR TITLE
fix: properly reject prioritized HEADERS with stream ID of zero

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -146,6 +146,10 @@ impl Headers {
 
         tracing::trace!("loading headers; flags={:?}", flags);
 
+        if head.stream_id().is_zero() {
+            return Err(Error::InvalidStreamId);
+        }
+
         // Read the padding length
         if flags.is_padded() {
             if src.is_empty() {


### PR DESCRIPTION
I don't love that this doesn't include a test... But, the test is *exactly* the same as in https://github.com/hyperium/h2/pull/571, but just with the stream ID changed to 0. Seemed like a waste to include duplicate tests...