### PR TITLE
fix: notify_recv after send_reset() in reset_on_recv_stream_err() to …

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1576,6 +1576,9 @@ impl Actions {
                 // Reset the stream.
                 self.send
                     .send_reset(reason, initiator, buffer, stream, counts, &mut self.task);
+                self.recv.enqueue_reset_expiration(stream, counts);
+                // if a RecvStream is parked, ensure it's notified
+                stream.notify_recv();
                 Ok(())
             } else {
                 tracing::warn!(


### PR DESCRIPTION
…ensure local stream is released properly (#816)

Similar to what have been done in fn send_reset<B>(), we should notify RecvStream that is parked after send_reset().