### PR TITLE
Fix documentation for max_send_buffer_size (#718)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1023,7 +1023,7 @@ impl Builder {
     /// stream have been written to the connection, the send buffer capacity
     /// will be freed up again.
     ///
-    /// The default is currently ~400MB, but may change.
+    /// The default is currently ~400KB, but may change.
     ///
     /// # Panics
     ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -937,7 +937,7 @@ impl Builder {
     /// stream have been written to the connection, the send buffer capacity
     /// will be freed up again.
     ///
-    /// The default is currently ~400MB, but may change.
+    /// The default is currently ~400KB, but may change.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
This PR updates the documentation to reflect the actual default for `max_send_buffer_size` field, which is 400 KB, not 400 MB.

Fixes #718.