### PR TITLE
chore: flatten unnecessary nested if expression

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -564,12 +564,10 @@ impl Pseudo {
 
             let path = if !path.is_empty() {
                 path
+            } else if method == Method::OPTIONS {
+                BytesStr::from_static("*")
             } else {
-                if method == Method::OPTIONS {
-                    BytesStr::from_static("*")
-                } else {
-                    BytesStr::from_static("/")
-                }
+                BytesStr::from_static("/")
             };
 
             (parts.scheme, Some(path))


### PR DESCRIPTION
Flattens unnecessary nested if expression.