### PR TITLE
fix: close connection when header size is way too large

### DIFF
--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -175,6 +175,13 @@ fn decode_frame(
                     proto_err!(stream: "malformed header block; stream={:?}", id);
                     return Err(Error::library_reset(id, Reason::PROTOCOL_ERROR));
                 },
+                Err(frame::Error::HeaderListWayTooLarge) => {
+                    proto_err!(conn: "decoded header list size over abuse limit");
+                    return Err(Error::library_go_away_data(
+                        Reason::ENHANCE_YOUR_CALM,
+                        "header_list_way_too_large",
+                    ));
+                },
                 Err(e) => {
                     proto_err!(conn: "failed HPACK decoding; err={:?}", e);
                     return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
@@ -346,6 +353,13 @@ fn decode_frame(
                     let id = head.stream_id();
                     proto_err!(stream: "malformed CONTINUATION frame; stream={:?}", id);
                     return Err(Error::library_reset(id, Reason::PROTOCOL_ERROR));
+                }
+                Err(frame::Error::HeaderListWayTooLarge) => {
+                    proto_err!(conn: "decoded CONTINUATION header list size over abuse limit");
+                    return Err(Error::library_go_away_data(
+                        Reason::ENHANCE_YOUR_CALM,
+                        "header_list_way_too_large",
+                    ));
                 }
                 Err(e) => {
                     proto_err!(conn: "failed HPACK decoding; err={:?}", e);

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -10,8 +10,11 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use std::fmt;
 use std::io::Cursor;
+use std::ops::ControlFlow;
 
 type EncodeBuf<'a> = bytes::buf::Limit<&'a mut BytesMut>;
+
+const MAX_HEADER_LIST_ABUSE_MULTIPLIER: usize = 4;
 
 /// Header frame
 ///
@@ -852,7 +855,26 @@ impl HeaderBlock {
     ) -> Result<(), Error> {
         let mut reg = !self.fields.is_empty();
         let mut malformed = false;
+        let mut header_list_way_too_large = false;
         let mut headers_size = self.calculate_header_list_size();
+        let max_header_list_abuse_size =
+            max_header_list_size.saturating_mul(MAX_HEADER_LIST_ABUSE_MULTIPLIER);
+
+        macro_rules! check_size {
+            () => {{
+                if headers_size > max_header_list_abuse_size {
+                    tracing::trace!("load_hpack; header list size over abuse max");
+                    header_list_way_too_large = true;
+                    ControlFlow::Break(())
+                } else {
+                    if headers_size >= max_header_list_size && !self.is_over_size {
+                        tracing::trace!("load_hpack; header list size over max");
+                        self.is_over_size = true;
+                    }
+                    ControlFlow::Continue(())
+                }
+            }};
+        }
 
         macro_rules! set_pseudo {
             ($field:ident, $val:expr) => {{
@@ -866,11 +888,11 @@ impl HeaderBlock {
                     let __val = $val;
                     headers_size +=
                         decoded_header_size(stringify!($field).len() + 1, __val.as_str().len());
-                    if headers_size < max_header_list_size {
+                    if check_size!().is_break() {
+                        return ControlFlow::Break(());
+                    }
+                    if !self.is_over_size {
                         self.pseudo.$field = Some(__val);
-                    } else if !self.is_over_size {
-                        tracing::trace!("load_hpack; header list size over max");
-                        self.is_over_size = true;
                     }
                 }
             }};
@@ -907,19 +929,19 @@ impl HeaderBlock {
                     } else {
                         reg = true;
 
-                        headers_size += decoded_header_size(name.as_str().len(), value.len());
-                        if headers_size < max_header_list_size {
-                            self.field_size +=
-                                decoded_header_size(name.as_str().len(), value.len());
+                        let header_size = decoded_header_size(name.as_str().len(), value.len());
+                        headers_size += header_size;
+                        if check_size!().is_break() {
+                            return ControlFlow::Break(());
+                        }
+                        if !self.is_over_size {
+                            self.field_size += header_size;
                             if let Err(_) = self.fields.try_append(name, value) {
                                 // HeaderMap capacity exceeded — treat as over-size
                                 // so the stream is rejected downstream (RST_STREAM / 431)
                                 // instead of panicking on the 24,577th unique header.
                                 self.is_over_size = true;
                             }
-                        } else if !self.is_over_size {
-                            tracing::trace!("load_hpack; header list size over max");
-                            self.is_over_size = true;
                         }
                     }
                 }
@@ -930,11 +952,21 @@ impl HeaderBlock {
                 Protocol(v) => set_pseudo!(protocol, v),
                 Status(v) => set_pseudo!(status, v),
             }
+
+            ControlFlow::Continue(())
         });
 
-        if let Err(e) = res {
-            tracing::trace!("hpack decoding error; err={:?}", e);
-            return Err(e.into());
+        match res {
+            Ok(()) => {}
+            Err(e) => {
+                tracing::trace!("hpack decoding error; err={:?}", e);
+                return Err(e.into());
+            }
+        }
+
+        if header_list_way_too_large {
+            tracing::trace!("header list way too large; aborting connection");
+            return Err(Error::HeaderListWayTooLarge);
         }
 
         if malformed {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -160,6 +160,9 @@ pub enum Error {
     /// A request or response is malformed.
     MalformedMessage,
 
+    /// The decoded header list was too large to continue processing.
+    HeaderListWayTooLarge,
+
     /// An invalid stream dependency ID was provided
     ///
     /// This is returned if a HEADERS or PRIORITY frame is received with an

--- a/src/fuzz_bridge.rs
+++ b/src/fuzz_bridge.rs
@@ -4,12 +4,13 @@ pub mod fuzz_logic {
     use bytes::BytesMut;
     use http::header::HeaderName;
     use std::io::Cursor;
+    use std::ops::ControlFlow;
 
     pub fn fuzz_hpack(data_: &[u8]) {
         let mut decoder_ = hpack::Decoder::new(0);
         let mut buf = BytesMut::new();
         buf.extend(data_);
-        let _dec_res = decoder_.decode(&mut Cursor::new(&mut buf), |_h| {});
+        let _dec_res = decoder_.decode(&mut Cursor::new(&mut buf), |_h| ControlFlow::Continue(()));
 
         if let Ok(s) = std::str::from_utf8(data_) {
             if let Ok(h) = http::Method::from_bytes(s.as_bytes()) {

--- a/src/hpack/decoder.rs
+++ b/src/hpack/decoder.rs
@@ -9,6 +9,7 @@ use http::status::{self, StatusCode};
 use std::cmp;
 use std::collections::VecDeque;
 use std::io::Cursor;
+use std::ops::ControlFlow;
 use std::str::Utf8Error;
 
 /// Decodes headers using HPACK
@@ -179,7 +180,7 @@ impl Decoder {
         mut f: F,
     ) -> Result<(), DecoderError>
     where
-        F: FnMut(Header),
+        F: FnMut(Header) -> ControlFlow<()>,
     {
         use self::Representation::*;
 
@@ -204,7 +205,9 @@ impl Decoder {
                     can_resize = false;
                     let entry = self.decode_indexed(src)?;
                     consume(src);
-                    f(entry);
+                    if f(entry).is_break() {
+                        break;
+                    }
                 }
                 LiteralWithIndexing => {
                     tracing::trace!(rem = src.remaining(), kind = %"LiteralWithIndexing");
@@ -215,14 +218,18 @@ impl Decoder {
                     self.table.insert(entry.clone());
                     consume(src);
 
-                    f(entry);
+                    if f(entry).is_break() {
+                        break;
+                    }
                 }
                 LiteralWithoutIndexing => {
                     tracing::trace!(rem = src.remaining(), kind = %"LiteralWithoutIndexing");
                     can_resize = false;
                     let entry = self.decode_literal(src, false)?;
                     consume(src);
-                    f(entry);
+                    if f(entry).is_break() {
+                        break;
+                    }
                 }
                 LiteralNeverIndexed => {
                     tracing::trace!(rem = src.remaining(), kind = %"LiteralNeverIndexed");
@@ -232,7 +239,9 @@ impl Decoder {
 
                     // TODO: Track that this should never be indexed
 
-                    f(entry);
+                    if f(entry).is_break() {
+                        break;
+                    }
                 }
                 SizeUpdate => {
                     tracing::trace!(rem = src.remaining(), kind = %"SizeUpdate");
@@ -851,7 +860,8 @@ mod test {
     fn test_decode_empty() {
         let mut de = Decoder::new(0);
         let mut buf = BytesMut::new();
-        let _: () = de.decode(&mut Cursor::new(&mut buf), |_| {}).unwrap();
+        de.decode(&mut Cursor::new(&mut buf), |_| ControlFlow::Continue(()))
+            .unwrap();
     }
 
     #[test]
@@ -867,6 +877,7 @@ mod test {
         let mut res = vec![];
         de.decode(&mut Cursor::new(&mut buf), |h| {
             res.push(h);
+            ControlFlow::Continue(())
         })
         .unwrap();
 
@@ -907,6 +918,7 @@ mod test {
         let e = de
             .decode(&mut Cursor::new(&mut buf), |h| {
                 res.push(h);
+                ControlFlow::Continue(())
             })
             .unwrap_err();
         // decode error because the header value is partial
@@ -916,6 +928,7 @@ mod test {
         buf.extend(&value[1..]);
         de.decode(&mut Cursor::new(&mut buf), |h| {
             res.push(h);
+            ControlFlow::Continue(())
         })
         .unwrap();
 

--- a/src/hpack/test/fixture.rs
+++ b/src/hpack/test/fixture.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::Cursor;
+use std::ops::ControlFlow;
 use std::path::Path;
 use std::str;
 
@@ -78,6 +79,7 @@ fn test_story(story: Value) {
                     let (name, value) = expect.remove(0);
                     assert_eq!(name, key_str(&e));
                     assert_eq!(value, value_str(&e));
+                    ControlFlow::Continue(())
                 })
                 .unwrap();
 
@@ -112,6 +114,7 @@ fn test_story(story: Value) {
             decoder
                 .decode(&mut Cursor::new(&mut buf), |e| {
                     assert_eq!(e, input.remove(0).reify().unwrap());
+                    ControlFlow::Continue(())
                 })
                 .unwrap();
 

--- a/src/hpack/test/fuzz.rs
+++ b/src/hpack/test/fuzz.rs
@@ -9,6 +9,7 @@ use rand::rngs::StdRng;
 use rand::{thread_rng, Rng, SeedableRng};
 
 use std::io::Cursor;
+use std::ops::ControlFlow;
 
 const MAX_CHUNK: usize = 2 * 1024;
 
@@ -170,6 +171,7 @@ impl FuzzHpack {
                 .decode(&mut Cursor::new(&mut buf), |h| {
                     let e = expect.remove(0);
                     assert_eq!(h, e);
+                    ControlFlow::Continue(())
                 })
                 .expect("full decode");
         }

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -827,7 +827,7 @@ async fn recv_too_big_headers() {
 
     let srv = async move {
         let settings = srv.assert_client_handshake().await;
-        assert_frame_eq(settings, frames::settings().max_header_list_size(10));
+        assert_frame_eq(settings, frames::settings().max_header_list_size(40));
         srv.recv_frame(
             frames::headers(1)
                 .request("GET", "https://http2.akamai.com/")
@@ -850,7 +850,7 @@ async fn recv_too_big_headers() {
 
     let client = async move {
         let (mut client, mut conn) = client::Builder::new()
-            .max_header_list_size(10)
+            .max_header_list_size(40)
             .handshake::<_, Bytes>(io)
             .await
             .expect("handshake");

--- a/tests/h2-tests/tests/push_promise.rs
+++ b/tests/h2-tests/tests/push_promise.rs
@@ -237,7 +237,7 @@ async fn recv_push_promise_over_max_header_list_size() {
 
     let srv = async move {
         let settings = srv.assert_client_handshake().await;
-        assert_frame_eq(settings, frames::settings().max_header_list_size(10));
+        assert_frame_eq(settings, frames::settings().max_header_list_size(64));
         srv.recv_frame(
             frames::headers(1)
                 .request("GET", "https://http2.akamai.com/")
@@ -255,7 +255,7 @@ async fn recv_push_promise_over_max_header_list_size() {
 
     let client = async move {
         let (mut client, mut conn) = client::Builder::new()
-            .max_header_list_size(10)
+            .max_header_list_size(64)
             .handshake::<_, Bytes>(io)
             .await
             .expect("handshake");
@@ -265,13 +265,13 @@ async fn recv_push_promise_over_max_header_list_size() {
             .unwrap();
 
         let req = async move {
-            let err = client
+            let resp = client
                 .send_request(request, true)
                 .expect("send_request")
                 .0
                 .await
-                .expect_err("response");
-            assert_eq!(err.reason(), Some(Reason::PROTOCOL_ERROR));
+                .expect("response");
+            assert_eq!(resp.status(), StatusCode::OK);
         };
 
         conn.drive(req).await;

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -976,7 +976,7 @@ async fn too_big_headers_sends_431() {
 
     let client = async move {
         let settings = client.assert_server_handshake().await;
-        assert_frame_eq(settings, frames::settings().max_header_list_size(10));
+        assert_frame_eq(settings, frames::settings().max_header_list_size(64));
         client
             .send_frame(
                 frames::headers(1)
@@ -993,7 +993,7 @@ async fn too_big_headers_sends_431() {
 
     let srv = async move {
         let mut srv = server::Builder::new()
-            .max_header_list_size(10)
+            .max_header_list_size(64)
             .handshake::<_, Bytes>(io)
             .await
             .expect("handshake");
@@ -1012,7 +1012,7 @@ async fn too_big_headers_sends_reset_after_431_if_not_eos() {
 
     let client = async move {
         let settings = client.assert_server_handshake().await;
-        assert_frame_eq(settings, frames::settings().max_header_list_size(10));
+        assert_frame_eq(settings, frames::settings().max_header_list_size(64));
         client
             .send_frame(
                 frames::headers(1)
@@ -1028,13 +1028,50 @@ async fn too_big_headers_sends_reset_after_431_if_not_eos() {
 
     let srv = async move {
         let mut srv = server::Builder::new()
-            .max_header_list_size(10)
+            .max_header_list_size(64)
             .handshake::<_, Bytes>(io)
             .await
             .expect("handshake");
 
         let req = srv.next().await;
         assert!(req.is_none(), "req is {:?}", req);
+    };
+
+    join(client, srv).await;
+}
+
+#[tokio::test]
+async fn abusive_headers_send_goaway() {
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_frame_eq(settings, frames::settings().max_header_list_size(64));
+        client
+            .send_frame(
+                frames::headers(1)
+                    .request("GET", "https://example.com/")
+                    .field("x-abuse", "a".repeat(200))
+                    .eos(),
+            )
+            .await;
+        client
+            .recv_frame(frames::go_away(0).calm().data("header_list_way_too_large"))
+            .await;
+    };
+
+    let srv = async move {
+        let mut srv = server::Builder::new()
+            .max_header_list_size(64)
+            .handshake::<_, Bytes>(io)
+            .await
+            .expect("handshake");
+
+        let err = srv.next().await.unwrap().expect_err("server");
+        assert!(err.is_go_away());
+        assert!(err.is_library());
+        assert_eq!(err.reason(), Some(Reason::ENHANCE_YOUR_CALM));
     };
 
     join(client, srv).await;


### PR DESCRIPTION
Inspired by the problem highlighted in #912, this will now close a connection if decoded headers are "way" too large.

HPACK requires that we keep decoding no matter what. If a set of headers are larger than the configured limit, we stop saving them, mark them oversize, and then send a RST_STREAM about it. But we keep decoding, because the HPACK table is connection-level state.

The size of the table is bounded, so old entries keep getting evicted. That is fine. But it can mean a lot of CPU usage to ignore them.

This PR says `max_header_list_size * 4` is way too big. You go away if you send something way too big.

cc @IgorBelyi this is kind of what I had in mind.