### PR TITLE
fix: streams awaiting capacity lockout

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ pub struct Error {
 #[derive(Debug)]
 enum Kind {
     /// A RST_STREAM frame was received or sent.
+    #[allow(dead_code)]
     Reset(StreamId, Reason, Initiator),
 
     /// A GO_AWAY frame was received or sent.

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -474,7 +474,13 @@ impl Prioritize {
             //
             // In this case, the stream needs to be queued up for when the
             // connection has more capacity.
-            self.pending_capacity.push(stream);
+            if stream.is_send_ready() {
+                // Prioritize assigning capacity to a send-ready stream
+                // See https://github.com/hyperium/hyper/issues/3338
+                self.pending_capacity.push_front(stream);
+            } else {
+                self.pending_capacity.push(stream);
+            }
         }
 
         // If data is buffered and the stream is send ready, then


### PR DESCRIPTION
Fixes https://github.com/hyperium/hyper/issues/3338

This PR changes the the assign-capacity queue to prioritize streams that are send-ready.

This is necessary to prevent a lockout when streams aren't able to proceed while waiting for connection capacity, but there is none.