### PR TITLE
Respond 400 + Reset to malformed request

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -447,7 +447,7 @@ where
             // Attempting to read a frame resulted in a stream level error.
             // This is handled by resetting the frame then trying to read
             // another frame.
-            Err(Error::Reset(id, reason, initiator)) => {
+            Err(Error::Reset(id, reason, initiator, _)) => {
                 debug_assert_eq!(initiator, Initiator::Library);
                 tracing::trace!(?id, ?reason, "stream error");
                 self.streams.send_reset(id, reason);

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -11,7 +11,7 @@ pub use self::error::{Error, Initiator};
 pub(crate) use self::peer::{Dyn as DynPeer, Peer};
 pub(crate) use self::ping_pong::UserPings;
 pub(crate) use self::streams::{DynStreams, OpaqueStreamRef, StreamRef, Streams};
-pub(crate) use self::streams::{Open, PollReset, Prioritized};
+pub(crate) use self::streams::{Open, PollReset, Prioritized, SendResetContext};
 
 use crate::codec::Codec;
 

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -12,7 +12,7 @@ mod streams;
 
 pub(crate) use self::prioritize::Prioritized;
 pub(crate) use self::recv::Open;
-pub(crate) use self::send::PollReset;
+pub(crate) use self::send::{PollReset, SendResetContext};
 pub(crate) use self::streams::{DynStreams, OpaqueStreamRef, StreamRef, Streams};
 
 use self::buffer::Buffer;

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -333,7 +333,9 @@ impl State {
 
     /// Set the stream state to reset locally.
     pub fn set_reset(&mut self, stream_id: StreamId, reason: Reason, initiator: Initiator) {
-        self.inner = Closed(Cause::Error(Error::Reset(stream_id, reason, initiator)));
+        self.inner = Closed(Cause::Error(Error::Reset(
+            stream_id, reason, initiator, None,
+        )));
     }
 
     /// Set the stream state to a scheduled reset.
@@ -364,7 +366,7 @@ impl State {
     pub fn is_remote_reset(&self) -> bool {
         matches!(
             self.inner,
-            Closed(Cause::Error(Error::Reset(_, _, Initiator::Remote)))
+            Closed(Cause::Error(Error::Reset(_, _, Initiator::Remote, _)))
         )
     }
 
@@ -446,7 +448,7 @@ impl State {
     /// Returns a reason if the stream has been reset.
     pub(super) fn ensure_reason(&self, mode: PollReset) -> Result<Option<Reason>, crate::Error> {
         match self.inner {
-            Closed(Cause::Error(Error::Reset(_, reason, _)))
+            Closed(Cause::Error(Error::Reset(_, reason, _, _)))
             | Closed(Cause::Error(Error::GoAway(_, reason, _)))
             | Closed(Cause::ScheduledLibraryReset(reason)) => Ok(Some(reason)),
             Closed(Cause::Error(ref e)) => Err(e.clone().into()),

--- a/src/server.rs
+++ b/src/server.rs
@@ -121,7 +121,7 @@ use crate::proto::{self, Config, Error, Prioritized};
 use crate::{FlowControl, PingPong, RecvStream, SendStream};
 
 use bytes::{Buf, Bytes};
-use http::{HeaderMap, Method, Request, Response};
+use http::{HeaderMap, Method, Request, Response, StatusCode};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -1517,7 +1517,7 @@ impl proto::Peer for Peer {
         macro_rules! malformed {
             ($($arg:tt)*) => {{
                 tracing::debug!($($arg)*);
-                return Err(Error::library_reset(stream_id, Reason::PROTOCOL_ERROR));
+                return Err(Error::library_reset_with_status_code(stream_id, Reason::PROTOCOL_ERROR, StatusCode::BAD_REQUEST));
             }}
         }
 

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -504,6 +504,9 @@ async fn recv_invalid_authority() {
         let settings = client.assert_server_handshake().await;
         assert_default_settings!(settings);
         client.send_frame(bad_headers).await;
+        client
+            .recv_frame(frames::headers(1).status(StatusCode::BAD_REQUEST).eos())
+            .await;
         client.recv_frame(frames::reset(1).protocol_error()).await;
     };
 
@@ -1290,6 +1293,9 @@ async fn reject_pseudo_protocol_on_non_connect_request() {
             )
             .await;
 
+        client
+            .recv_frame(frames::headers(1).status(StatusCode::BAD_REQUEST).eos())
+            .await;
         client.recv_frame(frames::reset(1).protocol_error()).await;
     };
 
@@ -1329,6 +1335,9 @@ async fn reject_authority_target_on_extended_connect_request() {
             )
             .await;
 
+        client
+            .recv_frame(frames::headers(1).status(StatusCode::BAD_REQUEST).eos())
+            .await;
         client.recv_frame(frames::reset(1).protocol_error()).await;
     };
 
@@ -1364,6 +1373,9 @@ async fn reject_non_authority_target_on_connect_request() {
             .send_frame(frames::headers(1).request("CONNECT", "https://bread/baguette"))
             .await;
 
+        client
+            .recv_frame(frames::headers(1).status(StatusCode::BAD_REQUEST).eos())
+            .await;
         client.recv_frame(frames::reset(1).protocol_error()).await;
     };
 

--- a/tests/h2-tests/tests/stream_states.rs
+++ b/tests/h2-tests/tests/stream_states.rs
@@ -524,6 +524,9 @@ async fn recv_next_stream_id_updated_by_malformed_headers() {
         assert_default_settings!(settings);
         // bad headers -- should error.
         client.send_frame(bad_headers).await;
+        client
+            .recv_frame(frames::headers(1).status(StatusCode::BAD_REQUEST).eos())
+            .await;
         client.recv_frame(frames::reset(1).protocol_error()).await;
         // this frame is good, but the stream id should already have been incr'd
         client


### PR DESCRIPTION
`h2` returns `RST_STREAM` frames with the `PROTOCOL_ERROR` bit set as a response to many types of errors in client requests. Many of those cases, when handled by an HTTP/1 server such as the one used in `hyper`, would result in an HTTP 400 Bad Request response returned to the client rather than a TCP reset (the HTTP/1 equivalent of a `RST_STREAM`). As a consequence, a client will observe differences in behaviour between HTTP/1 and HTTP/2: a malformed request will result in a 400 response when HTTP/1 is used whereas the same request will result in a reset stream with `h2`.

This PR makes `h2` reply a `HEADERS`+`400`+`END_STREAM` frame followed by a `RST_STREAM`+`PROTOCOL_ERROR` frame to all the `malformed!()` macro invocations in `Peer::convert_poll_message()` in `src/server.rs`.

The `Reset` variant in the `h2::proto::error::Error` Enum now contains an `Option<http::StatusCode>` value that is set by the `malformed!()` macro with a `Some(400)`. That value is propagated all the way until `h2::proto::streams::send::Send::send_reset()` where, if not `None`, a `h2::frame::headers::Headers` frame with the status code and the `END_STREAM` flag set will now be sent to the client before the `RST_STREAM` frame.

Some of the parameters passed to `send_reset()` have been grouped into a new `SendResetContext` Struct in order to avoid a `clippy::too_many_arguments` lint.

Tests where malformed requests were sent have been updated to check that an additional  `HEADERS`+`400`+`END_STREAM` frame is now received before the `RST_STREAM + PROTOCOL_ERROR` frame.

This change has been validated with  other clients like `curl`, a custom ad-hoc client written with `python3+httpx` and `varnishtest`.

Fixes #747 