### PR TITLE
tone down debugs from codec modules

### DIFF
--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -401,7 +401,7 @@ where
                 partial,
                 bytes,
             )? {
-                tracing::debug!(?frame, "received");
+                tracing::trace!(?frame, "received");
                 return Poll::Ready(Some(Ok(frame)));
             }
         }

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -210,7 +210,7 @@ where
         let span = tracing::trace_span!("FramedWrite::buffer", frame = ?item);
         let _e = span.enter();
 
-        tracing::debug!(frame = ?item, "send");
+        tracing::trace!(frame = ?item, "send");
 
         match item {
             Frame::Data(mut v) => {


### PR DESCRIPTION
Some logging frameworks don't really tolerate module level configurations well. I have quite a broad project but h2 seems to be the only dependency that has such chatty debug settings.

Would you be open-minded to removing all `debug!` in favor of `trace!`?