### PR TITLE
streams: notify recv task upon reset

### DIFF
--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -207,6 +207,9 @@ impl Send {
 
         // Transition the state to reset no matter what.
         stream.state.set_reset(stream_id, reason, initiator);
+        // Notify the recv task if it's waiting, because it'll
+        // want to hear about the reset.
+        stream.notify_recv();
 
         // If closed AND the send queue is flushed, then the stream cannot be
         // reset explicitly, either. Implicit resets can still be queued.


### PR DESCRIPTION
Before this change, the transition to the reset state wouldn't notify tasks that were waiting for a response. The motivating case for this patch involved a large header being sent by the server. This case was mostly tested by an existing test, but because that test did not spawn separate tasks and kept polling the futures through its use of `conn.drive`, the missing notify was masked.

Informs https://github.com/hyperium/hyper/issues/3724.