### PR TITLE
Add max send buffer per stream option

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -320,6 +320,9 @@ pub struct Builder {
     /// Initial target window size for new connections.
     initial_target_connection_window_size: Option<u32>,
 
+    /// Maximum amount of bytes to "buffer" for writing per stream.
+    max_send_buffer_size: usize,
+
     /// Maximum number of locally reset streams to keep at a time.
     reset_stream_max: usize,
 
@@ -628,6 +631,7 @@ impl Builder {
     /// ```
     pub fn new() -> Builder {
         Builder {
+            max_send_buffer_size: 1024 * 1024,
             reset_stream_duration: Duration::from_secs(proto::DEFAULT_RESET_STREAM_SECS),
             reset_stream_max: proto::DEFAULT_RESET_STREAM_MAX,
             initial_target_connection_window_size: None,
@@ -962,6 +966,17 @@ impl Builder {
         self
     }
 
+    /// Sets the maximum send buffer size per stream.
+    ///
+    /// Once a stream has buffered up to (or over) the maximum, the stream's
+    /// flow control will not "poll" additional capacity. Once bytes for the
+    /// stream have been written to the connection, the send buffer capacity
+    /// will be freed up again.
+    pub fn max_send_buffer_size(&mut self, max: usize) -> &mut Self {
+        self.max_send_buffer_size = max;
+        self
+    }
+
     /// Enables or disables server push promises.
     ///
     /// This value is included in the initial SETTINGS handshake. When set, the
@@ -1184,6 +1199,7 @@ where
             proto::Config {
                 next_stream_id: builder.stream_id,
                 initial_max_send_streams: builder.initial_max_send_streams,
+                max_send_buffer_size: builder.max_send_buffer_size,
                 reset_stream_duration: builder.reset_stream_duration,
                 reset_stream_max: builder.reset_stream_max,
                 settings: builder.settings.clone(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -631,7 +631,7 @@ impl Builder {
     /// ```
     pub fn new() -> Builder {
         Builder {
-            max_send_buffer_size: 1024 * 1024,
+            max_send_buffer_size: proto::DEFAULT_MAX_SEND_BUFFER_SIZE,
             reset_stream_duration: Duration::from_secs(proto::DEFAULT_RESET_STREAM_SECS),
             reset_stream_max: proto::DEFAULT_RESET_STREAM_MAX,
             initial_target_connection_window_size: None,
@@ -972,7 +972,14 @@ impl Builder {
     /// flow control will not "poll" additional capacity. Once bytes for the
     /// stream have been written to the connection, the send buffer capacity
     /// will be freed up again.
+    ///
+    /// The default is currently ~400MB, but may change.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `max` is larger than `u32::MAX`.
     pub fn max_send_buffer_size(&mut self, max: usize) -> &mut Self {
+        assert!(max <= std::u32::MAX as usize);
         self.max_send_buffer_size = max;
         self
     }

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -77,6 +77,7 @@ struct DynConnection<'a, B: Buf = Bytes> {
 pub(crate) struct Config {
     pub next_stream_id: StreamId,
     pub initial_max_send_streams: usize,
+    pub max_send_buffer_size: usize,
     pub reset_stream_duration: Duration,
     pub reset_stream_max: usize,
     pub settings: frame::Settings,
@@ -108,6 +109,7 @@ where
                     .initial_window_size()
                     .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE),
                 initial_max_send_streams: config.initial_max_send_streams,
+                local_max_buffer_size: config.max_send_buffer_size,
                 local_next_stream_id: config.next_stream_id,
                 local_push_enabled: config.settings.is_push_enabled().unwrap_or(true),
                 extended_connect_protocol_enabled: config

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -33,3 +33,4 @@ pub type WindowSize = u32;
 pub const MAX_WINDOW_SIZE: WindowSize = (1 << 31) - 1;
 pub const DEFAULT_RESET_STREAM_MAX: usize = 10;
 pub const DEFAULT_RESET_STREAM_SECS: u64 = 30;
+pub const DEFAULT_MAX_SEND_BUFFER_SIZE: usize = 1024 * 400;

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -41,6 +41,9 @@ pub struct Config {
     /// MAX_CONCURRENT_STREAMS specified in the frame.
     pub initial_max_send_streams: usize,
 
+    /// Max amount of DATA bytes to buffer per stream.
+    pub local_max_buffer_size: usize,
+
     /// The stream ID to start the next local stream with
     pub local_next_stream_id: StreamId,
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -340,10 +340,18 @@ impl Send {
         let available = stream.send_flow.available().as_size();
         let buffered = stream.buffered_send_data;
 
+        tracing::info!(
+            ?available,
+            ?buffered,
+            max_buffer_size = self.max_buffer_size
+        );
+
         if available as usize <= buffered {
             0
         } else {
-            available.min(self.max_buffer_size as WindowSize) - buffered as WindowSize
+            available
+                .min(self.max_buffer_size as WindowSize)
+                .saturating_sub(buffered as WindowSize)
         }
     }
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -28,6 +28,9 @@ pub(super) struct Send {
     /// > the identified last stream.
     max_stream_id: StreamId,
 
+    /// The maximum amount of bytes a stream should buffer.
+    max_buffer_size: usize,
+
     /// Initial window size of locally initiated streams
     init_window_sz: WindowSize,
 
@@ -52,6 +55,7 @@ impl Send {
     pub fn new(config: &Config) -> Self {
         Send {
             init_window_sz: config.remote_init_window_sz,
+            max_buffer_size: config.local_max_buffer_size,
             max_stream_id: StreamId::MAX,
             next_stream_id: Ok(config.local_next_stream_id),
             prioritize: Prioritize::new(config),
@@ -339,7 +343,7 @@ impl Send {
         if available as usize <= buffered {
             0
         } else {
-            available - buffered as WindowSize
+            available.min(self.max_buffer_size as WindowSize) - buffered as WindowSize
         }
     }
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -337,7 +337,7 @@ impl Send {
 
     /// Current available stream send capacity
     pub fn capacity(&self, stream: &mut store::Ptr) -> WindowSize {
-        let available = stream.send_flow.available().as_size();
+        let available = stream.send_flow.available().as_size() as usize;
         let buffered = stream.buffered_send_data;
 
         tracing::info!(
@@ -346,13 +346,7 @@ impl Send {
             max_buffer_size = self.max_buffer_size
         );
 
-        if available as usize <= buffered {
-            0
-        } else {
-            available
-                .min(self.max_buffer_size as WindowSize)
-                .saturating_sub(buffered as WindowSize)
-        }
+        available.min(self.max_buffer_size).saturating_sub(buffered) as WindowSize
     }
 
     pub fn poll_reset(

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -340,12 +340,6 @@ impl Send {
         let available = stream.send_flow.available().as_size() as usize;
         let buffered = stream.buffered_send_data;
 
-        tracing::info!(
-            ?available,
-            ?buffered,
-            max_buffer_size = self.max_buffer_size
-        );
-
         available.min(self.max_buffer_size).saturating_sub(buffered) as WindowSize
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -245,6 +245,9 @@ pub struct Builder {
 
     /// Initial target window size for new connections.
     initial_target_connection_window_size: Option<u32>,
+
+    /// Maximum amount of bytes to "buffer" for writing per stream.
+    max_send_buffer_size: usize,
 }
 
 /// Send a response back to the client
@@ -633,6 +636,7 @@ impl Builder {
             reset_stream_max: proto::DEFAULT_RESET_STREAM_MAX,
             settings: Settings::default(),
             initial_target_connection_window_size: None,
+            max_send_buffer_size: 1024 * 1024,
         }
     }
 
@@ -867,6 +871,17 @@ impl Builder {
     /// ```
     pub fn max_concurrent_reset_streams(&mut self, max: usize) -> &mut Self {
         self.reset_stream_max = max;
+        self
+    }
+
+    /// Sets the maximum send buffer size per stream.
+    ///
+    /// Once a stream has buffered up to (or over) the maximum, the stream's
+    /// flow control will not "poll" additional capacity. Once bytes for the
+    /// stream have been written to the connection, the send buffer capacity
+    /// will be freed up again.
+    pub fn max_send_buffer_size(&mut self, max: usize) -> &mut Self {
+        self.max_send_buffer_size = max;
         self
     }
 
@@ -1290,6 +1305,7 @@ where
                     next_stream_id: 2.into(),
                     // Server does not need to locally initiate any streams
                     initial_max_send_streams: 0,
+                    max_send_buffer_size: self.builder.max_send_buffer_size,
                     reset_stream_duration: self.builder.reset_stream_duration,
                     reset_stream_max: self.builder.reset_stream_max,
                     settings: self.builder.settings.clone(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -636,7 +636,7 @@ impl Builder {
             reset_stream_max: proto::DEFAULT_RESET_STREAM_MAX,
             settings: Settings::default(),
             initial_target_connection_window_size: None,
-            max_send_buffer_size: 1024 * 1024,
+            max_send_buffer_size: proto::DEFAULT_MAX_SEND_BUFFER_SIZE,
         }
     }
 
@@ -880,7 +880,14 @@ impl Builder {
     /// flow control will not "poll" additional capacity. Once bytes for the
     /// stream have been written to the connection, the send buffer capacity
     /// will be freed up again.
+    ///
+    /// The default is currently ~400MB, but may change.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `max` is larger than `u32::MAX`.
     pub fn max_send_buffer_size(&mut self, max: usize) -> &mut Self {
+        assert!(max <= std::u32::MAX as usize);
         self.max_send_buffer_size = max;
         self
     }


### PR DESCRIPTION
An alternative to #577.

This makes the max send buffer size **per stream**, instead of for the entire connection. It also does a lot less to try to enforce it, since the assigning of capacity is a complicated beast. All this does is clamp how high something like `SendStream::capacity()` will return. It's more just an advisory to the user of the `SendStream`.

Since hyper currently will only produce more data once the available capacity is over zero, it should behave well with this change. I've tried out this patch in the hyper HTTP/2 benchmarks, and see that they all still pass (don't hang). However, this is missing some unit tests in `flow_control.rs`...