### PR TITLE
chore(ci): use tokio-util 0.7.11 in MSRV check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,10 +88,10 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
 
-      - name: Make sure tokio 1.38.1 is used for MSRV
+      - name: Pin some dependencies for MSRV
         run: |
-          cargo update
           cargo update --package tokio --precise 1.38.1
+          cargo update --package tokio-util --precise 0.7.11
 
       - run: cargo check -p h2
 


### PR DESCRIPTION
Uses `tokio-util` 0.7.11 in MSRV check.