### PR TITLE
fix: notify_recv after send_reset() in reset_on_recv_stream_err(), to ensure local stream is released properly

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1549,6 +1549,9 @@ impl Actions {
                 // Reset the stream.
                 self.send
                     .send_reset(reason, initiator, buffer, stream, counts, &mut self.task);
+                self.recv.enqueue_reset_expiration(stream, counts);
+                // if a RecvStream is parked, ensure it's notified
+                stream.notify_recv();
                 Ok(())
             } else {
                 tracing::warn!(


### PR DESCRIPTION
Similar to what have been done in fn send_reset(), we should notify RecvStream that is parked after send_reset().

To fix an issue where if RecvStream is parked, server doesn't release the StreamRef properly after reset_on_recv_stream_err() and as a result Stream is never removed.