### PR TITLE
feat: expose current max {recv,send} stream count

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -548,6 +548,16 @@ where
     pub fn is_extended_connect_protocol_enabled(&self) -> bool {
         self.inner.is_extended_connect_protocol_enabled()
     }
+
+    /// Returns the current max send streams
+    pub fn current_max_send_streams(&self) -> usize {
+        self.inner.current_max_send_streams()
+    }
+
+    /// Returns the current max recv streams
+    pub fn current_max_recv_streams(&self) -> usize {
+        self.inner.current_max_recv_streams()
+    }
 }
 
 impl<B> fmt::Debug for SendRequest<B>

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -320,6 +320,16 @@ where
             .send
             .is_extended_connect_protocol_enabled()
     }
+
+    pub fn current_max_send_streams(&self) -> usize {
+        let me = self.inner.lock().unwrap();
+        me.counts.max_send_streams()
+    }
+
+    pub fn current_max_recv_streams(&self) -> usize {
+        let me = self.inner.lock().unwrap();
+        me.counts.max_recv_streams()
+    }
 }
 
 impl<B> DynStreams<'_, B> {


### PR DESCRIPTION
Addresses https://github.com/hyperium/hyper/issues/3623

This PR exposes the max count of recv and send streams for h2.