### PR TITLE
Use span without a parent for connection

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -137,7 +137,7 @@ where
                 ping_pong: PingPong::new(),
                 settings: Settings::new(config.settings),
                 streams,
-                span: tracing::debug_span!("Connection", peer = %P::NAME),
+                span: tracing::debug_span!(parent: None, "Connection", peer = %P::NAME),
                 _phantom: PhantomData,
             },
         }


### PR DESCRIPTION
We have found out in our project that sometimes when calling a gRPC service, a connection is created during that call and that connection is pooled for later use. However, when the connection was made a span was created which used the current span as a parent.

This leads to our traces that should be a few milliseconds long to include the whole lifetime of the connection which times out after 90 seconds or 3 minutes.

This change makes it so that the span is a root span.

I have asked in the `tracing-users` Discord about this and got [this reply](https://discord.com/channels/500028886025895936/627649734592561152/1116390927913713724) so I hope this is ok.

I've also thought about adding an optional span to be used as a parent into the `Config` struct but it does not seem useful enough to warrant a breaking change there, but if anyone thinks that it should be there, I will do that. I have just checked that it's used from within `Handshake` which creates its own `trace_span` so the propagation could touch a few more things.