### PR TITLE
Fix poll_capacity returning Ready(Some(0))

### DIFF
--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -321,14 +321,13 @@ impl Send {
             return Poll::Ready(None);
         }
 
-        if !stream.send_capacity_inc {
-            stream.wait_send(cx);
-            return Poll::Pending;
+        let capacity = self.capacity(stream);
+        if capacity > 0 {
+            return Poll::Ready(Some(Ok(capacity)));
         }
 
-        stream.send_capacity_inc = false;
-
-        Poll::Ready(Some(Ok(self.capacity(stream))))
+        stream.wait_send(cx);
+        return Poll::Pending;
     }
 
     /// Current available stream send capacity

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -60,9 +60,6 @@ pub(super) struct Stream {
     /// True if the stream is waiting for outbound connection capacity
     pub is_pending_send_capacity: bool,
 
-    /// Set to true when the send capacity has been incremented
-    pub send_capacity_inc: bool,
-
     /// Next node in the open linked list
     pub next_open: Option<store::Key>,
 
@@ -165,7 +162,6 @@ impl Stream {
             pending_send: buffer::Deque::new(),
             is_pending_send_capacity: false,
             next_pending_send_capacity: None,
-            send_capacity_inc: false,
             is_pending_open: false,
             next_open: None,
             is_pending_push: false,
@@ -283,7 +279,6 @@ impl Stream {
 
         // Only notify if the capacity exceeds the amount of buffered data
         if available.min(max_buffer_size) > buffered {
-            self.send_capacity_inc = true;
             tracing::trace!("  notifying task");
             self.notify_send();
         }


### PR DESCRIPTION
`poll_capacity` should never return `Some(0)` - because the caller has
no way to be woken up when send capacity is available.

Check capacity and return `Pending` if it is zero. The wakeup code is
already correctly triggers notification when capacity changes to non-zero.