### PR TITLE
HTTP/2 is the official name, so update terms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
   "Carl Lerche <me@carllerche.com>",
   "Sean McArthur <sean@seanmonstar.com>",
 ]
-description = "An HTTP/2.0 client and server"
+description = "An HTTP/2 client and server"
 documentation = "https://docs.rs/h2"
 repository = "https://github.com/hyperium/h2"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # H2
 
-A Tokio aware, HTTP/2.0 client & server implementation for Rust.
+A Tokio aware, HTTP/2 client & server implementation for Rust.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Crates.io](https://img.shields.io/crates/v/h2.svg)](https://crates.io/crates/h2)
@@ -12,21 +12,21 @@ More information about this crate can be found in the [crate documentation][dox]
 
 ## Features
 
-* Client and server HTTP/2.0 implementation.
-* Implements the full HTTP/2.0 specification.
+* Client and server HTTP/2 implementation.
+* Implements the full HTTP/2 specification.
 * Passes [h2spec](https://github.com/summerwind/h2spec).
 * Focus on performance and correctness.
 * Built on [Tokio](https://tokio.rs).
 
 ## Non goals
 
-This crate is intended to only be an implementation of the HTTP/2.0
+This crate is intended to only be an implementation of the HTTP/2
 specification. It does not handle:
 
 * Managing TCP connections
 * HTTP 1.0 upgrade
 * TLS
-* Any feature not described by the HTTP/2.0 specification.
+* Any feature not described by the HTTP/2 specification.
 
 This crate is now used by [hyper](https://github.com/hyperium/hyper), which will provide all of these features.
 
@@ -55,7 +55,7 @@ fn main() {
 
 **How does h2 compare to [solicit] or [rust-http2]?**
 
-The h2 library has implemented more of the details of the HTTP/2.0 specification
+The h2 library has implemented more of the details of the HTTP/2 specification
 than any other Rust library. It also passes the [h2spec] set of tests. The h2
 library is rapidly approaching "production ready" quality.
 


### PR DESCRIPTION
The IETF only define HTTP/2 with no minor version. And at this stage I think its safe to assume that will never change.

Remaining references to HTTP/2.0 after this PR would be: one in the changelog, one in the GitHub repo About section. 
I avoided touching the changelog since it felt like rewriting history, but let me know if you feel different 