### PR TITLE
Fix RecvStream::is_end_stream(): return true only when END_STREAM is received

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -557,7 +557,7 @@ impl Recv {
     }
 
     pub fn is_end_stream(&self, stream: &store::Ptr) -> bool {
-        if !stream.state.is_recv_closed() {
+        if !stream.state.is_recv_end_stream() {
             return false;
         }
 

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -409,15 +409,13 @@ impl State {
         )
     }
 
-    pub fn is_closed(&self) -> bool {
-        matches!(self.inner, Closed(_))
+    pub fn is_recv_end_stream(&self) -> bool {
+        // In either case END_STREAM has been received
+        matches!(self.inner, Closed(Cause::EndStream) | HalfClosedRemote(..))
     }
 
-    pub fn is_recv_closed(&self) -> bool {
-        matches!(
-            self.inner,
-            Closed(..) | HalfClosedRemote(..) | ReservedLocal
-        )
+    pub fn is_closed(&self) -> bool {
+        matches!(self.inner, Closed(_))
     }
 
     pub fn is_send_closed(&self) -> bool {

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -1339,7 +1339,7 @@ async fn client_decrease_initial_window_size() {
         conn.drive(async {
             data(&mut body5, "body5 data2").await;
             data(&mut body5, "body5 data3").await;
-            assert!(body3.is_end_stream());
+            assert!(!body3.is_end_stream());
         })
         .await;
 


### PR DESCRIPTION
Before this change, it returned true on other types of disconnection as well.

Fixes #806

Removed unused `is_recv_closed()`.

