### PR TITLE
chore: update indexmap dependency requirements to ^1.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ http = "0.2"
 tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 fnv = "1.0.5"
 slab = "0.4.2"
-indexmap = { version = "1.5.2", features = ["std"] }
+indexmap = { version = "^1.5.2", features = ["std"] }
 
 [dev-dependencies]
 


### PR DESCRIPTION
Indexmap released versions 1.6 and 1.7, which are relied on in other crates.

This unfortunately means relying on Hyper as well as other crates which depend on 1.6 and above will fail dependency resolution.

Relaxing the requirement here would allow resolution to find more compatible ranges, while maintaining compatibility according to semver.

How do you feel about this?

Thanks! :)