### PR TITLE
Return an error early if header list is overrun

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -930,6 +930,7 @@ impl HeaderBlock {
                 Protocol(v) => set_pseudo!(protocol, v),
                 Status(v) => set_pseudo!(status, v),
             }
+            self.is_over_size
         });
 
         if let Err(e) = res {

--- a/src/hpack/decoder.rs
+++ b/src/hpack/decoder.rs
@@ -179,7 +179,7 @@ impl Decoder {
         mut f: F,
     ) -> Result<(), DecoderError>
     where
-        F: FnMut(Header),
+        F: FnMut(Header) -> bool,
     {
         use self::Representation::*;
 
@@ -198,13 +198,13 @@ impl Decoder {
             // At this point we are always at the beginning of the next block
             // within the HPACK data. The type of the block can always be
             // determined from the first byte.
-            match Representation::load(ty)? {
+            if match Representation::load(ty)? {
                 Indexed => {
                     tracing::trace!(rem = src.remaining(), kind = %"Indexed");
                     can_resize = false;
                     let entry = self.decode_indexed(src)?;
                     consume(src);
-                    f(entry);
+                    f(entry)
                 }
                 LiteralWithIndexing => {
                     tracing::trace!(rem = src.remaining(), kind = %"LiteralWithIndexing");
@@ -215,14 +215,14 @@ impl Decoder {
                     self.table.insert(entry.clone());
                     consume(src);
 
-                    f(entry);
+                    f(entry)
                 }
                 LiteralWithoutIndexing => {
                     tracing::trace!(rem = src.remaining(), kind = %"LiteralWithoutIndexing");
                     can_resize = false;
                     let entry = self.decode_literal(src, false)?;
                     consume(src);
-                    f(entry);
+                    f(entry)
                 }
                 LiteralNeverIndexed => {
                     tracing::trace!(rem = src.remaining(), kind = %"LiteralNeverIndexed");
@@ -232,7 +232,7 @@ impl Decoder {
 
                     // TODO: Track that this should never be indexed
 
-                    f(entry);
+                    f(entry)
                 }
                 SizeUpdate => {
                     tracing::trace!(rem = src.remaining(), kind = %"SizeUpdate");
@@ -243,7 +243,10 @@ impl Decoder {
                     // Handle the dynamic table size update
                     self.process_size_update(src)?;
                     consume(src);
+                    false
                 }
+            } {
+                break;
             }
         }
 
@@ -851,7 +854,7 @@ mod test {
     fn test_decode_empty() {
         let mut de = Decoder::new(0);
         let mut buf = BytesMut::new();
-        let _: () = de.decode(&mut Cursor::new(&mut buf), |_| {}).unwrap();
+        let _: () = de.decode(&mut Cursor::new(&mut buf), |_| false).unwrap();
     }
 
     #[test]
@@ -867,6 +870,7 @@ mod test {
         let mut res = vec![];
         de.decode(&mut Cursor::new(&mut buf), |h| {
             res.push(h);
+            false
         })
         .unwrap();
 
@@ -907,6 +911,7 @@ mod test {
         let e = de
             .decode(&mut Cursor::new(&mut buf), |h| {
                 res.push(h);
+                false
             })
             .unwrap_err();
         // decode error because the header value is partial
@@ -916,6 +921,7 @@ mod test {
         buf.extend(&value[1..]);
         de.decode(&mut Cursor::new(&mut buf), |h| {
             res.push(h);
+            false
         })
         .unwrap();
 

--- a/src/hpack/test/fixture.rs
+++ b/src/hpack/test/fixture.rs
@@ -78,6 +78,7 @@ fn test_story(story: Value) {
                     let (name, value) = expect.remove(0);
                     assert_eq!(name, key_str(&e));
                     assert_eq!(value, value_str(&e));
+                    false
                 })
                 .unwrap();
 
@@ -112,6 +113,7 @@ fn test_story(story: Value) {
             decoder
                 .decode(&mut Cursor::new(&mut buf), |e| {
                     assert_eq!(e, input.remove(0).reify().unwrap());
+                    false
                 })
                 .unwrap();
 

--- a/src/hpack/test/fuzz.rs
+++ b/src/hpack/test/fuzz.rs
@@ -170,6 +170,7 @@ impl FuzzHpack {
                 .decode(&mut Cursor::new(&mut buf), |h| {
                     let e = expect.remove(0);
                     assert_eq!(h, e);
+                    false
                 })
                 .expect("full decode");
         }


### PR DESCRIPTION
I've ran into a problem that excessive headers still consume CPU even after condition of exceeding `max_header_list_size` is detected. This PR is a proposed fix for that problem. It allows closure passed into `Decoder::decode()` to report that it won't be accepting any more headers thus allowing decoder to return earlier skipping unnecessary memory allocations. I did verify locally that CPU overrun is addressed with this change.