### PR TITLE
fix: send PROTOCOL_ERROR instead of REFUSED_STREAM for oversized headers

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -719,16 +719,16 @@ impl Recv {
             // > that it cannot process.
             //
             // So, if peer is a server, we'll send a 431. In either case,
-            // an error is recorded, which will send a REFUSED_STREAM,
+            // an error is recorded, which will send a PROTOCOL_ERROR,
             // since we don't want any of the data frames either.
             tracing::debug!(
-                "stream error REFUSED_STREAM -- recv_push_promise: \
+                "stream error PROTOCOL_ERROR -- recv_push_promise: \
                  headers frame is over size; promised_id={:?};",
                 frame.promised_id(),
             );
             return Err(Error::library_reset(
                 frame.promised_id(),
-                Reason::REFUSED_STREAM,
+                Reason::PROTOCOL_ERROR,
             ));
         }
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -504,7 +504,7 @@ impl Inner {
 
                             actions.send.schedule_implicit_reset(
                                 stream,
-                                Reason::REFUSED_STREAM,
+                                Reason::PROTOCOL_ERROR,
                                 counts,
                                 &mut actions.task);
 
@@ -512,7 +512,7 @@ impl Inner {
 
                             Ok(())
                         } else {
-                            Err(Error::library_reset(stream.id, Reason::REFUSED_STREAM))
+                            Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR))
                         }
                     },
                     Err(RecvHeaderBlockError::State(err)) => Err(err),

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -844,7 +844,7 @@ async fn recv_too_big_headers() {
         srv.send_frame(frames::headers(3).response(200)).await;
         // no reset for 1, since it's closed anyway
         // but reset for 3, since server hasn't closed stream
-        srv.recv_frame(frames::reset(3).refused()).await;
+        srv.recv_frame(frames::reset(3).protocol_error()).await;
         idle_ms(10).await;
     };
 
@@ -865,7 +865,7 @@ async fn recv_too_big_headers() {
         // waiting for a response.
         let req1 = tokio::spawn(async move {
             let err = req1.expect("send_request").0.await.expect_err("response1");
-            assert_eq!(err.reason(), Some(Reason::REFUSED_STREAM));
+            assert_eq!(err.reason(), Some(Reason::PROTOCOL_ERROR));
         });
 
         let request = Request::builder()
@@ -876,7 +876,7 @@ async fn recv_too_big_headers() {
         let req2 = client.send_request(request, true);
         let req2 = tokio::spawn(async move {
             let err = req2.expect("send_request").0.await.expect_err("response2");
-            assert_eq!(err.reason(), Some(Reason::REFUSED_STREAM));
+            assert_eq!(err.reason(), Some(Reason::PROTOCOL_ERROR));
         });
 
         let conn = tokio::spawn(async move {

--- a/tests/h2-tests/tests/push_promise.rs
+++ b/tests/h2-tests/tests/push_promise.rs
@@ -249,7 +249,7 @@ async fn recv_push_promise_over_max_header_list_size() {
             frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
         )
         .await;
-        srv.recv_frame(frames::reset(2).refused()).await;
+        srv.recv_frame(frames::reset(2).protocol_error()).await;
         srv.send_frame(frames::headers(1).response(200).eos()).await;
         idle_ms(10).await;
     };
@@ -272,7 +272,7 @@ async fn recv_push_promise_over_max_header_list_size() {
                 .0
                 .await
                 .expect_err("response");
-            assert_eq!(err.reason(), Some(Reason::REFUSED_STREAM));
+            assert_eq!(err.reason(), Some(Reason::PROTOCOL_ERROR));
         };
 
         conn.drive(req).await;

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -866,7 +866,7 @@ async fn too_big_headers_sends_reset_after_431_if_not_eos() {
         client
             .recv_frame(frames::headers(1).response(431).eos())
             .await;
-        client.recv_frame(frames::reset(1).refused()).await;
+        client.recv_frame(frames::reset(1).protocol_error()).await;
     };
 
     let srv = async move {


### PR DESCRIPTION
Noticed during #791 

cc @ajwerner 