### PR TITLE
vis: make hpack mod public in 'unstable' feature set

### DIFF
--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -117,7 +117,7 @@ impl<T> Data<T> {
 }
 
 impl Data<Bytes> {
-    pub(crate) fn load(head: Head, mut payload: Bytes) -> Result<Self, Error> {
+    pub fn load(head: Head, mut payload: Bytes) -> Result<Self, Error> {
         let flags = DataFlags::load(head.flag());
 
         // The stream identifier must not be zero

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -254,7 +254,7 @@ impl Headers {
         &mut self.header_block.pseudo
     }
 
-    pub(crate) fn pseudo(&self) -> &Pseudo {
+    pub fn pseudo(&self) -> &Pseudo {
         &self.header_block.pseudo
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,13 @@ macro_rules! ready {
 #[cfg_attr(feature = "unstable", allow(missing_docs))]
 mod codec;
 mod error;
+
+#[cfg(not(feature = "unstable"))]
 mod hpack;
+
+#[cfg(feature = "unstable")]
+#[allow(missing_docs)]
+pub mod hpack;
 
 #[cfg(not(feature = "unstable"))]
 mod proto;


### PR DESCRIPTION
Grant h2 users access to hpack module when using the 'unstable' feature set.

Further, grant h2 users access to frame::Data when using the 'unstable' feature set. Other frame types have similar
visibility.