### PR TITLE
Add a message for EOF-related broken pipe errors

### DIFF
--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -303,7 +303,13 @@ impl State {
             Closed(..) => {}
             ref state => {
                 tracing::trace!("recv_eof; state={:?}", state);
-                self.inner = Closed(Cause::Error(io::ErrorKind::BrokenPipe.into()));
+                self.inner = Closed(Cause::Error(
+                    io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "stream closed because of a broken pipe",
+                    )
+                    .into(),
+                ));
             }
         }
     }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -806,7 +806,13 @@ impl Inner {
         let send_buffer = &mut *send_buffer;
 
         if actions.conn_error.is_none() {
-            actions.conn_error = Some(io::Error::from(io::ErrorKind::BrokenPipe).into());
+            actions.conn_error = Some(
+                io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "connection closed because of a broken pipe",
+                )
+                .into(),
+            );
         }
 
         tracing::trace!("Streams::recv_eof");

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -574,7 +574,7 @@ async fn connection_close_notifies_response_future() {
                 .0
                 .await;
             let err = res.expect_err("response");
-            assert_eq!(err.to_string(), "broken pipe");
+            assert_eq!(err.to_string(), "stream closed because of a broken pipe");
         };
         join(async move { conn.await.expect("conn") }, req).await;
     };
@@ -613,7 +613,7 @@ async fn connection_close_notifies_client_poll_ready() {
                 .0
                 .await;
             let err = res.expect_err("response");
-            assert_eq!(err.to_string(), "broken pipe");
+            assert_eq!(err.to_string(), "stream closed because of a broken pipe");
         };
 
         conn.drive(req).await;
@@ -621,7 +621,10 @@ async fn connection_close_notifies_client_poll_ready() {
         let err = poll_fn(move |cx| client.poll_ready(cx))
             .await
             .expect_err("poll_ready");
-        assert_eq!(err.to_string(), "broken pipe");
+        assert_eq!(
+            err.to_string(),
+            "connection closed because of a broken pipe"
+        );
     };
 
     join(srv, client).await;


### PR DESCRIPTION
It's quite confusing from production logs when all I get is "broken pipe" and I don't know which path was taken for that error to be logged.