### PR TITLE
Increase max send buf default to u32::MAX

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -33,4 +33,4 @@ pub type WindowSize = u32;
 pub const MAX_WINDOW_SIZE: WindowSize = (1 << 31) - 1;
 pub const DEFAULT_RESET_STREAM_MAX: usize = 10;
 pub const DEFAULT_RESET_STREAM_SECS: u64 = 30;
-pub const DEFAULT_MAX_SEND_BUFFER_SIZE: usize = 1024 * 400;
+pub const DEFAULT_MAX_SEND_BUFFER_SIZE: usize = std::u32::MAX as usize;


### PR DESCRIPTION
A hang was reported after the new release (https://github.com/hyperium/h2/pull/582#issuecomment-989340854).

@robjtede for now, this should make the default effectively off, while we investigate the hang.