### PR TITLE
Add `Status::is_reset` function

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -59,10 +59,7 @@ impl Error {
 
     /// Returns true if the error is an io::Error
     pub fn is_io(&self) -> bool {
-        match self.kind {
-            Kind::Io(_) => true,
-            _ => false,
-        }
+        matches!(self.kind, Kind::Io(..))
     }
 
     /// Returns the error if the error is an io::Error
@@ -90,6 +87,11 @@ impl Error {
     /// Returns true if the error is from a `GOAWAY`.
     pub fn is_go_away(&self) -> bool {
         matches!(self.kind, Kind::GoAway(..))
+    }
+
+    /// Returns true if the error is from a `RST_STREAM`.
+    pub fn is_reset(&self) -> bool {
+        matches!(self.kind, Kind::Reset(..))
     }
 
     /// Returns true if the error was received in a frame from the remote.


### PR DESCRIPTION
We are trying to determine if the remote issued a stream reset and found that this test is missing from the `Status` type.

Closes #617