### PR TITLE
fix: Unparent connection span

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -126,6 +126,8 @@ where
             }
         }
         let streams = Streams::new(streams_config(&config));
+        let span = tracing::debug_span!(parent: None, "Connection", peer = %P::NAME);
+        span.follows_from(tracing::Span::current());
         Connection {
             codec,
             inner: ConnectionInner {
@@ -135,7 +137,7 @@ where
                 ping_pong: PingPong::new(),
                 settings: Settings::new(config.settings),
                 streams,
-                span: tracing::debug_span!("Connection", peer = %P::NAME),
+                span,
                 _phantom: PhantomData,
             },
         }


### PR DESCRIPTION
The `Connection` struct contains a `tracing::Span` tracking its
lifetime. This can be useful. The problem is that this span has as its
parent the span within which the connection is created, meaning that it
keeps that span alive (not closed) while it is alive. In practice that
means, for example, instrumented functions that create connections and
store those connections for reuse will not have their spans closed and
exported when they end.

This shows up in `tonic`, where the first RPC call to any server will have its containing span alive for the remainder of the RPC client's lifetime.

This commit sets the `Connection`'s span's parent to `None` and gives it
a "follows-from" relation to the span in which it was created instead.
This shows the causal relationship between them, without tying the
creating span's lifetime to the connection's lifetime.