### PR TITLE
chore: use lints.rust.unexpected_cfgs in manifest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,20 +61,6 @@ jobs:
         run: ./ci/h2spec.sh
         if: matrix.rust == 'stable'
 
-  unexpected-cfgs:
-    runs-on: ubuntu-latest
-    needs: [style]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all-features
-        env:
-          RUSTFLAGS: >-
-            -D unexpected_cfgs
-            --cfg h2_internal_check_unexpected_cfgs
-            --check-cfg=cfg(h2_internal_check_unexpected_cfgs,fuzzing)
-
   #clippy_check:
   #  runs-on: ubuntu-latest
   #  steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,9 @@ env_logger = { version = "0.10", default-features = false }
 tokio-rustls = "0.26"
 webpki-roots = "0.26"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)"] }
+
 [package.metadata.docs.rs]
 features = ["stream"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@
     clippy::undocumented_unsafe_blocks
 )]
 #![allow(clippy::type_complexity, clippy::manual_range_contains)]
-#![cfg_attr(not(h2_internal_check_unexpected_cfgs), allow(unexpected_cfgs))]
 #![cfg_attr(test, deny(warnings))]
 
 macro_rules! proto_err {


### PR DESCRIPTION
Uses `lints.rust.unexpected_cfgs` in the manifest.