### PR TITLE
Move unexported macro doctest into unit test

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -11,7 +11,8 @@ use std::fmt;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore
+/// # // We ignore this doctest because the macro is not exported.
 /// let buf: [u8; 4] = [0, 0, 0, 1];
 /// assert_eq!(1u32, unpack_octets_4!(buf, 0, u32));
 /// ```
@@ -23,6 +24,15 @@ macro_rules! unpack_octets_4 {
             | (($buf[$offset + 2] as $tip) << 8)
             | (($buf[$offset + 3] as $tip) << 0)
     };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_unpack_octets_4() {
+        let buf: [u8; 4] = [0, 0, 0, 1];
+        assert_eq!(1u32, unpack_octets_4!(buf, 0, u32));
+    }
 }
 
 mod data;


### PR DESCRIPTION
Nightly has begun running doctests for unexported macros as of
https://github.com/rust-lang/rust/pull/96630, which caused a doctest for
test_unpack_octets_4 which was previously ignored to be run. This broke
the CI because macros that are not exported with `#[macro_export]`
cannot be used from external crates (and thus cannot be doctested). This
change ignores the doctest and copies the relevant code into a unit
test.