### PR TITLE
test: update `h2spec` version

### DIFF
--- a/ci/h2spec.sh
+++ b/ci/h2spec.sh
@@ -3,7 +3,7 @@ LOGFILE="h2server.log"
 
 if ! [ -e "h2spec" ] ; then
     # if we don't already have a h2spec executable, wget it from github
-    wget https://github.com/summerwind/h2spec/releases/download/v2.1.1/h2spec_linux_amd64.tar.gz
+    wget https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz
     tar xf h2spec_linux_amd64.tar.gz
 fi
 


### PR DESCRIPTION
But it fails against the current `h2` version, see #701