### PR TITLE
Fix for invalid header panic corrected

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -263,7 +263,9 @@ impl Recv {
 
         match stream.pending_recv.pop_front(&mut self.buffer) {
             Some(Event::Headers(Server(request))) => request,
-            _ => unreachable!("This panic should not be reached. Cut an issue at https://github.com/hyperium/h2"),
+            _ => unreachable!(
+                "This panic should not be reached. Cut an issue at https://github.com/hyperium/h2"
+            ),
         }
     }
 

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -248,6 +248,8 @@ impl Recv {
             // Only servers can receive a headers frame that initiates the stream.
             // This is verified in `Streams` before calling this function.
             if counts.peer().is_server() {
+                // Correctness: never push a stream to `pending_accept` without having the
+                // corresponding headers frame pushed to `stream.pending_recv`.
                 self.pending_accept.push(stream);
             }
         }
@@ -257,7 +259,10 @@ impl Recv {
 
     /// Called by the server to get the request
     ///
-    /// TODO: Should this fn return `Result`?
+    /// # Panics
+    ///
+    /// Panics if `stream.pending_recv` has no `Event::Headers` queued.
+    ///
     pub fn take_request(&mut self, stream: &mut store::Ptr) -> Request<()> {
         use super::peer::PollMessage::*;
 

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -263,7 +263,7 @@ impl Recv {
 
         match stream.pending_recv.pop_front(&mut self.buffer) {
             Some(Event::Headers(Server(request))) => request,
-            _ => panic!(),
+            _ => unreachable!("This panic should not be reached. Cut an issue at https://github.com/hyperium/h2"),
         }
     }
 

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -251,15 +251,14 @@ impl Recv {
     }
 
     /// Called by the server to get the request
-    pub fn take_request(&mut self, stream: &mut store::Ptr) -> Result<Request<()>, proto::Error> {
+    ///
+    /// TODO: Should this fn return `Result`?
+    pub fn take_request(&mut self, stream: &mut store::Ptr) -> Request<()> {
         use super::peer::PollMessage::*;
 
         match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Headers(Server(request))) => Ok(request),
-            _ => {
-                proto_err!(stream: "received invalid request; stream={:?}", stream.id);
-                Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR))
-            }
+            Some(Event::Headers(Server(request))) => request,
+            _ => panic!(),
         }
     }
 

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -268,9 +268,7 @@ impl Recv {
 
         match stream.pending_recv.pop_front(&mut self.buffer) {
             Some(Event::Headers(Server(request))) => request,
-            _ => unreachable!(
-                "This panic should not be reached. Cut an issue at https://github.com/hyperium/h2"
-            ),
+            _ => unreachable!("server stream queue must start with Headers"),
         }
     }
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1178,7 +1178,7 @@ impl<B> StreamRef<B> {
     /// # Panics
     ///
     /// This function panics if the request isn't present.
-    pub fn take_request(&self) -> Result<Request<()>, proto::Error> {
+    pub fn take_request(&self) -> Request<()> {
         let mut me = self.opaque.inner.lock().unwrap();
         let me = &mut *me;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -425,20 +425,13 @@ where
 
         if let Some(inner) = self.connection.next_incoming() {
             tracing::trace!("received incoming");
-            match inner.take_request() {
-                Ok(req) => {
-                    let (head, _) = req.into_parts();
-                    let body = RecvStream::new(FlowControl::new(inner.clone_to_opaque()));
+            let (head, _) = inner.take_request().into_parts();
+            let body = RecvStream::new(FlowControl::new(inner.clone_to_opaque()));
 
-                    let request = Request::from_parts(head, body);
-                    let respond = SendResponse { inner };
+            let request = Request::from_parts(head, body);
+            let respond = SendResponse { inner };
 
-                    return Poll::Ready(Some(Ok((request, respond))));
-                }
-                Err(e) => {
-                    return Poll::Ready(Some(Err(e.into())));
-                }
-            }
+            return Poll::Ready(Some(Ok((request, respond))));
         }
 
         Poll::Pending

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -1389,9 +1389,13 @@ async fn reject_informational_status_header_in_request() {
         let _ = client.assert_server_handshake().await;
 
         let status_code = 128;
-        assert!(StatusCode::from_u16(status_code).unwrap().is_informational());
+        assert!(StatusCode::from_u16(status_code)
+            .unwrap()
+            .is_informational());
 
-        client.send_frame(frames::headers(1).response(status_code)).await;
+        client
+            .send_frame(frames::headers(1).response(status_code))
+            .await;
 
         client.recv_frame(frames::reset(1).protocol_error()).await;
     };

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -1378,35 +1378,3 @@ async fn reject_non_authority_target_on_connect_request() {
 
     join(client, srv).await;
 }
-
-#[tokio::test]
-async fn reject_response_headers_in_request() {
-    h2_support::trace_init!();
-
-    let (io, mut client) = mock::new();
-
-    let client = async move {
-        let _ = client.assert_server_handshake().await;
-
-        client.send_frame(frames::headers(1).response(128)).await;
-
-        // TODO: is CANCEL the right error code to expect here?
-        client.recv_frame(frames::reset(1).cancel()).await;
-    };
-
-    let srv = async move {
-        let builder = server::Builder::new();
-        let mut srv = builder.handshake::<_, Bytes>(io).await.expect("handshake");
-
-        let res = srv.next().await;
-        tracing::warn!("{:?}", res);
-        assert!(res.is_some());
-        assert!(res.unwrap().is_err());
-
-        poll_fn(move |cx| srv.poll_closed(cx))
-            .await
-            .expect("server");
-    };
-
-    join(client, srv).await;
-}


### PR DESCRIPTION
Corrected fix in #690 - the root cause was that informational header frames are ignored, even if received by the server. However, the stream was still scheduled in `pending_accept`. This then triggers the `take_request`, while nothing is put in the `pending_recv` queue, which then causes the panic.