### PR TITLE
feat: Add option in client builder to ignore content length

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -344,6 +344,9 @@ pub struct Builder {
     ///
     /// When this gets exceeded, we issue GOAWAYs.
     local_max_error_reset_streams: Option<usize>,
+
+    /// Ignore content length and only stop receiving when peer close stream
+    ignore_content_length: bool,
 }
 
 #[derive(Debug)]
@@ -654,6 +657,7 @@ impl Builder {
             settings: Default::default(),
             stream_id: 1.into(),
             local_max_error_reset_streams: Some(proto::DEFAULT_LOCAL_RESET_COUNT_MAX),
+            ignore_content_length: false,
         }
     }
 
@@ -1136,6 +1140,14 @@ impl Builder {
         self
     }
 
+    /// Setup whether to ignore the content length when receiving
+    ///
+    /// If content length is ignored, receiving only stops when server closes stream
+    pub fn ignore_content_length(&mut self, ignore: bool) -> &mut Self {
+        self.ignore_content_length = ignore;
+        self
+    }
+
     /// Sets the first stream ID to something other than 1.
     #[cfg(feature = "unstable")]
     pub fn initial_stream_id(&mut self, stream_id: u32) -> &mut Self {
@@ -1326,6 +1338,7 @@ where
                 remote_reset_stream_max: builder.pending_accept_reset_stream_max,
                 local_error_reset_streams_max: builder.local_max_error_reset_streams,
                 settings: builder.settings.clone(),
+                ignore_content_length: builder.ignore_content_length,
             },
         );
         let send_request = SendRequest {

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -83,6 +83,7 @@ pub(crate) struct Config {
     pub remote_reset_stream_max: usize,
     pub local_error_reset_streams_max: Option<usize>,
     pub settings: frame::Settings,
+    pub ignore_content_length: bool,
 }
 
 #[derive(Debug)]
@@ -123,6 +124,7 @@ where
                     .max_concurrent_streams()
                     .map(|max| max as usize),
                 local_max_error_reset_streams: config.local_error_reset_streams_max,
+                ignore_content_length: config.ignore_content_length,
             }
         }
         let streams = Streams::new(streams_config(&config));

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -72,4 +72,7 @@ pub struct Config {
     ///
     /// When this gets exceeded, we issue GOAWAYs.
     pub local_max_error_reset_streams: Option<usize>,
+
+    /// Ignore the content length header and only stop receiving when peer close stream
+    pub ignore_content_length: bool,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1385,6 +1385,7 @@ where
                                 .builder
                                 .local_max_error_reset_streams,
                             settings: self.builder.settings.clone(),
+                            ignore_content_length: false,
                         },
                     );
 


### PR DESCRIPTION
In order to support [CURLOPT_IGNORE_CONTENT_LENGTH](https://curl.se/libcurl/c/CURLOPT_IGNORE_CONTENT_LENGTH.html) for curl hyper backend.

I haven't added tests yet. (I am not sure to how many tests to add, but flipping the default and running all the tests manually was successful)