### PR TITLE
server: Ignore `NotConnected` errors on shutdown

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -283,11 +283,16 @@ where
                     tracing::trace!("connection closing after flush");
                     // Flush/shutdown the codec
                     if let Err(e) = ready!(self.codec.shutdown(cx)) {
-                        // If the error kind is NotConnected then ignore that
-                        // since it means the connection is already shutdown.
+                        // If the error kind is NotConnected, ignore it, since
+                        // it just means the connection is already shutdown.
                         if e.kind() != io::ErrorKind::NotConnected {
                             return Poll::Ready(Err(e.into()));
-                        }
+                        } else {
+                            tracing::trace!(
+                                "ignoring NotConnected error \
+                                (the connection has already closed)"
+                           );
+                       }
                     }
 
                     // Transition the state to error

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -282,7 +282,13 @@ where
                 State::Closing(reason, initiator) => {
                     tracing::trace!("connection closing after flush");
                     // Flush/shutdown the codec
-                    ready!(self.codec.shutdown(cx))?;
+                    if let Err(e) = ready!(self.codec.shutdown(cx)) {
+                        // If the error kind is NotConnected then ignore that
+                        // since it means the connection is already shutdown.
+                        if e.kind() != io::ErrorKind::NotConnected {
+                            return Poll::Ready(Err(e.into()));
+                        }
+                    }
 
                     // Transition the state to error
                     self.inner.state = State::Closed(reason, initiator);


### PR DESCRIPTION
Related to https://github.com/hyperium/tonic/issues/1183

I started to see this error come up when debugging the above tonic issue, to me ignoring this error seems okay in this context, but I'd like to have some other eyes on it.

cc @seanmonstar @hawkw 