### PR TITLE
refactor: reduce noise in fmt::Debug outputs

### DIFF
--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -73,3 +73,56 @@ pub struct Config {
     /// When this gets exceeded, we issue GOAWAYs.
     pub local_max_error_reset_streams: Option<usize>,
 }
+
+trait DebugStructExt<'a, 'b> {
+    // h2_ prefixes to protect against possible future name collisions
+    fn h2_field_if(&mut self, name: &str, val: &bool) -> &mut std::fmt::DebugStruct<'a, 'b>;
+
+    fn h2_field_if_then<T: std::fmt::Debug>(
+        &mut self,
+        name: &str,
+        cond: bool,
+        val: &T,
+    ) -> &mut std::fmt::DebugStruct<'a, 'b>;
+
+    fn h2_field_some<T: std::fmt::Debug>(
+        &mut self,
+        name: &str,
+        val: &Option<T>,
+    ) -> &mut std::fmt::DebugStruct<'a, 'b>;
+}
+
+impl<'a, 'b> DebugStructExt<'a, 'b> for std::fmt::DebugStruct<'a, 'b> {
+    fn h2_field_if(&mut self, name: &str, val: &bool) -> &mut std::fmt::DebugStruct<'a, 'b> {
+        if *val {
+            self.field(name, val)
+        } else {
+            self
+        }
+    }
+
+    fn h2_field_if_then<T: std::fmt::Debug>(
+        &mut self,
+        name: &str,
+        cond: bool,
+        val: &T,
+    ) -> &mut std::fmt::DebugStruct<'a, 'b> {
+        if cond {
+            self.field(name, val)
+        } else {
+            self
+        }
+    }
+
+    fn h2_field_some<T: std::fmt::Debug>(
+        &mut self,
+        name: &str,
+        val: &Option<T>,
+    ) -> &mut std::fmt::DebugStruct<'a, 'b> {
+        if val.is_some() {
+            self.field(name, val)
+        } else {
+            self
+        }
+    }
+}

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io;
 
 use crate::codec::UserError;
@@ -47,7 +48,7 @@ use self::Peer::*;
 ///        ES: END_STREAM flag
 ///        R:  RST_STREAM frame
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct State {
     inner: Inner,
 }
