### PR TITLE
chore: remove unnecessary type converting

### DIFF
--- a/src/hpack/encoder.rs
+++ b/src/hpack/encoder.rs
@@ -695,7 +695,7 @@ mod test {
 
     fn encode(e: &mut Encoder, hdrs: Vec<Header<Option<HeaderName>>>) -> BytesMut {
         let mut dst = BytesMut::with_capacity(1024);
-        e.encode(&mut hdrs.into_iter(), &mut dst);
+        e.encode(hdrs, &mut dst);
         dst
     }
 

--- a/src/hpack/test/fixture.rs
+++ b/src/hpack/test/fixture.rs
@@ -107,7 +107,7 @@ fn test_story(story: Value) {
                 })
                 .collect();
 
-            encoder.encode(&mut input.clone().into_iter(), &mut buf);
+            encoder.encode(input.clone(), &mut buf);
 
             decoder
                 .decode(&mut Cursor::new(&mut buf), |e| {


### PR DESCRIPTION
Removes unnecessary type converting.