### PR TITLE
#3000: Serialize debug_data when present in GOAWAY frames

### DIFF
--- a/src/frame/go_away.rs
+++ b/src/frame/go_away.rs
@@ -8,7 +8,6 @@ use crate::frame::{self, Error, Head, Kind, Reason, StreamId};
 pub struct GoAway {
     last_stream_id: StreamId,
     error_code: Reason,
-    #[allow(unused)]
     debug_data: Bytes,
 }
 
@@ -18,6 +17,15 @@ impl GoAway {
             last_stream_id,
             error_code: reason,
             debug_data: Bytes::new(),
+        }
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "unstable")]
+    pub fn with_debug_data(self, debug_data: impl Into<Bytes>) -> Self {
+        Self {
+            debug_data: debug_data.into(),
+            ..self
         }
     }
 
@@ -52,9 +60,10 @@ impl GoAway {
     pub fn encode<B: BufMut>(&self, dst: &mut B) {
         tracing::trace!("encoding GO_AWAY; code={:?}", self.error_code);
         let head = Head::new(Kind::GoAway, 0, StreamId::zero());
-        head.encode(8, dst);
+        head.encode(8 + self.debug_data.len(), dst);
         dst.put_u32(self.last_stream_id.into());
         dst.put_u32(self.error_code.into());
+        dst.put(self.debug_data.slice(..));
     }
 }
 

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -398,6 +398,18 @@ where
         self.go_away.go_away_now(frame);
     }
 
+    #[doc(hidden)]
+    #[cfg(feature = "unstable")]
+    fn go_away_now_debug_data(&mut self) {
+        let last_processed_id = self.streams.last_processed_id();
+
+        let frame = frame::GoAway::new(last_processed_id, Reason::NO_ERROR)
+            .with_debug_data("something went wrong");
+
+        self.streams.send_go_away(last_processed_id);
+        self.go_away.go_away(frame);
+    }
+
     fn go_away_from_user(&mut self, e: Reason) {
         let last_processed_id = self.streams.last_processed_id();
         let frame = frame::GoAway::new(last_processed_id, e);
@@ -574,6 +586,17 @@ where
 
         // We take the advice of waiting 1 RTT literally, and wait
         // for a pong before proceeding.
+        self.inner.ping_pong.ping_shutdown();
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "unstable")]
+    pub fn go_away_debug_data(&mut self) {
+        if self.inner.go_away.is_going_away() {
+            return;
+        }
+
+        self.inner.as_dyn().go_away_now_debug_data();
         self.inner.ping_pong.ping_shutdown();
     }
 }

--- a/src/proto/go_away.rs
+++ b/src/proto/go_away.rs
@@ -26,10 +26,6 @@ pub(super) struct GoAway {
 /// were a `frame::GoAway`, it might appear like we eventually wanted to
 /// serialize it. We **only** want to be able to look up these fields at a
 /// later time.
-///
-/// (Technically, `frame::GoAway` should gain an opaque_debug_data field as
-/// well, and we wouldn't want to save that here to accidentally dump in logs,
-/// or waste struct space.)
 #[derive(Debug)]
 pub(crate) struct GoingAway {
     /// Stores the highest stream ID of a GOAWAY that has been sent.

--- a/src/server.rs
+++ b/src/server.rs
@@ -544,6 +544,12 @@ where
         self.connection.go_away_gracefully();
     }
 
+    #[doc(hidden)]
+    #[cfg(feature = "unstable")]
+    pub fn debug_data_shutdown(&mut self) {
+        self.connection.go_away_debug_data();
+    }
+
     /// Takes a `PingPong` instance from the connection.
     ///
     /// # Note

--- a/tests/h2-support/src/frames.rs
+++ b/tests/h2-support/src/frames.rs
@@ -305,6 +305,13 @@ impl Mock<frame::GoAway> {
         self.reason(frame::Reason::NO_ERROR)
     }
 
+    pub fn data<I>(self, debug_data: I) -> Self
+    where
+        I: Into<Bytes>,
+    {
+        Mock(self.0.with_debug_data(debug_data.into()))
+    }
+
     pub fn reason(self, reason: frame::Reason) -> Self {
         Mock(frame::GoAway::new(self.0.last_stream_id(), reason))
     }


### PR DESCRIPTION
Fixes hyperium/hyper#3200

Debug data in GOAWAY frames is opaque information meant for diagnostic purposes. The data was previously read and stored when being received, but was never written during encoding.

This pull request includes the data when encoding the frame but does not add a (stable) way of setting the data. If it is desired I am happy to include it too. I suspect the function added for testing purposes wouldn't be fit for a stable, public API.

Additionally, I've included an integration test as described in the original issue. However, I'm quite sure there is a better way of creating the GOAWAY frame, I'm just not familiar enough with the structure of the integration tests to find it at the moment. With a few pointers I'd like to rewrite how it is done, if needed.