### PR TITLE
Change a debug_assert to assert

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -736,7 +736,7 @@ impl Prioritize {
 
                             // There *must* be be enough connection level
                             // capacity at this point.
-                            debug_assert!(len <= self.flow.window_size());
+                            assert!(len <= self.flow.window_size());
 
                             tracing::trace!(len, "sending data frame");
 


### PR DESCRIPTION
This is already asserted a few lines later anyway when calling `self.flow.send_data(len)` in the "updating connection flow" span.