### PR TITLE
Shorter Debug for StreamId

### DIFF
--- a/src/frame/stream_id.rs
+++ b/src/frame/stream_id.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
 /// A stream identifier, as described in [Section 5.1.1] of RFC 7540.
 ///
 /// Streams are identified with an unsigned 31-bit integer. Streams
@@ -8,8 +11,14 @@
 /// new stream.
 ///
 /// [Section 5.1.1]: https://tools.ietf.org/html/rfc7540#section-5.1.1
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct StreamId(u32);
+
+impl Debug for StreamId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Copy, Clone)]
 pub struct StreamIdOverflow;


### PR DESCRIPTION
Logs look like this:

```
2025-12-31T00:06:55.081648Z DEBUG Connection{peer=Client}: h2::codec::framed_read: received frame=Headers { stream_id: StreamId(1679), flags: (0x5: END_HEADERS | END_STREAM) }
```

This makes logs less verbose.