### PR TITLE
Make the hpack a public module

### DIFF
--- a/src/hpack/header.rs
+++ b/src/hpack/header.rs
@@ -117,6 +117,16 @@ impl Header {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        match *self {
+            Header::Field {
+                ref name,
+                ref value,
+            } => len(name, value) == 0,
+            _ => false,
+        }
+    }
+
     /// Returns the header name
     pub fn name(&self) -> Name {
         match *self {

--- a/src/hpack/mod.rs
+++ b/src/hpack/mod.rs
@@ -1,5 +1,7 @@
-mod decoder;
-mod encoder;
+#[allow(missing_docs)]
+pub mod decoder;
+#[allow(missing_docs)]
+pub mod encoder;
 pub(crate) mod header;
 pub(crate) mod huffman;
 mod table;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,8 @@ macro_rules! ready {
 #[cfg_attr(feature = "unstable", allow(missing_docs))]
 mod codec;
 mod error;
-mod hpack;
+#[allow(missing_docs)]
+pub mod hpack;
 
 #[cfg(not(feature = "unstable"))]
 mod proto;


### PR DESCRIPTION
This PR is making the hpack module with its encoder/decoder as public for other projects which have the need for this low-level capablities specifically.