### PR TITLE
chore(ci): use tokio 1.38.1 in MSRV check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,6 +102,11 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
 
+      - name: Make sure tokio 1.38.1 is used for MSRV
+        run: |
+          cargo update
+          cargo update --package tokio --precise 1.38.1
+
       - run: cargo check -p h2
 
   minimal-versions:


### PR DESCRIPTION
Uses tokio 1.38.1 in the MSRV checking as tokio 1.39 bumps its MSRV to 1.70.