### PR TITLE
Removed unnecessary `'static` & Unpin bounds from body generic

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -341,7 +341,7 @@ pub(crate) struct Peer;
 
 impl<B> SendRequest<B>
 where
-    B: Buf + 'static,
+    B: Buf,
 {
     /// Returns `Ready` when the connection can initialize a new HTTP/2
     /// stream.
@@ -584,7 +584,7 @@ where
 
 impl<B> Future for ReadySendRequest<B>
 where
-    B: Buf + 'static,
+    B: Buf,
 {
     type Output = Result<SendRequest<B>, crate::Error>;
 
@@ -1100,7 +1100,7 @@ impl Builder {
     ) -> impl Future<Output = Result<(SendRequest<B>, Connection<T, B>), crate::Error>>
     where
         T: AsyncRead + AsyncWrite + Unpin,
-        B: Buf + 'static,
+        B: Buf,
     {
         Connection::handshake2(io, self.clone())
     }
@@ -1177,7 +1177,7 @@ where
 impl<T, B> Connection<T, B>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-    B: Buf + 'static,
+    B: Buf,
 {
     async fn handshake2(
         mut io: T,
@@ -1306,7 +1306,7 @@ where
 impl<T, B> Future for Connection<T, B>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-    B: Buf + 'static,
+    B: Buf,
 {
     type Output = Result<(), crate::Error>;
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1229,10 +1229,7 @@ impl<B> StreamRef<B> {
             .map_err(From::from)
     }
 
-    pub fn clone_to_opaque(&self) -> OpaqueStreamRef
-    where
-        B: 'static,
-    {
+    pub fn clone_to_opaque(&self) -> OpaqueStreamRef {
         self.opaque.clone()
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -364,7 +364,7 @@ where
 impl<T, B> Connection<T, B>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-    B: Buf + 'static,
+    B: Buf,
 {
     fn handshake2(io: T, builder: Builder) -> Handshake<T, B> {
         let span = tracing::trace_span!("server_handshake");
@@ -582,7 +582,7 @@ where
 impl<T, B> futures_core::Stream for Connection<T, B>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-    B: Buf + 'static,
+    B: Buf,
 {
     type Item = Result<(Request<RecvStream>, SendResponse<B>), crate::Error>;
 
@@ -1007,7 +1007,7 @@ impl Builder {
     pub fn handshake<T, B>(&self, io: T) -> Handshake<T, B>
     where
         T: AsyncRead + AsyncWrite + Unpin,
-        B: Buf + 'static,
+        B: Buf,
     {
         Connection::handshake2(io, self.clone())
     }
@@ -1262,7 +1262,7 @@ where
 impl<T, B: Buf> Future for Handshake<T, B>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-    B: Buf + 'static,
+    B: Buf,
 {
     type Output = Result<Connection<T, B>, crate::Error>;
 

--- a/tests/h2-support/src/client_ext.rs
+++ b/tests/h2-support/src/client_ext.rs
@@ -11,7 +11,7 @@ pub trait SendRequestExt {
 
 impl<B> SendRequestExt for SendRequest<B>
 where
-    B: Buf + Unpin + 'static,
+    B: Buf,
 {
     fn get(&mut self, uri: &str) -> ResponseFuture {
         let req = Request::builder()

--- a/tests/h2-support/src/prelude.rs
+++ b/tests/h2-support/src/prelude.rs
@@ -90,7 +90,7 @@ pub trait ClientExt {
 impl<T, B> ClientExt for client::Connection<T, B>
 where
     T: AsyncRead + AsyncWrite + Unpin + 'static,
-    B: Buf + Unpin + 'static,
+    B: Buf,
 {
     fn run<'a, F: Future + Unpin + 'a>(
         &'a mut self,


### PR DESCRIPTION
## Motivation

When proxying large requests, I want to be able to pass the request body straight through my server without loading all of it it in memory at once. This is currently very difficult due to the (seemingly) arbitrary `'static` bound on Hyper's body generic. And so, I want to remove the `'static` bounds for hyper 1.0, but before I can do that I need to remove them from here. (Will this require an h2 release before I can make the hyper patch?)

## Changes

- Removed unnecessary bounds from body generic
- ~~Fixed all clippy warnings~~ (Moved to #652)