### PR TITLE
Switch to trace logging for frame sent messages

### DIFF
--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -210,7 +210,7 @@ where
         let span = tracing::trace_span!("FramedWrite::buffer", frame = ?item);
         let _e = span.enter();
 
-        tracing::debug!(frame = ?item, "send");
+        tracing::trace!(frame = ?item, "send");
 
         match item {
             Frame::Data(mut v) => {


### PR DESCRIPTION
This is the same justification as #765 - many hundreds of debug messages are output when making a few number of HTTP calls.

Emitting a message on every frame sent feel smuch more like it should be `trace` messages.

<img width="929" alt="Screenshot 2024-04-13 at 20 22 19" src="https://github.com/hyperium/h2/assets/1027207/64700795-f080-4d7f-98a3-bd9167c39901">

