### PR TITLE
fix: Discard buffered DATA when a scheduled reset is pending

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -731,6 +731,23 @@ impl Prioritize {
 
                     let frame = match stream.pending_send.pop_front(buffer) {
                         Some(Frame::Data(mut frame)) => {
+                            if let Some(reason) = stream.state.get_scheduled_reset() {
+                                // If a reset is scheduled due to cancellation or
+                                // an error, discard buffered DATA and let the `None`
+                                // arm emit the RST_STREAM on the next iteration.
+                                //
+                                // NO_ERROR is excluded. Per RFC 9113 §8.1, a NO_ERROR
+                                // stream reset may only be sent after a complete
+                                // response, which requires sending all queued DATA.
+                                if reason != Reason::NO_ERROR {
+                                    stream.pending_send.push_front(buffer, frame.into());
+                                    self.clear_queue(buffer, &mut stream);
+                                    self.reclaim_all_capacity(&mut stream, counts);
+                                    self.pending_send.push(&mut stream);
+                                    continue;
+                                }
+                            }
+
                             // Get the amount of capacity remaining for stream's
                             // window.
                             let stream_capacity = stream.send_flow.available();

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -1588,6 +1588,95 @@ async fn reset_stream_waiting_for_capacity() {
 }
 
 #[tokio::test]
+async fn scheduled_reset_with_buffered_data_sends_rst() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv
+            .assert_client_handshake_with_settings(frames::settings().initial_window_size(0))
+            .await;
+        assert_default_settings!(settings);
+
+        srv.recv_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+        srv.send_frame(frames::headers(1).response(200)).await;
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            srv.recv_frame(frames::reset(1).cancel()),
+        )
+        .await
+        .expect("RST_STREAM not received within 5s");
+    };
+
+    let client = async move {
+        let (mut client, mut conn) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+        let (response, mut stream) = client.send_request(request, false).unwrap();
+        let resp = conn.drive(response).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Buffer data that can never be sent (zero stream window).
+        stream.send_data(vec![0u8; 10].into(), false).unwrap();
+        // Drop both handles to schedule a CANCEL reset.
+        drop(stream);
+        drop(resp);
+        conn.await.unwrap();
+    };
+
+    join(srv, client).await;
+}
+
+#[tokio::test]
+async fn scheduled_reset_with_excess_buffered_data_is_cleaned_up() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let _ = srv.assert_client_handshake().await;
+        srv.recv_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+        srv.recv_frame(frames::data(1, vec![0; 16384])).await;
+        srv.recv_frame(frames::data(1, vec![0; 16384])).await;
+        srv.recv_frame(frames::data(1, vec![0; 16384])).await;
+        srv.recv_frame(frames::data(1, vec![0; 16383])).await;
+        srv.send_frame(frames::window_update(0, 65535)).await;
+        srv.send_frame(frames::headers(1).response(200)).await;
+        srv.recv_frame(frames::reset(1).cancel()).await;
+    };
+
+    let client = async move {
+        let (mut client, mut conn) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+        let (response, mut stream) = client.send_request(request, false).unwrap();
+        // Buffer the full window plus excess. The first 65535 bytes
+        // are sent, and the remaining 1000 are stuck.
+        stream
+            .send_data(vec![0u8; 65535 + 1000].into(), false)
+            .unwrap();
+        let resp = conn.drive(response).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        drop(stream);
+        drop(resp);
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(5), conn)
+            .await
+            .expect("connection did not shut down within 5s")
+            .unwrap();
+    };
+
+    join(srv, client).await;
+}
+
+#[tokio::test]
 async fn data_padding() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -635,6 +635,55 @@ async fn sends_reset_no_error_when_req_body_is_dropped() {
 }
 
 #[tokio::test]
