### PR TITLE
fix: Remove unnecessary clones

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1334,7 +1334,7 @@ where
                 reset_stream_max: builder.reset_stream_max,
                 remote_reset_stream_max: builder.pending_accept_reset_stream_max,
                 local_error_reset_streams_max: builder.local_max_error_reset_streams,
-                settings: builder.settings.clone(),
+                settings: builder.settings,
             },
         );
         let send_request = SendRequest {

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -2410,7 +2410,7 @@ async fn capacity_not_assigned_to_unopened_streams() {
 
         let (response1, mut stream1) = client.send_request(request.clone(), false).unwrap();
         stream1.send_data("hello".into(), false).unwrap();
-        let (_, mut stream2) = client.send_request(request.clone(), false).unwrap();
+        let (_, mut stream2) = client.send_request(request, false).unwrap();
         stream2.reserve_capacity(frame::DEFAULT_INITIAL_WINDOW_SIZE as usize);
         stream1.send_data("world".into(), true).unwrap();
         h2.drive(response1).await.unwrap();
@@ -2469,7 +2469,7 @@ async fn new_initial_window_size_capacity_not_assigned_to_unopened_streams() {
 
         let (response1, mut stream1) = client.send_request(request.clone(), false).unwrap();
         stream1.send_data("hello".into(), false).unwrap();
-        let (_, mut stream2) = client.send_request(request.clone(), false).unwrap();
+        let (_, mut stream2) = client.send_request(request, false).unwrap();
         stream2.reserve_capacity(frame::DEFAULT_INITIAL_WINDOW_SIZE as usize);
         h2.drive(response1).await.unwrap();
         stream1.send_data("world".into(), true).unwrap();


### PR DESCRIPTION
If I am not overlooking anything, these clones can be safely removed since they aren't used anywhere else later.

CC @nunoplopes