### PR TITLE
streams: add a second check in front of reset flood mitigations

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -82,6 +82,7 @@ pub(crate) struct Config {
     pub reset_stream_max: usize,
     pub remote_reset_stream_max: usize,
     pub local_error_reset_streams_max: Option<usize>,
+    pub reset_flood_pending_frames_min: usize,
     pub settings: frame::Settings,
 }
 
@@ -127,6 +128,7 @@ where
                     .max_concurrent_streams()
                     .map(|max| max as usize),
                 local_max_error_reset_streams: config.local_error_reset_streams_max,
+                reset_flood_pending_frames_min: config.reset_flood_pending_frames_min,
             }
         }
         let streams = Streams::new(streams_config(&config));

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -32,9 +32,9 @@ pub type WindowSize = u32;
 // Constants
 pub const MAX_WINDOW_SIZE: WindowSize = (1 << 31) - 1; // i32::MAX as u32
 pub const DEFAULT_REMOTE_RESET_STREAM_MAX: usize = 20;
-pub const DEFAULT_LOCAL_RESET_COUNT_MAX: usize = 1024;
+pub const DEFAULT_LOCAL_RESET_COUNT_MAX: usize = 2048;
 
-pub const DEFAULT_RESET_FLOOD_PENDING_FRAMES_MIN: usize = 1024;
+pub const DEFAULT_RESET_FLOOD_PENDING_FRAMES_MIN: usize = DEFAULT_LOCAL_RESET_COUNT_MAX / 4;
 pub const DEFAULT_RESET_STREAM_MAX: usize = 10;
 pub const DEFAULT_RESET_STREAM_SECS: u64 = 30;
 pub const DEFAULT_MAX_SEND_BUFFER_SIZE: usize = 1024 * 400;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -33,6 +33,8 @@ pub type WindowSize = u32;
 pub const MAX_WINDOW_SIZE: WindowSize = (1 << 31) - 1; // i32::MAX as u32
 pub const DEFAULT_REMOTE_RESET_STREAM_MAX: usize = 20;
 pub const DEFAULT_LOCAL_RESET_COUNT_MAX: usize = 1024;
+
+pub const DEFAULT_RESET_FLOOD_PENDING_FRAMES_MIN: usize = 1024;
 pub const DEFAULT_RESET_STREAM_MAX: usize = 10;
 pub const DEFAULT_RESET_STREAM_SECS: u64 = 30;
 pub const DEFAULT_MAX_SEND_BUFFER_SIZE: usize = 1024 * 400;

--- a/src/proto/streams/buffer.rs
+++ b/src/proto/streams/buffer.rs
@@ -29,6 +29,10 @@ impl<T> Buffer<T> {
     pub fn new() -> Self {
         Buffer { slab: Slab::new() }
     }
+
+    pub fn len(&self) -> usize {
+        self.slab.len()
+    }
 }
 
 impl Deque {

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -41,6 +41,9 @@ pub(super) struct Counts {
     /// Total number of locally reset streams due to protocol error across the
     /// lifetime of the connection.
     num_local_error_reset_streams: usize,
+
+    /// Minimum number of frames after which we will mitigate for Reset Flood
+    min_reset_flood_pending_frames: usize,
 }
 
 impl Counts {
@@ -54,6 +57,7 @@ impl Counts {
             num_recv_streams: 0,
             max_local_reset_streams: config.local_reset_max,
             num_local_reset_streams: 0,
+            min_reset_flood_pending_frames: config.reset_flood_pending_frames_min,
             max_remote_reset_streams: config.remote_reset_max,
             num_remote_reset_streams: 0,
             max_local_error_reset_streams: config.local_max_error_reset_streams,
@@ -96,6 +100,10 @@ impl Counts {
 
     pub(crate) fn max_local_error_resets(&self) -> Option<usize> {
         self.max_local_error_reset_streams
+    }
+
+    pub fn min_reset_flood_pending_frames(&self) -> usize {
+        self.min_reset_flood_pending_frames
     }
 
     /// Returns true if the receive stream concurrency can be incremented

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -73,6 +73,11 @@ pub struct Config {
     /// Maximum number of locally reset streams due to protocol error across
     /// the lifetime of the connection.
     ///
-    /// When this gets exceeded, we issue GOAWAYs.
+    /// When this gets exceeded, we issue GOAWAYs if the
+    /// reset_flood_pending_frames_min check also fails.
     pub local_max_error_reset_streams: Option<usize>,
+
+    /// Minimum number of pending frames after which we will start mitigating
+    /// reset flood attacks.
+    pub reset_flood_pending_frames_min: usize,
 }


### PR DESCRIPTION
Some clients occasionally send garbage, so let's also only mitigate if they actually start inflating the queue to try and attack us.