### PR TITLE
use HeaderName::from_static in Send::check_headers

### DIFF
--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -82,8 +82,8 @@ impl Send {
         if fields.contains_key(http::header::CONNECTION)
             || fields.contains_key(http::header::TRANSFER_ENCODING)
             || fields.contains_key(http::header::UPGRADE)
-            || fields.contains_key(http::HeaderName::from_static("keep-alive"))
-            || fields.contains_key(http::HeaderName::from_static("proxy-connection"))
+            || fields.contains_key(http::header::HeaderName::from_static("keep-alive"))
+            || fields.contains_key(http::header::HeaderName::from_static("proxy-connection"))
         {
             tracing::debug!("illegal connection-specific headers found");
             return Err(UserError::MalformedHeaders);

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -82,8 +82,8 @@ impl Send {
         if fields.contains_key(http::header::CONNECTION)
             || fields.contains_key(http::header::TRANSFER_ENCODING)
             || fields.contains_key(http::header::UPGRADE)
-            || fields.contains_key("keep-alive")
-            || fields.contains_key("proxy-connection")
+            || fields.contains_key(http::HeaderName::from_static("keep-alive"))
+            || fields.contains_key(http::HeaderName::from_static("proxy-connection"))
         {
             tracing::debug!("illegal connection-specific headers found");
             return Err(UserError::MalformedHeaders);


### PR DESCRIPTION
Prevents parsing the header names (due to the `AsHeaderName` impl on `&str`) over and over again at runtime. It's just a small optimization in my case (sub-1% cpu time) but given the simplicity of the change seemed worth making in any case.