### PR TITLE
chore: Fix msrv ci build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,6 +93,7 @@ jobs:
           cargo update --package tokio --precise 1.38.1
           cargo update --package tokio-util --precise 0.7.11
           cargo update --package hashbrown --precise 0.15.0
+          cargo update --package once_cell --precise 1.20.3
 
 
       - run: cargo check -p h2


### PR DESCRIPTION
This just pins our CI to the latest working version of `once_cell`.