### PR TITLE
Implement HTTP/2 informational responses (1xx) support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1485,6 +1485,22 @@ impl ResponseFuture {
     pub fn stream_id(&self) -> crate::StreamId {
         crate::StreamId::from_internal(self.inner.stream_id())
     }
+
+    /// Polls for informational responses (1xx status codes).
+    ///
+    /// This method should be called before polling the main response future
+    /// to check for any informational responses that have been received.
+    ///
+    /// Returns `Poll::Ready(Some(response))` if an informational response is available,
+    /// `Poll::Ready(None)` if no more informational responses are expected,
+    /// or `Poll::Pending` if no informational response is currently available.
+    pub fn poll_informational(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Response<()>, crate::Error>>> {
+        self.inner.poll_informational(cx).map_err(Into::into)
+    }
+
     /// Returns a stream of PushPromises
     ///
     /// # Panics

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -49,6 +49,9 @@ pub enum UserError {
 
     /// Tries to send push promise to peer who has disabled server push
     PeerDisabledServerPush,
+
+    /// Invalid status code for informational response (must be 1xx)
+    InvalidInformationalStatusCode,
 }
 
 // ===== impl SendError =====
@@ -97,6 +100,7 @@ impl fmt::Display for UserError {
             SendPingWhilePending => "send_ping before received previous pong",
             SendSettingsWhilePending => "sending SETTINGS before received previous ACK",
             PeerDisabledServerPush => "sending PUSH_PROMISE to peer who disabled server push",
+            InvalidInformationalStatusCode => "invalid informational status code",
         })
     }
 }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1150,6 +1150,43 @@ impl<B> StreamRef<B> {
         }
     }
 
