### PR TITLE
Add Protocol extension to Request on Extended CONNECT

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1451,8 +1451,13 @@ impl proto::Peer for Peer {
         }
 
         let has_protocol = pseudo.protocol.is_some();
-        if !is_connect && has_protocol {
-            malformed!("malformed headers: :protocol on non-CONNECT request");
+        if has_protocol {
+            if is_connect {
+                // Assert that we have the right type.
+                b = b.extension::<crate::ext::Protocol>(pseudo.protocol.unwrap());
+            } else {
+                malformed!("malformed headers: :protocol on non-CONNECT request");
+            }
         }
 
         if pseudo.status.is_some() {

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -1214,7 +1214,12 @@ async fn extended_connect_protocol_enabled_during_handshake() {
 
         let mut srv = builder.handshake::<_, Bytes>(io).await.expect("handshake");
 
-        let (_req, mut stream) = srv.next().await.unwrap().unwrap();
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+
+        assert_eq!(
+            req.extensions().get::<crate::ext::Protocol>(),
+            Some(&crate::ext::Protocol::from_static("the-bread-protocol"))
+        );
 
         let rsp = Response::new(());
         stream.send_response(rsp, false).unwrap();


### PR DESCRIPTION
This exposes the :protocol pseudo header as Request extension.

Fixes #347