### PR TITLE
Switch to trace logging for frame recieved messages

### DIFF
--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -402,7 +402,7 @@ where
                 partial,
                 bytes,
             )? {
-                tracing::debug!(?frame, "received");
+                tracing::trace!(?frame, "received");
                 return Poll::Ready(Some(Ok(frame)));
             }
         }


### PR DESCRIPTION
Enabling `DEBUG` tracing/logging when using `h2` results in a very, very large volume of messages being logged.

These feel like `trace`-level messages, not debug messages. This PR switches them to `trace` instead.

<img width="703" alt="Screenshot 2024-04-13 at 20 15 12" src="https://github.com/hyperium/h2/assets/1027207/ff4226e9-a28f-464e-a07b-cdce15fb2104">
