### PR TITLE
Fix window size decrement of send-closed streams

### DIFF
--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -466,6 +466,16 @@ impl Send {
                     store.try_for_each(|mut stream| {
                         let stream = &mut *stream;
 
+                        if stream.state.is_send_closed() && stream.buffered_send_data == 0 {
+                            tracing::trace!(
+                                "skipping send-closed stream; id={:?}; flow={:?}",
+                                stream.id,
+                                stream.send_flow
+                            );
+
+                            return Ok(());
+                        }
+
                         tracing::trace!(
                             "decrementing stream window; id={:?}; decr={}; flow={:?}",
                             stream.id,

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -1859,7 +1859,7 @@ async fn poll_capacity_wakeup_after_window_update() {
 }
 
 #[tokio::test]
-async fn window_size_decremented_past_zero() {
+async fn window_size_does_not_underflow() {
     h2_support::trace_init!();
     let (io, mut client) = mock::new();
 
@@ -1891,9 +1891,7 @@ async fn window_size_decremented_past_zero() {
         let builder = server::Builder::new();
         let mut srv = builder.handshake::<_, Bytes>(io).await.expect("handshake");
 
-        // just keep it open
-        let res = poll_fn(move |cx| srv.poll_closed(cx)).await;
-        tracing::debug!("{:?}", res);
+        poll_fn(move |cx| srv.poll_closed(cx)).await.unwrap();
     };
 
     join(client, srv).await;


### PR DESCRIPTION
Send-closed streams should be skipped when decreasing window size, as they are skipped when increasing it.