### PR TITLE
set rust `edition` to `2021`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 keywords = ["http", "async", "non-blocking"]
 categories = ["asynchronous", "web-programming", "network-programming"]
 exclude = ["fixtures/**", "ci/**"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 
 [features]

--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -5,7 +5,6 @@ use tokio_rustls::TlsConnector;
 
 use tokio_rustls::rustls::{OwnedTrustAnchor, RootCertStore, ServerName};
 
-use std::convert::TryFrom;
 use std::error::Error;
 use std::net::ToSocketAddrs;
 

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -972,8 +972,6 @@ fn decoded_header_size(name: usize, value: usize) -> usize {
 
 #[cfg(test)]
 mod test {
-    use std::iter::FromIterator;
-
     use super::*;
     use crate::frame;
     use crate::hpack::{huffman, Encoder};


### PR DESCRIPTION
msrv is already newer than `2021`. However `2021` also enables the v2 resolver