### PR TITLE
fix: do not ignore result of `ensure_recv_open`

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -308,7 +308,9 @@ impl Recv {
             Some(Event::Headers(Client(response))) => Poll::Ready(Ok(response)),
             Some(_) => panic!("poll_response called after response returned"),
             None => {
-                stream.state.ensure_recv_open()?;
+                if !stream.state.ensure_recv_open()? {
+                    return Poll::Ready(Ok(Response::new(())))
+                }
 
                 stream.recv_task = Some(cx.waker().clone());
                 Poll::Pending

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -726,7 +726,10 @@ impl Inner {
                 }
 
                 // The stream must be receive open
-                stream.state.ensure_recv_open()?;
+                if !stream.state.ensure_recv_open()? {
+                    return Ok(())
+                }
+
                 stream.key()
             }
             None => {


### PR DESCRIPTION
It may cause hanging, because result isn't checked
Noticed within #600