### PR TITLE
chore: replace legacy numeric constant with corresponding one

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -148,7 +148,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use std::usize;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tracing::Instrument;
 
@@ -1070,7 +1069,7 @@ impl Builder {
     ///
     /// This function panics if `max` is larger than `u32::MAX`.
     pub fn max_send_buffer_size(&mut self, max: usize) -> &mut Self {
-        assert!(max <= std::u32::MAX as usize);
+        assert!(max <= u32::MAX as usize);
         self.max_send_buffer_size = max;
         self
     }

--- a/src/frame/stream_id.rs
+++ b/src/frame/stream_id.rs
@@ -1,5 +1,3 @@
-use std::u32;
-
 /// A stream identifier, as described in [Section 5.1.1] of RFC 7540.
 ///
 /// Streams are identified with an unsigned 31-bit integer. Streams

--- a/src/hpack/table.rs
+++ b/src/hpack/table.rs
@@ -6,7 +6,7 @@ use http::method::Method;
 
 use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
-use std::{cmp, mem, usize};
+use std::{cmp, mem};
 
 /// HPACK encoder table
 #[derive(Debug)]

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use std::usize;
-
 #[derive(Debug)]
 pub(super) struct Counts {
     /// Acting as a client or server. This allows us to track which values to

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -2,7 +2,6 @@ use super::*;
 
 use std::task::{Context, Waker};
 use std::time::Instant;
-use std::usize;
 
 /// Tracks Stream related state
 ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -963,7 +963,7 @@ impl Builder {
     ///
     /// This function panics if `max` is larger than `u32::MAX`.
     pub fn max_send_buffer_size(&mut self, max: usize) -> &mut Self {
-        assert!(max <= std::u32::MAX as usize);
+        assert!(max <= u32::MAX as usize);
         self.max_send_buffer_size = max;
         self
     }


### PR DESCRIPTION
Replaces legacy numeric constants with corresponding one.