### PR TITLE
fix: canonicalize Host header into :authority for outbound HTTP/2

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -51,6 +51,7 @@ mod window_update;
 pub use self::data::Data;
 pub use self::go_away::GoAway;
 pub use self::head::{Head, Kind};
+pub(crate) use self::headers::canonicalize_host_authority;
 pub use self::headers::{
     parse_u64, Continuation, Headers, Pseudo, PushPromise, PushPromiseHeaderError,
 };

--- a/src/server.rs
+++ b/src/server.rs
@@ -1581,13 +1581,16 @@ impl Peer {
             Parts {
                 method,
                 uri,
-                headers,
+                mut headers,
                 ..
             },
             _,
         ) = request.into_parts();
 
-        let pseudo = Pseudo::request(method, uri, None);
+        let mut pseudo = Pseudo::request(method, uri, None);
+
+        // Canonicalize Host header into :authority for HTTP/2 push promises
+        frame::canonicalize_host_authority(&mut pseudo, &mut headers);
 
         Ok(frame::PushPromise::new(
             stream_id,

--- a/tests/h2-support/src/frames.rs
+++ b/tests/h2-support/src/frames.rs
@@ -243,6 +243,12 @@ impl Mock<frame::PushPromise> {
         Mock(frame)
     }
 
+    pub fn pseudo(self, pseudo: frame::Pseudo) -> Self {
+        let (id, promised, _, fields) = self.into_parts();
+        let frame = frame::PushPromise::new(id, promised, pseudo, fields);
+        Mock(frame)
+    }
+
     pub fn fields(self, fields: HeaderMap) -> Self {
         let (id, promised, pseudo, _) = self.into_parts();
         let frame = frame::PushPromise::new(id, promised, pseudo, fields);

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -2060,9 +2060,9 @@ async fn reset_before_headers_reaches_peer_without_headers() {
 }
 
 #[tokio::test]
-async fn host_authority_mismatch_promotes_host_to_authority() {
-    // When Host differs from URI authority, Host should win for :authority
-    // and Host header should be stripped from regular headers.
+async fn host_authority_mismatch_host_wins() {
+    // When Host differs from URI authority, Host wins and becomes :authority.
+    // Host is retained.
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 
@@ -2078,6 +2078,7 @@ async fn host_authority_mismatch_promotes_host_to_authority() {
                     path: util::byte_str("/").into(),
                     ..Default::default()
                 })
+                .field("host", "example.com")
                 .eos(),
         )
         .await;
@@ -2103,11 +2104,10 @@ async fn host_authority_mismatch_promotes_host_to_authority() {
 }
 
 #[tokio::test]
-async fn host_authority_http11_version_still_promotes_host_to_authority() {
+async fn host_authority_http11_version_still_promotes_host() {
     // Real integration path: higher layers (for example hyper/hyper-util)
     // commonly pass Request values with the default HTTP/1.1 version even when
-    // the selected transport is HTTP/2. We still need HTTP/2-compliant
-    // canonicalization on the wire, so Host must promote to :authority here.
+    // the selected transport is HTTP/2. Host wins and is retained on the wire.
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 
@@ -2123,6 +2123,7 @@ async fn host_authority_http11_version_still_promotes_host_to_authority() {
                     path: util::byte_str("/").into(),
                     ..Default::default()
                 })
+                .field("host", "example.com")
                 .eos(),
         )
         .await;
@@ -2148,8 +2149,8 @@ async fn host_authority_http11_version_still_promotes_host_to_authority() {
 }
 
 #[tokio::test]
-async fn host_authority_matching_strips_host() {
-    // When Host matches URI authority, Host header should still be stripped.
+async fn host_authority_matching_retains_host() {
+    // When Host matches URI authority, Host header is retained on the wire.
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 
@@ -2165,6 +2166,7 @@ async fn host_authority_matching_strips_host() {
                     path: util::byte_str("/").into(),
                     ..Default::default()
                 })
+                .field("host", "example.com")
                 .eos(),
         )
         .await;
@@ -2192,6 +2194,7 @@ async fn host_authority_matching_strips_host() {
 #[tokio::test]
 async fn host_authority_duplicate_host_first_wins() {
     // When multiple Host headers are present, first value is used for :authority.
+    // Host headers are collapsed to the first value.
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 
@@ -2207,6 +2210,7 @@ async fn host_authority_duplicate_host_first_wins() {
                     path: util::byte_str("/").into(),
                     ..Default::default()
                 })
+                .field("host", "first.example")
                 .eos(),
         )
         .await;
@@ -2234,7 +2238,8 @@ async fn host_authority_duplicate_host_first_wins() {
 
 #[tokio::test]
 async fn host_authority_invalid_host_keeps_uri_authority() {
-    // When Host is invalid (unparseable as authority), keep URI authority and strip Host.
+    // When Host is invalid (unparseable as authority), URI authority is kept
+    // and invalid Host is stripped to avoid violating RFC 9113 §8.3.1.
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 
@@ -2276,9 +2281,9 @@ async fn host_authority_invalid_host_keeps_uri_authority() {
 
 #[tokio::test]
 async fn host_authority_relative_uri_http2_still_errors() {
-    // Relative URI with HTTP/2 version should still produce MissingUriSchemeAndAuthority error,
-    // even when a Host header is provided. The Host canonicalization does not synthesize
-    // authority for relative URIs.
+    // Relative URI with HTTP/2 version should still produce MissingUriSchemeAndAuthority
+    // error. The scheme check fires before canonicalization runs, so Host cannot rescue
+    // a relative URI.
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
 

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -2059,6 +2059,255 @@ async fn reset_before_headers_reaches_peer_without_headers() {
     join(srv, client).await;
 }
 
+#[tokio::test]
+async fn host_authority_mismatch_promotes_host_to_authority() {
+    // When Host differs from URI authority, Host should win for :authority
+    // and Host header should be stripped from regular headers.
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .pseudo(frame::Pseudo {
+                    method: Method::GET.into(),
+                    scheme: util::byte_str("https").into(),
+                    authority: util::byte_str("example.com").into(),
+                    path: util::byte_str("/").into(),
+                    ..Default::default()
+                })
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200).eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.expect("handshake");
+
+        let request = Request::builder()
+            .version(Version::HTTP_2)
+            .method(Method::GET)
+            .uri("https://example.net/")
+            .header("host", "example.com")
+            .body(())
+            .unwrap();
+
+        let (response, _) = client.send_request(request, true).unwrap();
+        h2.drive(response).await.unwrap();
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
+async fn host_authority_http11_version_still_promotes_host_to_authority() {
+    // Real integration path: higher layers (for example hyper/hyper-util)
+    // commonly pass Request values with the default HTTP/1.1 version even when
+    // the selected transport is HTTP/2. We still need HTTP/2-compliant
+    // canonicalization on the wire, so Host must promote to :authority here.
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .pseudo(frame::Pseudo {
+                    method: Method::GET.into(),
+                    scheme: util::byte_str("https").into(),
+                    authority: util::byte_str("example.com").into(),
+                    path: util::byte_str("/").into(),
+                    ..Default::default()
+                })
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200).eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.expect("handshake");
+
+        let request = Request::builder()
+            // Keep the default request version to model the common caller behavior.
+            .method(Method::GET)
+            .uri("https://example.net/")
+            .header("host", "example.com")
+            .body(())
+            .unwrap();
+
+        let (response, _) = client.send_request(request, true).unwrap();
+        h2.drive(response).await.unwrap();
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
+async fn host_authority_matching_strips_host() {
+    // When Host matches URI authority, Host header should still be stripped.
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .pseudo(frame::Pseudo {
+                    method: Method::GET.into(),
+                    scheme: util::byte_str("https").into(),
+                    authority: util::byte_str("example.com").into(),
+                    path: util::byte_str("/").into(),
+                    ..Default::default()
+                })
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200).eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.expect("handshake");
+
+        let request = Request::builder()
+            .version(Version::HTTP_2)
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("host", "example.com")
+            .body(())
+            .unwrap();
+
+        let (response, _) = client.send_request(request, true).unwrap();
+        h2.drive(response).await.unwrap();
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
+async fn host_authority_duplicate_host_first_wins() {
+    // When multiple Host headers are present, first value is used for :authority.
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .pseudo(frame::Pseudo {
+                    method: Method::GET.into(),
+                    scheme: util::byte_str("https").into(),
+                    authority: util::byte_str("first.example").into(),
+                    path: util::byte_str("/").into(),
+                    ..Default::default()
+                })
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200).eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.expect("handshake");
+
+        let request = Request::builder()
+            .version(Version::HTTP_2)
+            .method(Method::GET)
+            .uri("https://example.net/")
+            .header("host", "first.example")
+            .header("host", "second.example")
+            .body(())
+            .unwrap();
+
+        let (response, _) = client.send_request(request, true).unwrap();
+        h2.drive(response).await.unwrap();
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
+async fn host_authority_invalid_host_keeps_uri_authority() {
+    // When Host is invalid (unparseable as authority), keep URI authority and strip Host.
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .pseudo(frame::Pseudo {
+                    method: Method::GET.into(),
+                    scheme: util::byte_str("https").into(),
+                    authority: util::byte_str("example.net").into(),
+                    path: util::byte_str("/").into(),
+                    ..Default::default()
+                })
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200).eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.expect("handshake");
+
+        let request = Request::builder()
+            .version(Version::HTTP_2)
+            .method(Method::GET)
+            .uri("https://example.net/")
+            .header("host", "not:a/good authority")
+            .body(())
+            .unwrap();
+
+        let (response, _) = client.send_request(request, true).unwrap();
+        h2.drive(response).await.unwrap();
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
+async fn host_authority_relative_uri_http2_still_errors() {
+    // Relative URI with HTTP/2 version should still produce MissingUriSchemeAndAuthority error,
+    // even when a Host header is provided. The Host canonicalization does not synthesize
+    // authority for relative URIs.
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+    };
+
+    let h2 = async move {
+        let (mut client, h2) = client::handshake(io).await.expect("handshake");
+
+        let request = Request::builder()
+            .version(Version::HTTP_2)
+            .method(Method::GET)
+            .uri("/")
+            .header("host", "example.com")
+            .body(())
+            .unwrap();
+
+        client
+            .send_request(request, true)
+            .expect_err("should be UserError");
+        let _: () = h2.await.expect("h2");
+        drop(client);
+    };
+
+    join(srv, h2).await;
+}
+
 const SETTINGS: &[u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
 const SETTINGS_ACK: &[u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -1592,3 +1592,196 @@ async fn init_window_size_smaller_than_default_should_use_default_before_ack() {
 
     join(client, h2).await;
 }
+
+#[tokio::test]
+async fn push_promise_host_authority_mismatch() {
+    // Push promise with URI/Host mismatch: Host wins for :authority, Host stripped.
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        client
+            .assert_server_handshake_with_settings(frames::settings().max_concurrent_streams(100))
+            .await;
+        client
+            .send_frame(
+                frames::headers(1)
+                    .request("GET", "https://example.com/")
+                    .eos(),
+            )
+            .await;
+        // Expect push promise with authority from Host, not URI
+        client
+            .recv_frame(frames::push_promise(1, 2).pseudo(frame::Pseudo {
+                method: Method::GET.into(),
+                scheme: util::byte_str("https").into(),
+                authority: util::byte_str("example.com").into(),
+                path: util::byte_str("/style.css").into(),
+                ..Default::default()
+            }))
+            .await;
+        client
+            .recv_frame(frames::headers(2).response(200).eos())
+            .await;
+        client
+            .recv_frame(frames::headers(1).response(200).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+        assert_eq!(req.method(), &http::Method::GET);
+
+        // Push with URI authority example.net but Host: example.com
+        {
+            let req = http::Request::builder()
+                .method("GET")
+                .uri("https://example.net/style.css")
+                .header("host", "example.com")
+                .body(())
+                .unwrap();
+            let rsp = http::Response::builder().status(200).body(()).unwrap();
+            stream
+                .push_request(req)
+                .unwrap()
+                .send_response(rsp, true)
+                .unwrap();
+        }
+
+        let rsp = http::Response::builder().status(200).body(()).unwrap();
+        stream.send_response(rsp, true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
+async fn push_promise_host_authority_duplicate_first_wins() {
+    // Push promise with duplicate Host: first value wins for :authority.
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        client
+            .assert_server_handshake_with_settings(frames::settings().max_concurrent_streams(100))
+            .await;
+        client
+            .send_frame(
+                frames::headers(1)
+                    .request("GET", "https://example.com/")
+                    .eos(),
+            )
+            .await;
+        client
+            .recv_frame(frames::push_promise(1, 2).pseudo(frame::Pseudo {
+                method: Method::GET.into(),
+                scheme: util::byte_str("https").into(),
+                authority: util::byte_str("first.example").into(),
+                path: util::byte_str("/style.css").into(),
+                ..Default::default()
+            }))
+            .await;
+        client
+            .recv_frame(frames::headers(2).response(200).eos())
+            .await;
+        client
+            .recv_frame(frames::headers(1).response(200).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+        assert_eq!(req.method(), &http::Method::GET);
+
+        {
+            let req = http::Request::builder()
+                .method("GET")
+                .uri("https://example.net/style.css")
+                .header("host", "first.example")
+                .header("host", "second.example")
+                .body(())
+                .unwrap();
+            let rsp = http::Response::builder().status(200).body(()).unwrap();
+            stream
+                .push_request(req)
+                .unwrap()
+                .send_response(rsp, true)
+                .unwrap();
+        }
+
+        let rsp = http::Response::builder().status(200).body(()).unwrap();
+        stream.send_response(rsp, true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
+async fn push_promise_host_authority_invalid_keeps_uri() {
+    // Push promise with invalid Host: keep URI authority, strip Host.
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        client
+            .assert_server_handshake_with_settings(frames::settings().max_concurrent_streams(100))
+            .await;
+        client
+            .send_frame(
+                frames::headers(1)
+                    .request("GET", "https://example.com/")
+                    .eos(),
+            )
+            .await;
+        // Expect push promise with original URI authority since Host is invalid
+        client
+            .recv_frame(frames::push_promise(1, 2).pseudo(frame::Pseudo {
+                method: Method::GET.into(),
+                scheme: util::byte_str("https").into(),
+                authority: util::byte_str("example.net").into(),
+                path: util::byte_str("/style.css").into(),
+                ..Default::default()
+            }))
+            .await;
+        client
+            .recv_frame(frames::headers(2).response(200).eos())
+            .await;
+        client
+            .recv_frame(frames::headers(1).response(200).eos())
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (req, mut stream) = srv.next().await.unwrap().unwrap();
+        assert_eq!(req.method(), &http::Method::GET);
+
+        {
+            let req = http::Request::builder()
+                .method("GET")
+                .uri("https://example.net/style.css")
+                .header("host", "not:a/good authority")
+                .body(())
+                .unwrap();
+            let rsp = http::Response::builder().status(200).body(()).unwrap();
+            stream
+                .push_request(req)
+                .unwrap()
+                .send_response(rsp, true)
+                .unwrap();
+        }
+
+        let rsp = http::Response::builder().status(200).body(()).unwrap();
+        stream.send_response(rsp, true).unwrap();
+
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}


### PR DESCRIPTION
When sending HTTP/2 requests or push promises, promote the first valid Host header value to :authority and retain it on the wire. Duplicate Host values are collapsed to a single entry matching :authority, and unparseable Host values are stripped. This prevents emitting conflicting :authority and Host while keeping the Host header available for intermediaries that may need it ([RFC 9113 §8.3.1][rfc]).
The "Host wins" semantics align with the behavior of other HTTP/2 client implementations such as curl, Go's std, and Python's httpx.

[rfc]: https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1

Fixes #876