### PR TITLE
feat: not return UnexpectedEof when server drops without close_notify

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -482,7 +482,12 @@ where
                 // without error
                 //
                 // See https://github.com/hyperium/hyper/issues/3427
-                if self.streams.is_buffer_empty() && matches!(kind, io::ErrorKind::UnexpectedEof) {
+                if self.streams.is_buffer_empty()
+                    && matches!(kind, io::ErrorKind::UnexpectedEof)
+                    && (self.streams.is_server()
+                        || self.error.as_ref().map(|f| f.reason() == Reason::NO_ERROR)
+                            == Some(true))
+                {
                     *self.state = State::Closed(Reason::NO_ERROR, Initiator::Library);
                     return Ok(());
                 }

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -482,10 +482,7 @@ where
                 // without error
                 //
                 // See https://github.com/hyperium/hyper/issues/3427
-                if self.streams.is_server()
-                    && self.streams.is_buffer_empty()
-                    && matches!(kind, io::ErrorKind::UnexpectedEof)
-                {
+                if self.streams.is_buffer_empty() && matches!(kind, io::ErrorKind::UnexpectedEof) {
                     *self.state = State::Closed(Reason::NO_ERROR, Initiator::Library);
                     return Ok(());
                 }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -337,6 +337,10 @@ impl<B> DynStreams<'_, B> {
         self.send_buffer.is_empty()
     }
 
+    pub fn is_server(&self) -> bool {
+        self.peer.is_server()
+    }
+
     pub fn recv_headers(&mut self, frame: frame::Headers) -> Result<(), Error> {
         let mut me = self.inner.lock().unwrap();
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -337,10 +337,6 @@ impl<B> DynStreams<'_, B> {
         self.send_buffer.is_empty()
     }
 
-    pub fn is_server(&self) -> bool {
-        self.peer.is_server()
-    }
-
     pub fn recv_headers(&mut self, frame: frame::Headers) -> Result<(), Error> {
         let mut me = self.inner.lock().unwrap();
 

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -2,9 +2,9 @@ use futures::future::{ready, Either};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use h2_support::prelude::*;
+use std::panic;
 use std::pin::Pin;
 use std::task::Context;
-use std::{io, panic};
 
 #[tokio::test]
 async fn handshake() {
@@ -1914,7 +1914,7 @@ async fn receive_settings_frame_twice_with_second_one_non_empty() {
 }
 
 #[tokio::test]
-async fn server_drop_connection_unexpectedly_return_unexpected_eof_err() {
+async fn server_drop_connection_without_close_notify() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 
@@ -1944,11 +1944,7 @@ async fn server_drop_connection_unexpectedly_return_unexpected_eof_err() {
                 .await
                 .expect("request");
         });
-        let err = h2.await.expect_err("should receive UnexpectedEof");
-        assert_eq!(
-            err.get_io().expect("should be UnexpectedEof").kind(),
-            io::ErrorKind::UnexpectedEof,
-        );
+        let _ = h2.await.unwrap();
     };
     join(srv, h2).await;
 }


### PR DESCRIPTION
This PR extends the change made in #743 to include client connections that are closed by servers that drop connections without sending `close_notify` when the client has nothing to send.

This is motivated by server H2 implementations  sending `go_away` frames and then closing the connections without a `close_notify` in longer lived applications (specifically DoH).

I originally reported this as an issue in the `hickory-dns` (https://github.com/hickory-dns/hickory-dns/issues/3064) but after discussion with @djc the real underlying issue seems to be the handling of this type of intentional connections close within the H2 client.