+async fn no_error_response_body_delivered_before_rst() {
+    // When a server sends a large response body and drops the request
+    // body without reading it, NO_ERROR is scheduled. The response DATA
+    // must still be delivered.
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_default_settings!(settings);
+        client
+            .send_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+        client.recv_frame(frames::headers(1).response(200)).await;
+        client.recv_frame(frames::data(1, vec![0; 16384])).await;
+        client.recv_frame(frames::data(1, vec![0; 16384])).await;
+        client.recv_frame(frames::data(1, vec![0; 16384])).await;
+        client.recv_frame(frames::data(1, vec![0; 16383])).await;
+        // These window updates allow the full response to be delivered.
+        client.send_frame(frames::window_update(0, 65535)).await;
+        client.send_frame(frames::window_update(1, 65535)).await;
+        client.recv_frame(frames::data(1, vec![0; 16384])).await;
+        client.recv_frame(frames::data(1, vec![0; 16384])).await;
+        client.recv_frame(frames::data(1, vec![0; 1]).eos()).await;
+        client
+            .recv_frame(frames::reset(1).reason(Reason::NO_ERROR))
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        {
+            let (req, mut stream) = srv.next().await.unwrap().unwrap();
+            assert_eq!(req.method(), &http::Method::POST);
+
+            let rsp = http::Response::builder().status(200).body(()).unwrap();
+            let mut tx = stream.send_response(rsp, false).unwrap();
+            // Response body larger than the stream window. The first 65535 bytes
+            // are sent immediately, and the remaining bytes wait for the client's
+            // WINDOW_UPDATE.
+            tx.send_data(vec![0; 16384 * 6].into(), true).unwrap();
+        }
+        assert!(srv.next().await.is_none());
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
 async fn abrupt_shutdown() {
     h2_support::trace_init!();
     let (io, mut client) = mock::new();
@@ -890,7 +939,8 @@ async fn sends_reset_cancel_when_res_body_is_dropped() {
             )
             .await;
         client.recv_frame(frames::headers(3).response(200)).await;
-        client.recv_frame(frames::data(3, vec![0; 10])).await;
+        // CANCEL means "stream is no longer needed" (RFC 9113 §7). Buffered DATA
+        // is discarded and RST_STREAM is sent immediately.
         client.recv_frame(frames::reset(3).cancel()).await;
     };
 


### PR DESCRIPTION
A revival of https://github.com/hyperium/h2/pull/881

Implicit resets rely on `pop_frame` reaching the `None` arm to emit `RST_STREAM`. If `DATA` is queued but the stream has zero window capacity to send it, `pop_frame` hits this check
```rust
if sz > 0 && stream_capacity == 0 {
    tracing::trace!("stream capacity is 0");

    // The stream has no more capacity, this can
    // happen if the remote reduced the stream
    // window. In this case, we need to buffer the
    // frame and wait for a window update...
    stream.pending_send.push_front(buffer, frame.into());

    continue;
}
```
The frame is pushed back, but the stream is not re-enqueued until we receive a window update for it. If that update is never received, the stream reset will be delayed indefinitely (we're at the mercy of the remote). In debug builds this crashes with

```
panicked at src/proto/streams/counts.rs:282:13:
assertion failed: !self.has_streams()
```
when the connection is dropped.

```rust
fn maybe_cancel(stream: &mut store::Ptr, actions: &mut Actions, counts: &mut Counts) {
    if stream.is_canceled_interest() {
        // Server is allowed to early respond without fully consuming the client input stream
        // But per the RFC, must send a RST_STREAM(NO_ERROR) in such cases. https://www.rfc-editor.org/rfc/rfc7540#section-8.1
        // Some other http2 implementation may interpret other error code as fatal if not respected (i.e: nginx https://trac.nginx.org/nginx/ticket/2376)
        let reason = if counts.peer().is_server()
            && stream.state.is_send_closed()
            && stream.state.is_recv_streaming()
        {
            Reason::NO_ERROR
        } else {
            Reason::CANCEL
        };

        actions
            .send
            .schedule_implicit_reset(stream, reason, counts, &mut actions.task);
        actions.recv.enqueue_reset_expiration(stream, counts);
    }
}
```
Implicit resets can occur under three circumstances:
* `CANCEL`: In [`maybe_cancel`](https://github.com/hyperium/h2/blob/1e68f995edec9e5c462d4e9af906e2d5304412c2/src/proto/streams/streams.rs#L1579-L1598), when all user handles are dropped for a stream that is still open
* `NO_ERROR`: In [`maybe_cancel`](https://github.com/hyperium/h2/blob/1e68f995edec9e5c462d4e9af906e2d5304412c2/src/proto/streams/streams.rs#L1579-L1598), when all user handles are dropped for a server stream where the response is already queued
* `PROTOCOL_ERROR`: From the oversized headers path in [`streams.rs`](https://github.com/hyperium/h2/blob/1e68f995edec9e5c462d4e9af906e2d5304412c2/src/proto/streams/streams.rs#L509-L513), after a rejection response is sent

For context, `NO_ERROR` for a stream reset is only supposed to be sent after a complete response. Buffering data + response, and then dropping the stream handles sounds like a relatively normal thing to do, and I think we want to support it.

However, for the other cases we should just fast-track stream reset and delete the buffered data, as we don't care about the stream anymore. Sending it would be wasteful.