@@ -463,5 +464,12 @@ impl State {
 impl Default for State {
     fn default() -> State {
         State { inner: Inner::Idle }
+    }
+}
+
+// remove some noise for debug output
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
     }
 }

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -34,7 +34,6 @@ pub(crate) struct Key {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SlabIndex(u32);
 
-#[derive(Debug)]
 pub(super) struct Queue<N> {
     indices: Option<store::Indices>,
     _p: PhantomData<N>,
@@ -375,6 +374,15 @@ where
         }
 
         None
+    }
+}
+
+impl<N> fmt::Debug for Queue<N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Queue")
+            .field("indices", &self.indices)
+            // skip phantom data
+            .finish()
     }
 }
 

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -398,35 +398,47 @@ impl fmt::Debug for Stream {
             .field("state", &self.state)
             .field("is_counted", &self.is_counted)
             .field("ref_count", &self.ref_count)
-            .field("next_pending_send", &self.next_pending_send)
-            .field("is_pending_send", &self.is_pending_send)
+            .h2_field_some("next_pending_send", &self.next_pending_send)
+            .h2_field_if("is_pending_send", &self.is_pending_send)
             .field("send_flow", &self.send_flow)
             .field("requested_send_capacity", &self.requested_send_capacity)
             .field("buffered_send_data", &self.buffered_send_data)
-            .field("send_task", &self.send_task.as_ref().map(|_| ()))
-            .field("pending_send", &self.pending_send)
-            .field(
+            .h2_field_some("send_task", &self.send_task.as_ref().map(|_| ()))
+            .h2_field_if_then(
+                "pending_send",
+                !self.pending_send.is_empty(),
+                &self.pending_send,
+            )
+            .h2_field_some(
                 "next_pending_send_capacity",
                 &self.next_pending_send_capacity,
             )
-            .field("is_pending_send_capacity", &self.is_pending_send_capacity)
-            .field("send_capacity_inc", &self.send_capacity_inc)
-            .field("next_open", &self.next_open)
-            .field("is_pending_open", &self.is_pending_open)
-            .field("is_pending_push", &self.is_pending_push)
-            .field("next_pending_accept", &self.next_pending_accept)
-            .field("is_pending_accept", &self.is_pending_accept)
+            .h2_field_if("is_pending_send_capacity", &self.is_pending_send_capacity)
+            .h2_field_if("send_capacity_inc", &self.send_capacity_inc)
+            .h2_field_some("next_open", &self.next_open)
+            .h2_field_if("is_pending_open", &self.is_pending_open)
+            .h2_field_if("is_pending_push", &self.is_pending_push)
+            .h2_field_some("next_pending_accept", &self.next_pending_accept)
+            .h2_field_if("is_pending_accept", &self.is_pending_accept)
             .field("recv_flow", &self.recv_flow)
             .field("in_flight_recv_data", &self.in_flight_recv_data)
-            .field("next_window_update", &self.next_window_update)
-            .field("is_pending_window_update", &self.is_pending_window_update)
-            .field("reset_at", &self.reset_at)
-            .field("next_reset_expire", &self.next_reset_expire)
-            .field("pending_recv", &self.pending_recv)
-            .field("is_recv", &self.is_recv)
-            .field("recv_task", &self.recv_task.as_ref().map(|_| ()))
-            .field("push_task", &self.push_task.as_ref().map(|_| ()))
-            .field("pending_push_promises", &self.pending_push_promises)
+            .h2_field_some("next_window_update", &self.next_window_update)
+            .h2_field_if("is_pending_window_update", &self.is_pending_window_update)
+            .h2_field_some("reset_at", &self.reset_at)
+            .h2_field_some("next_reset_expire", &self.next_reset_expire)
+            .h2_field_if_then(
+                "pending_recv",
+                !self.pending_recv.is_empty(),
+                &self.pending_recv,
+            )
+            .h2_field_if("is_recv", &self.is_recv)
+            .h2_field_some("recv_task", &self.recv_task.as_ref().map(|_| ()))
+            .h2_field_some("push_task", &self.push_task.as_ref().map(|_| ()))
+            .h2_field_if_then(
+                "pending_push_promises",
+                !self.pending_push_promises.is_empty(),
+                &self.pending_push_promises,
+            )
             .field("content_length", &self.content_length)
             .finish()
     }


### PR DESCRIPTION
I was doing some debugging again, and again reminded that some of these things just print way too much worthless noise. Such as:

```
h2::proto::streams::streams drop_stream_ref; stream=Stream {
	id: StreamId(187),
	state: State { inner: Closed(Error(Reset(StreamId(187), REFUSED_STREAM, Remote))) },
	is_counted: false,
	ref_count: 1,
	next_pending_send: None,
	is_pending_send: false,
	send_flow: FlowControl { window_size: Window(65535), available: Window(0) },
	requested_send_capacity: 0,
	buffered_send_data: 0,
	send_task: None,
	pending_send: Deque { indices: None },
	next_pending_send_capacity: Some(Key { index: SlabIndex(94), stream_id: StreamId(189) }),
	is_pending_send_capacity: true,
	send_capacity_inc: false,
	next_open: None,
	is_pending_open: false,
	is_pending_push: false,
	next_pending_accept: None,
	is_pending_accept: false,
	recv_flow: FlowControl { window_size: Window(65535), available: Window(65535) },
	in_flight_recv_data: 0,
	next_window_update: None,
	is_pending_window_update: false,
	reset_at: None,
	next_reset_expire: None,
	pending_recv: Deque { indices: None },
	is_recv: true,
	recv_task: None,
	push_task: None,
	pending_push_promises: Queue { indices: None, _p: PhantomData<h2::proto::streams::stream::NextAccept> },
	content_length: Omitted
}
```

(I indented that to help myself in this PR)

The most interesting changes here are that on the `Stream` type, many fields are only printed if they are in an interesting state. Such as if the boolean is true, or the option is Some. This does mean that if you care about the field always being there, this will be different. But I think it's a significant improvement.

This is the revised output:

```
h2::proto::streams::streams drop_stream_ref; stream=Stream {
	id: StreamId(187),
	state: State { inner: Closed(Error(Reset(StreamId(187), REFUSED_STREAM, Remote))) },
	is_counted: false,
	ref_count: 1,
	send_flow: FlowControl { window_size: Window(65535), available: Window(0) },
	requested_send_capacity: 0,
	buffered_send_data: 0,
	next_pending_send_capacity: Some(Key { index: SlabIndex(94), stream_id: StreamId(189) }),
	is_pending_send_capacity: true,
	recv_flow: FlowControl { window_size: Window(65535), available: Window(65535) },
	in_flight_recv_data: 0,
	is_recv: true,
	content_length: Omitted
}
```