### PR TITLE
Feat: Add a feature flag to ignore connection headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rust-version = "1.63"
 [features]
 # Enables `futures::Stream` implementations for various types.
 stream = []
+ignore_connection_header = []
 
 # Enables **unstable** APIs. Any API exposed by this feature has no backwards
 # compatibility guarantees. In other words, you should not use this feature for

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -871,16 +871,25 @@ impl HeaderBlock {
             match header {
                 Field { name, value } => {
                     // Connection level header fields are not supported and must
-                    // result in a protocol error.
+                    // result in a protocol error. However in reality there are
+                    // servers setting these headers. Some of these headers are
+                    // purely informational and can be simply ignored without
+                    // affecting the integrity of the stream.
 
-                    if name == header::CONNECTION
-                        || name == header::TRANSFER_ENCODING
+                    if name == header::TRANSFER_ENCODING {
+                        tracing::trace!("load_hpack; connection level header");
+                        malformed = true;
+                    } else if name == header::CONNECTION
                         || name == header::UPGRADE
                         || name == "keep-alive"
                         || name == "proxy-connection"
                     {
-                        tracing::trace!("load_hpack; connection level header");
-                        malformed = true;
+                        if cfg!(feature = "ignore_connection_header") {
+                            tracing::trace!("load_hpack; connection level header ignored");
+                        } else {
+                            tracing::trace!("load_hpack; connection level header");
+                            malformed = true;
+                        }
                     } else if name == header::TE && value != "trailers" {
                         tracing::trace!(
                             "load_hpack; TE header not set to trailers; val={:?}",

--- a/tests/h2-support/Cargo.toml
+++ b/tests/h2-support/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 
+[features]
+ignore_connection_header = ["h2/ignore_connection_header"]
+
 [dependencies]
 h2 = { path = "../..", features = ["stream", "unstable"] }
 

--- a/tests/h2-tests/Cargo.toml
+++ b/tests/h2-tests/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 edition = "2018"
 
+[features]
+ignore_connection_header = ["h2-support/ignore_connection_header"]
+
 [dependencies]
 
 [dev-dependencies]


### PR DESCRIPTION
According to the RFC, when encountering connection headers, H2 should treat them as protocol errors. However, in reality there are servers just setting these headers but only for informational purpose.

This feature allow the receiving end to just ignore these headers without bailing the entire stream.

I'm just putting this out here to see whether it is possible for things like this to be accepted.