### PR TITLE
#769: Fix request pseudo-header construction for CONNECT & OPTION methods

### DIFF
--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -1252,11 +1252,11 @@ async fn extended_connect_protocol_disabled_by_default() {
         assert_eq!(settings.is_extended_connect_protocol_enabled(), None);
 
         client
-            .send_frame(
-                frames::headers(1)
-                    .request("CONNECT", "http://bread/baguette")
-                    .protocol("the-bread-protocol"),
-            )
+            .send_frame(frames::headers(1).pseudo(frame::Pseudo::request(
+                Method::CONNECT,
+                uri::Uri::from_static("http://bread/baguette"),
+                Protocol::from_static("the-bread-protocol").into(),
+            )))
             .await;
 
         client.recv_frame(frames::reset(1).protocol_error()).await;
@@ -1285,11 +1285,11 @@ async fn extended_connect_protocol_enabled_during_handshake() {
         assert_eq!(settings.is_extended_connect_protocol_enabled(), Some(true));
 
         client
-            .send_frame(
-                frames::headers(1)
-                    .request("CONNECT", "http://bread/baguette")
-                    .protocol("the-bread-protocol"),
-            )
+            .send_frame(frames::headers(1).pseudo(frame::Pseudo::request(
+                Method::CONNECT,
+                uri::Uri::from_static("http://bread/baguette"),
+                Protocol::from_static("the-bread-protocol").into(),
+            )))
             .await;
 
         client.recv_frame(frames::headers(1).response(200)).await;
@@ -1332,11 +1332,11 @@ async fn reject_pseudo_protocol_on_non_connect_request() {
         assert_eq!(settings.is_extended_connect_protocol_enabled(), Some(true));
 
         client
-            .send_frame(
-                frames::headers(1)
-                    .request("GET", "http://bread/baguette")
-                    .protocol("the-bread-protocol"),
-            )
+            .send_frame(frames::headers(1).pseudo(frame::Pseudo::request(
+                Method::GET,
+                uri::Uri::from_static("http://bread/baguette"),
+                Some(Protocol::from_static("the-bread-protocol")),
+            )))
             .await;
 
         client.recv_frame(frames::reset(1).protocol_error()).await;
@@ -1360,7 +1360,7 @@ async fn reject_pseudo_protocol_on_non_connect_request() {
 }
 
 #[tokio::test]
-async fn reject_authority_target_on_extended_connect_request() {
+async fn reject_extended_connect_request_without_scheme() {
     h2_support::trace_init!();
 
     let (io, mut client) = mock::new();
@@ -1371,11 +1371,12 @@ async fn reject_authority_target_on_extended_connect_request() {
         assert_eq!(settings.is_extended_connect_protocol_enabled(), Some(true));
 
         client
-            .send_frame(
-                frames::headers(1)
-                    .request("CONNECT", "bread:80")
-                    .protocol("the-bread-protocol"),
-            )
+            .send_frame(frames::headers(1).pseudo(frame::Pseudo {
+                method: Method::CONNECT.into(),
+                path: util::byte_str("/").into(),
+                protocol: Protocol::from("the-bread-protocol").into(),
+                ..Default::default()
+            }))
             .await;
 
         client.recv_frame(frames::reset(1).protocol_error()).await;
@@ -1399,7 +1400,7 @@ async fn reject_authority_target_on_extended_connect_request() {
 }
 
 #[tokio::test]
-async fn reject_non_authority_target_on_connect_request() {
+async fn reject_extended_connect_request_without_path() {
     h2_support::trace_init!();
 
     let (io, mut client) = mock::new();
@@ -1410,7 +1411,12 @@ async fn reject_non_authority_target_on_connect_request() {
         assert_eq!(settings.is_extended_connect_protocol_enabled(), Some(true));
 
         client
-            .send_frame(frames::headers(1).request("CONNECT", "https://bread/baguette"))
+            .send_frame(frames::headers(1).pseudo(frame::Pseudo {
+                method: Method::CONNECT.into(),
+                scheme: util::byte_str("https").into(),
+                protocol: Protocol::from("the-bread-protocol").into(),
+                ..Default::default()
+            }))
             .await;
 
         client.recv_frame(frames::reset(1).protocol_error()).await;


### PR DESCRIPTION
`CONNECT` & `OPTIONS` request has special requirements regarding :path & :scheme pseudo-header which were not met.

Construction of pseudo-header was fixed to not include `:path` & `:scheme` fields for `CONNECT` method. Empty `:path` field for `OPTIONS` requests now translates to `'*'` value sent in `:path` field.

`CONNECT` request changes were tested against server based on hyper 1.2.