### PR TITLE
examples: update to rustls 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ serde_json = "1.0.0"
 # Examples
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
 env_logger = { version = "0.10", default-features = false }
-tokio-rustls = "0.24"
-webpki-roots = "0.25"
+tokio-rustls = "0.26"
+webpki-roots = "0.26"
 
 [package.metadata.docs.rs]
 features = ["stream"]


### PR DESCRIPTION
Updates `rustls` crates dependencies used in the examples.