### PR TITLE
feat: not returning UnexpectedEof when client drop without close_notify

### DIFF
--- a/src/proto/streams/buffer.rs
+++ b/src/proto/streams/buffer.rs
@@ -29,6 +29,10 @@ impl<T> Buffer<T> {
     pub fn new() -> Self {
         Buffer { slab: Slab::new() }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.slab.is_empty()
+    }
 }
 
 impl Deque {

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -323,6 +323,14 @@ where
 }
 
 impl<B> DynStreams<'_, B> {
+    pub fn is_buffer_empty(&self) -> bool {
+        self.send_buffer.is_empty()
+    }
+
+    pub fn is_server(&self) -> bool {
+        self.peer.is_server()
+    }
+
     pub fn recv_headers(&mut self, frame: frame::Headers) -> Result<(), Error> {
         let mut me = self.inner.lock().unwrap();
 
@@ -1508,6 +1516,11 @@ impl<B> SendBuffer<B> {
     fn new() -> Self {
         let inner = Mutex::new(Buffer::new());
         SendBuffer { inner }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let buf = self.inner.lock().unwrap();
+        buf.is_empty()
     }
 }
 

--- a/tests/h2-support/src/mock.rs
+++ b/tests/h2-support/src/mock.rs
@@ -54,6 +54,9 @@ struct Inner {
 
     /// True when the pipe is closed.
     closed: bool,
+
+    /// Trigger an `UnexpectedEof` error on read
+    unexpected_eof: bool,
 }
 
 const PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
@@ -73,6 +76,7 @@ pub fn new_with_write_capacity(cap: usize) -> (Mock, Handle) {
         tx_rem: cap,
         tx_rem_task: None,
         closed: false,
+        unexpected_eof: false,
     }));
 
     let mock = Mock {
@@ -94,6 +98,11 @@ impl Handle {
     /// Get a mutable reference to inner Codec.
     pub fn codec_mut(&mut self) -> &mut crate::Codec<Pipe> {
         &mut self.codec
+    }
+
+    pub fn close_without_notify(&mut self) {
+        let mut me = self.codec.get_mut().inner.lock().unwrap();
+        me.unexpected_eof = true;
     }
 
     /// Send a frame
@@ -347,6 +356,13 @@ impl AsyncRead for Mock {
         );
 
         let mut me = self.pipe.inner.lock().unwrap();
+
+        if me.unexpected_eof {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Simulate an unexpected eof error",
+            )));
+        }
 
         if me.rx.is_empty() {
             if me.closed {

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -2,6 +2,7 @@ use futures::future::{join, ready, select, Either};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use h2_support::prelude::*;
+use std::io;
 use std::pin::Pin;
 use std::task::Context;
 
@@ -1773,52 +1774,42 @@ async fn receive_settings_frame_twice_with_second_one_empty() {
 }
 
 #[tokio::test]
-async fn receive_settings_frame_twice_with_second_one_non_empty() {
+async fn server_drop_connection_unexpectedly_return_unexpected_eof_err() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 
     let srv = async move {
-        // Send the initial SETTINGS frame with MAX_CONCURRENT_STREAMS set to 42
-        srv.send_frame(frames::settings().max_concurrent_streams(42))
-            .await;
-
-        // Handle the client's connection preface
-        srv.read_preface().await.unwrap();
-        match srv.next().await {
-            Some(frame) => match frame.unwrap() {
-                h2::frame::Frame::Settings(_) => {
-                    let ack = frame::Settings::ack();
-                    srv.send(ack.into()).await.unwrap();
-                }
-                frame => {
-                    panic!("unexpected frame: {:?}", frame);
-                }
-            },
-            None => {
-                panic!("unexpected EOF");
-            }
-        }
-
-        // Should receive the ack for the server's initial SETTINGS frame
-        let frame = assert_settings!(srv.next().await.unwrap().unwrap());
-        assert!(frame.is_ack());
-
-        // Send another SETTINGS frame with no MAX_CONCURRENT_STREAMS
-        // This should not update the max_concurrent_send_streams value that
-        // the client manages.
-        srv.send_frame(frames::settings().max_concurrent_streams(2024))
-            .await;
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .await;
+        srv.close_without_notify();
     };
 
     let h2 = async move {
-        let (_client, h2) = client::handshake(io).await.unwrap();
-        let mut h2 = std::pin::pin!(h2);
-        assert_eq!(h2.max_concurrent_send_streams(), usize::MAX);
-        h2.as_mut().await.unwrap();
-        // The most-recently advertised value should be used
-        assert_eq!(h2.max_concurrent_send_streams(), 2024);
+        let (mut client, h2) = client::handshake(io).await.unwrap();
+        tokio::spawn(async move {
+            let request = Request::builder()
+                .uri("https://http2.akamai.com/")
+                .body(())
+                .unwrap();
+            let _res = client
+                .send_request(request, true)
+                .unwrap()
+                .0
+                .await
+                .expect("request");
+        });
+        let err = h2.await.expect_err("should receive UnexpectedEof");
+        assert_eq!(
+            err.get_io().expect("should be UnexpectedEof").kind(),
+            io::ErrorKind::UnexpectedEof,
+        );
     };
-
     join(srv, h2).await;
 }
 


### PR DESCRIPTION
closes https://github.com/hyperium/hyper/issues/3427

This PR makes it so that if we encountered `UnexpectedEof` as a server, and when there is nothing else to send (i.e. we sent what the client wanted), `Connection::poll` will not return an `Err`.

Note that this does not change the client behaviour when the server closed the connection abruptly.

---

Something to consider is whether we should handle this in hyper instead. But I don't see a good reason why we shouldn't put it in `h2`