### PR TITLE
fix: panicked when a reset stream would decrement twice

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -859,15 +859,6 @@ impl Recv {
 
         tracing::trace!("enqueue_reset_expiration; {:?}", stream.id);
 
-        if !counts.can_inc_num_reset_streams() {
-            // try to evict 1 stream if possible
-            // if max allow is 0, this won't be able to evict,
-            // and then we'll just bail after
-            if let Some(evicted) = self.pending_reset_expired.pop(stream.store_mut()) {
-                counts.transition_after(evicted, true);
-            }
-        }
-
         if counts.can_inc_num_reset_streams() {
             counts.inc_num_reset_streams();
             self.pending_reset_expired.push(stream);

--- a/tests/h2-tests/tests/stream_states.rs
+++ b/tests/h2-tests/tests/stream_states.rs
@@ -750,14 +750,14 @@ async fn rst_stream_max() {
         srv.recv_frame(frames::reset(1).cancel()).await;
         srv.recv_frame(frames::reset(3).cancel()).await;
         // sending frame after canceled!
-        // newer streams trump older streams
-        // 3 is still being ignored
-        srv.send_frame(frames::data(3, vec![0; 16]).eos()).await;
+        // olders streams trump newer streams
+        // 1 is still being ignored
+        srv.send_frame(frames::data(1, vec![0; 16]).eos()).await;
         // ping pong to be sure of no goaway
         srv.ping_pong([1; 8]).await;
-        // 1 has been evicted, will get a reset
-        srv.send_frame(frames::data(1, vec![0; 16]).eos()).await;
-        srv.recv_frame(frames::reset(1).stream_closed()).await;
+        // 3 has been evicted, will get a reset
+        srv.send_frame(frames::data(3, vec![0; 16]).eos()).await;
+        srv.recv_frame(frames::reset(3).stream_closed()).await;
     };
 
     let client = async move {


### PR DESCRIPTION
I noticed in logs that when a stream was dropped, and thus within `transition` and ready to expire as a locally reset stream, it would then pop its related push promises, and _those_ could trigger the original stream to call `transition_after`. The end result is that the original stream would call `dec_num_reset_streams()` twice.

This gets rid of a dangerous call to `transition_after` that is happening outside the bounds of a transition. It ends up making _newer_ streams that are locally reset to get forgotten, instead of older streams, but that's not really better or worse.

There is a fuzz seed that triggered the panic, and with this change, that fuzz seed no longer panics.