### PR TITLE
Reduce huffman decode table size

### DIFF
--- a/src/hpack/huffman/mod.rs
+++ b/src/hpack/huffman/mod.rs
@@ -7,7 +7,7 @@ use bytes::{BufMut, BytesMut};
 
 // Constructed in the generated `table.rs` file
 struct Decoder {
-    state: usize,
+    state: u8,
     maybe_eos: bool,
 }
 
@@ -76,7 +76,7 @@ impl Decoder {
     // Decodes 4 bits
     fn decode4(&mut self, input: u8) -> Result<Option<u8>, DecoderError> {
         // (next-state, byte, flags)
-        let (next, byte, flags) = DECODE_TABLE[self.state][input as usize];
+        let (next, byte, flags) = DECODE_TABLE[self.state as usize][input as usize];
 
         if flags & ERROR == ERROR {
             // Data followed the EOS marker

--- a/src/hpack/huffman/table.rs
+++ b/src/hpack/huffman/table.rs
@@ -262,7 +262,7 @@ pub const ENCODE_TABLE: [(usize, u64); 257] = [
 ];
 
 // (next-state, byte, flags)
-pub const DECODE_TABLE: [[(usize, u8, u8); 16]; 256] = [
+pub const DECODE_TABLE: [[(u8, u8, u8); 16]; 256] = [
     // 0
     [
         (4, 0, 0x00),

--- a/util/genhuff/src/main.rs
+++ b/util/genhuff/src/main.rs
@@ -249,7 +249,7 @@ pub fn main() {
 
     println!();
     println!("// (next-state, byte, flags)");
-    println!("pub const DECODE_TABLE: [[(usize, u8, u8); 16]; 256] = [");
+    println!("pub const DECODE_TABLE: [[(u8, u8, u8); 16]; 256] = [");
 
     decode.print();
 


### PR DESCRIPTION
The type of huffman decode table is `[[(usize, u8, u8); 16]; 256]`, where the `usize` is an index to the next entry within that table. Because the length of the table is exactly 256, by storing the index as `u8` it will make the table size significantly smaller.

Closes #870