### PR TITLE
chore(dependencies): update tracing minimal version to 0.1.35

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,6 +90,13 @@ jobs:
 
       - run: cargo check -p h2
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    needs: [style]
+    steps:
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions --ignore-private check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tokio-util = { version = "0.7.1", features = ["codec", "io"] }
 tokio = { version = "1", features = ["io-util"] }
 bytes = "1"
 http = "0.2"
-tracing = { version = "0.1.32", default-features = false, features = ["std"] }
+tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 fnv = "1.0.5"
 slab = "0.4.2"
 indexmap = { version = "2", features = ["std"] }

--- a/tests/h2-support/Cargo.toml
+++ b/tests/h2-support/Cargo.toml
@@ -2,6 +2,7 @@
 name = "h2-support"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+publish = false
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This pull request contains some changes related to the minimal version checking.

- Brings back a minimal versions checking in ci, changed to be run on stable Rust.
- Marks `h2-support` as a private crate not to affect minimal versions.
- Fixes `tracing` minimal version, which seems to have been affected by `h2-support`.