### PR TITLE
h2 server panics when receiving headers that look like response

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -251,14 +251,15 @@ impl Recv {
     }
 
     /// Called by the server to get the request
-    ///
-    /// TODO: Should this fn return `Result`?
-    pub fn take_request(&mut self, stream: &mut store::Ptr) -> Request<()> {
+    pub fn take_request(&mut self, stream: &mut store::Ptr) -> Result<Request<()>, proto::Error> {
         use super::peer::PollMessage::*;
 
         match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Headers(Server(request))) => request,
-            _ => panic!(),
+            Some(Event::Headers(Server(request))) => Ok(request),
+            _ => {
+                proto_err!(stream: "received invalid request; stream={:?}", stream.id);
+                Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR))
+            }
         }
     }
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1178,7 +1178,7 @@ impl<B> StreamRef<B> {
     /// # Panics
     ///
     /// This function panics if the request isn't present.
-    pub fn take_request(&self) -> Request<()> {
+    pub fn take_request(&self) -> Result<Request<()>, proto::Error> {
         let mut me = self.opaque.inner.lock().unwrap();
         let me = &mut *me;
 

--- a/tests/h2-tests/Cargo.toml
+++ b/tests/h2-tests/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 h2-support = { path = "../h2-support" }
 tracing = "0.1.13"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-tokio = { version = "1", features = ["macros", "net", "rt", "io-util"] }
+tokio = { version = "1", features = ["macros", "net", "rt", "io-util", "rt-multi-thread"] }


### PR DESCRIPTION
Sending a response frame to an `h2` server triggers a panic. this PR makes the `take_request` function return a Result instead of panicking.