### PR TITLE
fix: stream flow control insufficient size before ack

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -106,10 +106,6 @@ where
     pub fn new(codec: Codec<T, Prioritized<B>>, config: Config) -> Connection<T, P, B> {
         fn streams_config(config: &Config) -> streams::Config {
             streams::Config {
-                local_init_window_sz: config
-                    .settings
-                    .initial_window_size()
-                    .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE),
                 initial_max_send_streams: config.initial_max_send_streams,
                 local_max_buffer_size: config.max_send_buffer_size,
                 local_next_stream_id: config.next_stream_id,

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -33,9 +33,6 @@ use std::time::Duration;
 
 #[derive(Debug)]
 pub struct Config {
-    /// Initial window size of locally initiated streams
-    pub local_init_window_sz: WindowSize,
-
     /// Initial maximum number of locally initiated streams.
     /// After receiving a Settings frame from the remote peer,
     /// the connection will overwrite this value with the

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -93,7 +93,7 @@ impl Recv {
         flow.assign_capacity(DEFAULT_INITIAL_WINDOW_SIZE).unwrap();
 
         Recv {
-            init_window_sz: config.local_init_window_sz,
+            init_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
             flow,
             in_flight_data: 0 as WindowSize,
             next_stream_id: Ok(next_stream_id.into()),


### PR DESCRIPTION
closes #630 

This PR makes the Recv stream use the default window size before receiving ACK from the other party.

This matters as a server when we want the stream `initial_window_size` <= default settings. In some cases, the client will eagerly send some data frames before ACK-ing settings, thus resulting in a flow control error if the size of data frames is greater than the set `initial_window_size`.