+    pub fn send_informational_headers(&mut self, frame: frame::Headers) -> Result<(), UserError> {
+        let mut me = self.opaque.inner.lock().unwrap();
+        let me = &mut *me;
+
+        let stream = me.store.resolve(self.opaque.key);
+        let actions = &mut me.actions;
+        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
+        let send_buffer = &mut *send_buffer;
+
+        me.counts.transition(stream, |counts, stream| {
+            // For informational responses (1xx), we need to send headers without
+            // changing the stream state. This allows multiple informational responses
+            // to be sent before the final response.
+
+            // Validate that this is actually an informational response
+            debug_assert!(
+                frame.is_informational(),
+                "Frame must be informational after conversion from informational response"
+            );
+
+            // Ensure the frame is not marked as end_stream for informational responses
+            if frame.is_end_stream() {
+                return Err(UserError::UnexpectedFrameType);
+            }
+
+            // Send the interim informational headers directly to the buffer without state changes
+            // This bypasses the normal send_headers flow that would transition the stream state
+            actions.send.send_interim_informational_headers(
+                frame,
+                send_buffer,
+                stream,
+                counts,
+                &mut actions.task,
+            )
+        })
+    }
+
     pub fn send_response(
         &mut self,
         mut response: Response<()>,
@@ -1333,6 +1370,19 @@ impl OpaqueStreamRef {
         let mut stream = me.store.resolve(self.key);
 
         me.actions.recv.poll_response(cx, &mut stream)
+    }
+
+    /// Called by a client to check for informational responses (1xx status codes)
+    pub fn poll_informational(
+        &mut self,
+        cx: &Context,
+    ) -> Poll<Option<Result<Response<()>, proto::Error>>> {
+        let mut me = self.inner.lock().unwrap();
+        let me = &mut *me;
+
+        let mut stream = me.store.resolve(self.key);
+
+        me.actions.recv.poll_informational(cx, &mut stream)
     }
     /// Called by a client to check for a pushed request.
     pub fn poll_pushed(

--- a/tests/h2-tests/tests/informational_responses.rs
+++ b/tests/h2-tests/tests/informational_responses.rs
@@ -1,0 +1,387 @@
+#![deny(warnings)]
+
+use futures::{future::poll_fn, StreamExt};
+use h2_support::prelude::*;
+use http::{Response, StatusCode};
+
+#[tokio::test]
+async fn send_100_continue() {
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_default_settings!(settings);
+
+        // Send a POST request
+        client
+            .send_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+
+        // Expect 100 Continue response first
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::CONTINUE))
+            .await;
+
+        // Send request body after receiving 100 Continue
+        client
+            .send_frame(frames::data(1, &b"request body"[..]).eos())
+            .await;
+
+        // Expect final response
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::OK).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+
+        assert_eq!(req.method(), &http::Method::POST);
+
+        // Send 100 Continue informational response
+        let continue_response = Response::builder()
+            .status(StatusCode::CONTINUE)
+            .body(())
+            .unwrap();
+        stream.send_informational(continue_response).unwrap();
+
+        // Send final response
+        let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
+        stream.send_response(rsp, true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
+async fn send_103_early_hints() {
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_default_settings!(settings);
+
+        // Send a GET request
+        client
+            .send_frame(
+                frames::headers(1)
+                    .request("GET", "https://example.com/")
+                    .eos(),
+            )
+            .await;
+
+        // Expect 103 Early Hints response first
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::EARLY_HINTS).field(
+                "link",
+                "</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script",
+            ))
+            .await;
+
+        // Expect final response
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::OK).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+
+        assert_eq!(req.method(), &http::Method::GET);
+
+        // Send 103 Early Hints informational response
+        let early_hints_response = Response::builder()
+            .status(StatusCode::EARLY_HINTS)
+            .header(
+                "link",
+                "</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script",
+            )
+            .body(())
+            .unwrap();
+        stream.send_informational(early_hints_response).unwrap();
+
+        // Send final response
+        let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
+        stream.send_response(rsp, true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
+async fn send_multiple_informational_responses() {
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_default_settings!(settings);
+
+        client
+            .send_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+
+        // Expect 100 Continue
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::CONTINUE))
+            .await;
+
+        client
+            .send_frame(frames::data(1, &b"request body"[..]).eos())
+            .await;
+
+        // Expect 103 Early Hints
+        client
+            .recv_frame(
+                frames::headers(1)
+                    .response(StatusCode::EARLY_HINTS)
+                    .field("link", "</style.css>; rel=preload; as=style"),
+            )
+            .await;
+
+        // Expect final response
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::OK).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+
+        assert_eq!(req.method(), &http::Method::POST);
+
+        // Send 100 Continue
+        let continue_response = Response::builder()
+            .status(StatusCode::CONTINUE)
+            .body(())
+            .unwrap();
+        stream.send_informational(continue_response).unwrap();
+
+        // Send 103 Early Hints
+        let early_hints_response = Response::builder()
+            .status(StatusCode::EARLY_HINTS)
+            .header("link", "</style.css>; rel=preload; as=style")
+            .body(())
+            .unwrap();
+        stream.send_informational(early_hints_response).unwrap();
+
+        // Send final response
+        let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
+        stream.send_response(rsp, true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
+async fn invalid_informational_status_returns_error() {
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_default_settings!(settings);
+
+        client
+            .send_frame(
+                frames::headers(1)
+                    .request("GET", "https://example.com/")
+                    .eos(),
+            )
+            .await;
+
+        // Should only receive the final response since invalid informational response errors out
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::OK).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+
+        assert_eq!(req.method(), &http::Method::GET);
+
+        // Try to send invalid informational response (200 is not 1xx)
+        // This should return an error
+        let invalid_response = Response::builder().status(StatusCode::OK).body(()).unwrap();
+        let result = stream.send_informational(invalid_response);
+
+        // Expect error for invalid status code
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("invalid informational status code"));
+
+        // Send actual final response after error
+        let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
+        stream.send_response(rsp, true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
+async fn client_poll_informational_responses() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let recv_settings = srv.assert_client_handshake().await;
+        assert_default_settings!(recv_settings);
+
+        srv.recv_frame(
+            frames::headers(1)
+                .request("GET", "https://example.com/")
+                .eos(),
+        )
+        .await;
+
+        // Send 103 Early Hints
+        srv.send_frame(
+            frames::headers(1)
+                .response(StatusCode::EARLY_HINTS)
+                .field("link", "</style.css>; rel=preload"),
+        )
+        .await;
+
+        // Send final response
+        srv.send_frame(frames::headers(1).response(StatusCode::OK).eos())
+            .await;
+    };
+
+    let client = async move {
+        let (client, connection) = client::handshake(io).await.expect("handshake");
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+
+        let (mut response_future, _) = client
+            .ready()
+            .await
+            .unwrap()
+            .send_request(request, true)
+            .unwrap();
+
+        let conn_fut = async move {
+            connection.await.expect("connection error");
+        };
+
+        let response_fut = async move {
+            // Poll for informational responses
+            loop {
+                match poll_fn(|cx| response_future.poll_informational(cx)).await {
+                    Some(Ok(info_response)) => {
+                        assert_eq!(info_response.status(), StatusCode::EARLY_HINTS);
+                        assert_eq!(
+                            info_response.headers().get("link").unwrap(),
+                            "</style.css>; rel=preload"
+                        );
+                        break;
+                    }
+                    Some(Err(e)) => panic!("Error polling informational: {:?}", e),
+                    None => break,
+                }
+            }
+
+            // Get the final response
+            let response = response_future.await.expect("response error");
+            assert_eq!(response.status(), StatusCode::OK);
+        };
+
+        join(conn_fut, response_fut).await;
+    };
+
+    join(srv, client).await;
+}
+
+#[tokio::test]
+async fn informational_responses_with_body_streaming() {
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_default_settings!(settings);
+
+        client
+            .send_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+
+        // Expect 100 Continue
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::CONTINUE))
+            .await;
+
+        client.send_frame(frames::data(1, &b"chunk1"[..])).await;
+
+        // Expect 103 Early Hints while still receiving body
+        client
+            .recv_frame(
+                frames::headers(1)
+                    .response(StatusCode::EARLY_HINTS)
+                    .field("link", "</resource.js>; rel=preload"),
+            )
+            .await;
+
+        client
+            .send_frame(frames::data(1, &b"chunk2"[..]).eos())
+            .await;
+
+        // Expect final response with streaming body
+        client
+            .recv_frame(frames::headers(1).response(StatusCode::OK))
+            .await;
+
+        client
+            .recv_frame(frames::data(1, &b"response data"[..]).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+
+        assert_eq!(req.method(), &http::Method::POST);
+
+        // Send 100 Continue
+        let continue_response = Response::builder()
+            .status(StatusCode::CONTINUE)
+            .body(())
+            .unwrap();
+        stream.send_informational(continue_response).unwrap();
+
+        // Send 103 Early Hints while processing
+        let early_hints_response = Response::builder()
+            .status(StatusCode::EARLY_HINTS)
+            .header("link", "</resource.js>; rel=preload")
+            .body(())
+            .unwrap();
+        stream.send_informational(early_hints_response).unwrap();
+
+        // Send final response with body
+        let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
+        let mut send_stream = stream.send_response(rsp, false).unwrap();
+
+        send_stream.send_data("response data".into(), true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}


### PR DESCRIPTION
Add support for HTTP/2 informational responses, enabling servers to send multiple 1xx status code responses before the final response and clients to receive them separately.

## Key Features Added

### Client-side Support
- Add `poll_informational()` method to `ResponseFuture` for polling 1xx responses
- Modify response polling logic to properly handle and skip informational headers
- Ensure informational responses don't interfere with main response flow

### Server-side Support
- Add `send_informational()` method to `SendResponse` with documentation
- Support multiple informational responses per request (e.g., 100 Continue, 103 Early Hints)
- Validate that only 1xx status codes are sent as informational responses
- Gracefully handle invalid informational responses without breaking the stream

### Protocol Implementation
- Add `InformationalHeaders` event type to distinguish from regular headers
- Implement `send_informational_headers_direct()` for sending without state changes
- Modify header processing to route informational responses correctly
- Ensure informational responses don't affect HTTP/2 stream state transitions

## Changed Files
- **Cargo.toml**: Switch to local http crate dependency for extended status code support
- **src/client.rs**: Add client-side informational response polling API
- **src/proto/streams/recv.rs**: Implement informational header event handling and polling
- **src/proto/streams/send.rs**: Add direct informational header sending capability
- **src/proto/streams/streams.rs**: Integrate informational response methods into stream APIs
- **src/server.rs**: Add server-side informational response API
- **tests/h2-tests/tests/informational_responses.rs**: Add 6 unit tests
      * send_100_continue: Basic 100 Continue functionality
      * send_103_early_hints: 103 Early Hints with Link headers
      * send_multiple_informational_responses: Multiple 1xx responses in sequence
      * invalid_informational_status_returns_error: Invalid status code handling
      * client_poll_informational_responses: Client-side polling API
      * informational_responses_with_body_streaming: Streaming scenarios

## Use Cases Supported
- **100 Continue**: Allow clients to continue sending request body
- **103 Early Hints**: Provide early resource hints for client preloading

## Technical Notes
- Informational responses are sent without the END_STREAM flag
- Stream state remains unchanged when sending informational responses
- Multiple informational responses can be sent before the final response
- Client polling separates informational responses from the main response flow
- Backward compatibility maintained - existing code continues to work unchanged

Resolves support for HTTP 103 Early Hints and 100 Continue HTTP/2 informational responses.