### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 A Tokio aware, HTTP/2 client & server implementation for Rust.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Crates.io](https://img.shields.io/crates/v/h2.svg)](https://crates.io/crates/h2)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/license/mit)
+[![crates.io](https://img.shields.io/crates/v/h2.svg)](https://crates.io/crates/h2)
 [![Documentation](https://docs.rs/h2/badge.svg)][dox]
 
-More information about this crate can be found in the [crate documentation][dox].
+More information about this crate can be found in the
+[crate documentation][dox].
 
 [dox]: https://docs.rs/h2
 
@@ -16,19 +17,20 @@ More information about this crate can be found in the [crate documentation][dox]
 * Implements the full HTTP/2 specification.
 * Passes [h2spec](https://github.com/summerwind/h2spec).
 * Focus on performance and correctness.
-* Built on [Tokio](https://tokio.rs).
+* Built on [Tokio](https://tokio.rs/).
 
-## Non goals
+## Non-goals
 
-This crate is intended to only be an implementation of the HTTP/2
-specification. It does not handle:
+This crate is intended to only be an implementation of the HTTP/2 specification.
+It does not handle:
 
-* Managing TCP connections
-* HTTP 1.0 upgrade
-* TLS
+* Managing TCP connections.
+* HTTP 1.0 upgrade.
+* TLS.
 * Any feature not described by the HTTP/2 specification.
 
-This crate is now used by [hyper](https://github.com/hyperium/hyper), which will provide all of these features.
+This crate is now used by [hyper](https://github.com/hyperium/hyper), which will
+provide all of these features.
 
 ## Usage
 
@@ -42,8 +44,6 @@ h2 = "0.4"
 Next, add this to your crate:
 
 ```rust
-extern crate h2;
-
 use h2::server::Connection;
 
 fn main() {
@@ -55,4 +55,4 @@ fn main() {
 
 **Is this an embedded Java SQL database engine?**
 
-[No](https://www.h2database.com).
+[No](https://www.h2database.com/).


### PR DESCRIPTION
- Update URLs
- Remove `extern crate h2;` from example for Rust 2018
- Use consistent formatting throughout