### PR TITLE
Avoid flushing h2 socket while holding stream locks

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -8,12 +8,63 @@ use http::Request;
 
 use std::{
     error::Error,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 
 use tokio::net::{TcpListener, TcpStream};
 
 const NUM_REQUESTS_TO_SEND: usize = 100_000;
+const WRITE_CONTENTION_STREAMS: usize = 512;
+const WRITE_CONTENTION_CHUNKS_PER_STREAM: usize = 128;
+const WRITE_CONTENTION_CHUNK_SIZE: usize = 16 * 1024;
+const WRITE_CONTENTION_WINDOW: u32 = 16 * 1024 * 1024;
+const WRITE_CONTENTION_MAX_FRAME_SIZE: u32 = 64 * 1024;
+const WRITE_CONTENTION_MAX_SEND_BUFFER: usize = 8 * 1024 * 1024;
+const WRITE_CONTENTION_WORKER_THREADS: usize = 4;
+
+#[derive(Clone, Copy)]
+struct WriteContentionConfig {
+    streams: usize,
+    chunks_per_stream: usize,
+    chunk_size: usize,
+}
+
+impl WriteContentionConfig {
+    fn from_env() -> Self {
+        Self {
+            streams: env_usize("H2_WRITE_CONTENTION_STREAMS", WRITE_CONTENTION_STREAMS),
+            chunks_per_stream: env_usize(
+                "H2_WRITE_CONTENTION_CHUNKS_PER_STREAM",
+                WRITE_CONTENTION_CHUNKS_PER_STREAM,
+            ),
+            chunk_size: env_usize(
+                "H2_WRITE_CONTENTION_CHUNK_SIZE",
+                WRITE_CONTENTION_CHUNK_SIZE,
+            ),
+        }
+    }
+
+    fn bytes(&self) -> usize {
+        self.streams * self.chunks_per_stream * self.chunk_size
+    }
+}
+
+fn write_contention_worker_threads() -> usize {
+    env_usize(
+        "H2_WRITE_CONTENTION_WORKER_THREADS",
+        WRITE_CONTENTION_WORKER_THREADS,
+    )
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
 
 // The actual server.
 async fn server(addr: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -111,8 +162,174 @@ async fn send_requests(addr: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+async fn write_contention_benchmark() -> Result<(), Box<dyn Error>> {
+    let config = WriteContentionConfig::from_env();
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+
+    println!(
+        "H2 write contention: {} streams x {} chunks x {}B = {:.1} MiB",
+        config.streams,
+        config.chunks_per_stream,
+        config.chunk_size,
+        config.bytes() as f64 / (1024.0 * 1024.0),
+    );
+
+    tokio::spawn(async move {
+        let (socket, _peer_addr) = listener.accept().await.unwrap();
+        if let Err(e) = serve_write_contention(socket, config).await {
+            println!("write contention server error: {e:?}");
+        }
+    });
+
+    let tcp = TcpStream::connect(addr).await?;
+    let mut builder = client::Builder::new();
+    builder
+        .initial_window_size(WRITE_CONTENTION_WINDOW)
+        .initial_connection_window_size(WRITE_CONTENTION_WINDOW)
+        .max_frame_size(WRITE_CONTENTION_MAX_FRAME_SIZE)
+        .max_concurrent_streams(config.streams as u32)
+        .max_send_buffer_size(WRITE_CONTENTION_MAX_SEND_BUFFER);
+
+    let (client, h2) = builder.handshake::<_, Bytes>(tcp).await?;
+    tokio::spawn(async move {
+        if let Err(e) = h2.await {
+            println!("write contention client connection error: {e:?}");
+        }
+    });
+
+    let mut handles = Vec::with_capacity(config.streams);
+    let started = Instant::now();
+    for _ in 0..config.streams {
+        let client = client.clone();
+        let expected = config.chunks_per_stream * config.chunk_size;
+        handles.push(tokio::spawn(async move {
+            let request = Request::builder().body(()).unwrap();
+            let mut client = client.ready().await.unwrap();
+            let (response, _) = client.send_request(request, true).unwrap();
+            let response = response.await.unwrap();
+            let mut body = response.into_body();
+            let mut received = 0;
+
+            while let Some(chunk) = body.data().await {
+                let chunk = chunk.unwrap();
+                received += chunk.len();
+                let _ = body.flow_control().release_capacity(chunk.len());
+            }
+
+            assert_eq!(received, expected);
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    let elapsed = started.elapsed();
+    let mib = config.bytes() as f64 / (1024.0 * 1024.0);
+    println!("Overall: {}ms.", elapsed.as_millis());
+    println!("Throughput: {:.1} MiB/s", mib / elapsed.as_secs_f64());
+
+    Ok(())
+}
+
+async fn serve_write_contention(
+    socket: TcpStream,
+    config: WriteContentionConfig,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let mut builder = server::Builder::new();
+    builder
+        .initial_window_size(WRITE_CONTENTION_WINDOW)
+        .initial_connection_window_size(WRITE_CONTENTION_WINDOW)
+        .max_frame_size(WRITE_CONTENTION_MAX_FRAME_SIZE)
+        .max_concurrent_streams(config.streams as u32)
+        .max_send_buffer_size(WRITE_CONTENTION_MAX_SEND_BUFFER);
+
+    let mut connection = builder.handshake(socket).await?;
+    while let Some(result) = connection.accept().await {
+        let (request, respond) = result?;
+        tokio::spawn(async move {
+            if let Err(e) = handle_write_contention_request(request, respond, config).await {
+                println!("write contention request error: {e}");
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn handle_write_contention_request(
+    mut request: Request<RecvStream>,
+    mut respond: SendResponse<Bytes>,
+    config: WriteContentionConfig,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let body = request.body_mut();
+    while let Some(data) = body.data().await {
+        let data = data?;
+        let _ = body.flow_control().release_capacity(data.len());
+    }
+
+    let response = http::Response::new(());
+    let mut send = respond.send_response(response, false)?;
+    let chunk = Bytes::from(vec![b'x'; config.chunk_size]);
+
+    for idx in 0..config.chunks_per_stream {
+        let end_of_stream = idx + 1 == config.chunks_per_stream;
+        send_chunk(&mut send, chunk.clone(), end_of_stream).await?;
+    }
+
+    Ok(())
+}
+
+async fn send_chunk(
+    send: &mut h2::SendStream<Bytes>,
+    chunk: Bytes,
+    end_of_stream: bool,
+) -> Result<(), h2::Error> {
+    let len = chunk.len();
+    send.reserve_capacity(len);
+    loop {
+        if send.capacity() >= len {
+            send.send_data(chunk, end_of_stream)?;
+            return Ok(());
+        }
+
+        match (Capacity { send }).await {
+            Some(Ok(_)) => {}
+            Some(Err(err)) => return Err(err),
+            None => return Err(h2::Reason::INTERNAL_ERROR.into()),
+        }
+    }
+}
+
+struct Capacity<'a> {
+    send: &'a mut h2::SendStream<Bytes>,
+}
+
+impl Future for Capacity<'_> {
+    type Output = Option<Result<usize, h2::Error>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.send.poll_capacity(cx)
+    }
+}
+
 fn main() {
     let _ = env_logger::try_init();
+    let bench = std::env::var("H2_BENCH").unwrap_or_else(|_| "all".to_string());
+
+    if bench == "write-contention" {
+        let worker_threads = write_contention_worker_threads();
+        println!("H2 write contention worker threads: {worker_threads}");
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(worker_threads)
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(write_contention_benchmark()).unwrap();
+        return;
+    }
+
     let addr = "127.0.0.1:5928";
     println!("H2 running in current-thread runtime at {addr}:");
     std::thread::spawn(|| {
@@ -145,4 +362,15 @@ fn main() {
         .build()
         .unwrap();
     rt.block_on(send_requests(addr)).unwrap();
+
+    if bench == "all" {
+        let worker_threads = write_contention_worker_threads();
+        println!("H2 write contention worker threads: {worker_threads}");
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(worker_threads)
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(write_contention_benchmark()).unwrap();
+    }
 }

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -120,6 +120,12 @@ where
         Poll::Ready(Ok(()))
     }
 
+    /// Returns whether a frame can be buffered without first flushing the
+    /// underlying I/O object.
+    pub(crate) fn has_capacity(&self) -> bool {
+        self.encoder.has_capacity()
+    }
+
     /// Buffer a frame.
     ///
     /// `poll_ready` must be called first to ensure that a frame may be

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -136,6 +136,12 @@ where
         self.framed_write().poll_ready(cx)
     }
 
+    /// Returns whether the codec can buffer a frame without flushing the
+    /// underlying I/O object.
+    pub(crate) fn has_send_capacity(&mut self) -> bool {
+        self.framed_write().has_capacity()
+    }
+
     /// Buffer a frame.
     ///
     /// `poll_ready` must be called first to ensure that a frame may be

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -31,6 +31,12 @@ use crate::proto::*;
 use bytes::Bytes;
 use std::time::Duration;
 
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum BufferStatus {
+    Complete,
+    CodecFull,
+}
+
 #[derive(Debug)]
 pub struct Config {
     /// Initial maximum number of locally initiated streams.

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -543,6 +543,12 @@ impl Prioritize {
                         self.in_flight_data_frame = InFlightData::DataFrame(frame.payload().stream);
                     }
                     dst.buffer(frame).expect("invalid frame");
+
+                    // Small DATA frames can be fully encoded by `buffer`,
+                    // which records completion in a single codec slot. Reclaim
+                    // before accepting another frame so that slot is not
+                    // overwritten.
+                    self.reclaim_frame(buffer, store, dst);
                 }
                 None => {
                     return Ok(true);

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -10,7 +10,7 @@ use bytes::buf::Take;
 use std::{
     cmp::{self, Ordering},
     fmt, io, mem,
-    task::{Context, Poll, Waker},
+    task::Waker,
 };
 
 /// # Warning
@@ -505,30 +505,30 @@ impl Prioritize {
         }
     }
 
-    pub fn poll_complete<T, B>(
+    pub fn buffer_pending<T, B>(
         &mut self,
-        cx: &mut Context,
         buffer: &mut Buffer<Frame<B>>,
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> Poll<io::Result<()>>
+    ) -> io::Result<bool>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
     {
-        // Ensure codec is ready
-        ready!(dst.poll_ready(cx))?;
-
         // Reclaim any frame that has previously been written
         self.reclaim_frame(buffer, store, dst);
 
         // The max frame length
         let max_frame_len = dst.max_send_frame_size();
 
-        tracing::trace!("poll_complete");
+        tracing::trace!("buffer_pending");
 
         loop {
+            if !dst.has_send_capacity() {
+                return Ok(false);
+            }
+
             if let Some(mut stream) = self.pop_pending_open(store, counts) {
                 self.pending_send.push_front(&mut stream);
                 self.try_assign_capacity(&mut stream);
@@ -543,27 +543,24 @@ impl Prioritize {
                         self.in_flight_data_frame = InFlightData::DataFrame(frame.payload().stream);
                     }
                     dst.buffer(frame).expect("invalid frame");
-
-                    // Ensure the codec is ready to try the loop again.
-                    ready!(dst.poll_ready(cx))?;
-
-                    // Because, always try to reclaim...
-                    self.reclaim_frame(buffer, store, dst);
                 }
                 None => {
-                    // Try to flush the codec.
-                    ready!(dst.flush(cx))?;
-
-                    // This might release a data frame...
-                    if !self.reclaim_frame(buffer, store, dst) {
-                        return Poll::Ready(Ok(()));
-                    }
-
-                    // No need to poll ready as poll_complete() does this for
-                    // us...
+                    return Ok(true);
                 }
             }
         }
+    }
+
+    pub fn reclaim_written_frame<T, B>(
+        &mut self,
+        buffer: &mut Buffer<Frame<B>>,
+        store: &mut Store,
+        dst: &mut Codec<T, Prioritized<B>>,
+    ) -> bool
+    where
+        B: Buf,
+    {
+        self.reclaim_frame(buffer, store, dst)
     }
 
     /// Tries to reclaim a pending data frame from the codec.

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -511,7 +511,7 @@ impl Prioritize {
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> io::Result<bool>
+    ) -> io::Result<BufferStatus>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
@@ -526,7 +526,7 @@ impl Prioritize {
 
         loop {
             if !dst.has_send_capacity() {
-                return Ok(false);
+                return Ok(BufferStatus::CodecFull);
             }
 
             if let Some(mut stream) = self.pop_pending_open(store, counts) {
@@ -551,7 +551,7 @@ impl Prioritize {
                     self.reclaim_frame(buffer, store, dst);
                 }
                 None => {
-                    return Ok(true);
+                    return Ok(BufferStatus::Complete);
                 }
             }
         }

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -1005,15 +1005,16 @@ impl Recv {
     /// Send any pending refusals.
     pub fn send_pending_refusal<T, B>(
         &mut self,
-        cx: &mut Context,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> Poll<io::Result<()>>
+    ) -> io::Result<bool>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
     {
         if let Some(stream_id) = self.refused {
-            ready!(dst.poll_ready(cx))?;
+            if !dst.has_send_capacity() {
+                return Ok(false);
+            }
 
             // Create the RST_STREAM frame
             let frame = frame::Reset::new(stream_id, Reason::REFUSED_STREAM);
@@ -1024,7 +1025,7 @@ impl Recv {
 
         self.refused = None;
 
-        Poll::Ready(Ok(()))
+        Ok(true)
     }
 
     pub fn clear_expired_reset_streams(&mut self, store: &mut Store, counts: &mut Counts) {
@@ -1078,32 +1079,34 @@ impl Recv {
         }
     }
 
-    pub fn poll_complete<T, B>(
+    pub fn buffer_pending<T, B>(
         &mut self,
-        cx: &mut Context,
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> Poll<io::Result<()>>
+    ) -> io::Result<bool>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
     {
         // Send any pending connection level window updates
-        ready!(self.send_connection_window_update(cx, dst))?;
+        if !self.send_connection_window_update(dst)? {
+            return Ok(false);
+        }
 
         // Send any pending stream level window updates
-        ready!(self.send_stream_window_updates(cx, store, counts, dst))?;
+        if !self.send_stream_window_updates(store, counts, dst)? {
+            return Ok(false);
+        }
 
-        Poll::Ready(Ok(()))
+        Ok(true)
     }
 
     /// Send connection level window update
     fn send_connection_window_update<T, B>(
         &mut self,
-        cx: &mut Context,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> Poll<io::Result<()>>
+    ) -> io::Result<bool>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
@@ -1112,7 +1115,9 @@ impl Recv {
             let frame = frame::WindowUpdate::new(StreamId::zero(), incr);
 
             // Ensure the codec has capacity
-            ready!(dst.poll_ready(cx))?;
+            if !dst.has_send_capacity() {
+                return Ok(false);
+            }
 
             // Buffer the WINDOW_UPDATE frame
             dst.buffer(frame.into())
@@ -1124,29 +1129,30 @@ impl Recv {
                 .expect("unexpected flow control state");
         }
 
-        Poll::Ready(Ok(()))
+        Ok(true)
     }
 
     /// Send stream level window update
     pub fn send_stream_window_updates<T, B>(
         &mut self,
-        cx: &mut Context,
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> Poll<io::Result<()>>
+    ) -> io::Result<bool>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
     {
         loop {
             // Ensure the codec has capacity
-            ready!(dst.poll_ready(cx))?;
+            if !dst.has_send_capacity() {
+                return Ok(false);
+            }
 
             // Get the next stream
             let stream = match self.pending_window_updates.pop(store) {
                 Some(stream) => stream,
-                None => return Poll::Ready(Ok(())),
+                None => return Ok(true),
             };
 
             counts.transition(stream, |_, stream| {

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -1006,14 +1006,14 @@ impl Recv {
     pub fn send_pending_refusal<T, B>(
         &mut self,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> io::Result<bool>
+    ) -> io::Result<BufferStatus>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
     {
         if let Some(stream_id) = self.refused {
             if !dst.has_send_capacity() {
-                return Ok(false);
+                return Ok(BufferStatus::CodecFull);
             }
 
             // Create the RST_STREAM frame
@@ -1025,7 +1025,7 @@ impl Recv {
 
         self.refused = None;
 
-        Ok(true)
+        Ok(BufferStatus::Complete)
     }
 
     pub fn clear_expired_reset_streams(&mut self, store: &mut Store, counts: &mut Counts) {
@@ -1084,29 +1084,29 @@ impl Recv {
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> io::Result<bool>
+    ) -> io::Result<BufferStatus>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
     {
         // Send any pending connection level window updates
-        if !self.send_connection_window_update(dst)? {
-            return Ok(false);
+        if self.send_connection_window_update(dst)? == BufferStatus::CodecFull {
+            return Ok(BufferStatus::CodecFull);
         }
 
         // Send any pending stream level window updates
-        if !self.send_stream_window_updates(store, counts, dst)? {
-            return Ok(false);
+        if self.send_stream_window_updates(store, counts, dst)? == BufferStatus::CodecFull {
+            return Ok(BufferStatus::CodecFull);
         }
 
-        Ok(true)
+        Ok(BufferStatus::Complete)
     }
 
     /// Send connection level window update
     fn send_connection_window_update<T, B>(
         &mut self,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> io::Result<bool>
+    ) -> io::Result<BufferStatus>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
@@ -1116,7 +1116,7 @@ impl Recv {
 
             // Ensure the codec has capacity
             if !dst.has_send_capacity() {
-                return Ok(false);
+                return Ok(BufferStatus::CodecFull);
             }
 
             // Buffer the WINDOW_UPDATE frame
@@ -1129,7 +1129,7 @@ impl Recv {
                 .expect("unexpected flow control state");
         }
 
-        Ok(true)
+        Ok(BufferStatus::Complete)
     }
 
     /// Send stream level window update
@@ -1138,7 +1138,7 @@ impl Recv {
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> io::Result<bool>
+    ) -> io::Result<BufferStatus>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
@@ -1146,13 +1146,13 @@ impl Recv {
         loop {
             // Ensure the codec has capacity
             if !dst.has_send_capacity() {
-                return Ok(false);
+                return Ok(BufferStatus::CodecFull);
             }
 
             // Get the next stream
             let stream = match self.pending_window_updates.pop(store) {
                 Some(stream) => stream,
-                None => return Ok(true),
+                None => return Ok(BufferStatus::Complete),
             };
 
             counts.transition(stream, |_, stream| {

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -334,20 +334,30 @@ impl Send {
         Ok(())
     }
 
-    pub fn poll_complete<T, B>(
+    pub fn buffer_pending<T, B>(
         &mut self,
-        cx: &mut Context,
         buffer: &mut Buffer<Frame<B>>,
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> Poll<io::Result<()>>
+    ) -> io::Result<bool>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
     {
-        self.prioritize
-            .poll_complete(cx, buffer, store, counts, dst)
+        self.prioritize.buffer_pending(buffer, store, counts, dst)
+    }
+
+    pub fn reclaim_written_frame<T, B>(
+        &mut self,
+        buffer: &mut Buffer<Frame<B>>,
+        store: &mut Store,
+        dst: &mut Codec<T, Prioritized<B>>,
+    ) -> bool
+    where
+        B: Buf,
+    {
+        self.prioritize.reclaim_written_frame(buffer, store, dst)
     }
 
     /// Request capacity to send data

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -1,6 +1,6 @@
 use super::{
-    store, Buffer, Codec, Config, Counts, Frame, Prioritize, Prioritized, Store, Stream, StreamId,
-    StreamIdOverflow, WindowSize,
+    store, Buffer, BufferStatus, Codec, Config, Counts, Frame, Prioritize, Prioritized, Store,
+    Stream, StreamId, StreamIdOverflow, WindowSize,
 };
 use crate::codec::UserError;
 use crate::frame::{self, Reason};
@@ -340,7 +340,7 @@ impl Send {
         store: &mut Store,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> io::Result<bool>
+    ) -> io::Result<BufferStatus>
     where
         T: AsyncWrite + Unpin,
         B: Buf,

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -197,7 +197,17 @@ where
 
             let status = {
                 let mut me = self.inner.lock().unwrap();
-                me.buffer_pending(&self.send_buffer, dst)?
+                let status = me.buffer_pending(&self.send_buffer, dst)?;
+
+                // Register the task while holding the same lock used to
+                // observe that all pending frames have been buffered. A
+                // producer that queues another frame while the codec is being
+                // flushed will then take and wake this task.
+                if status == BufferStatus::Complete {
+                    me.actions.task = Some(cx.waker().clone());
+                }
+
+                status
             };
 
             match status {
@@ -211,11 +221,7 @@ where
 
             let reclaimed = {
                 let mut me = self.inner.lock().unwrap();
-                let reclaimed = me.reclaim_written_frame(&self.send_buffer, dst);
-                if !reclaimed {
-                    me.actions.task = Some(cx.waker().clone());
-                }
-                reclaimed
+                me.reclaim_written_frame(&self.send_buffer, dst)
             };
 
             if !reclaimed {

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -161,13 +161,17 @@ where
     where
         T: AsyncWrite + Unpin,
     {
-        ready!(dst.poll_ready(cx))?;
+        loop {
+            let status = {
+                let mut me = self.inner.lock().unwrap();
+                let me = &mut *me;
+                me.actions.recv.send_pending_refusal(dst)?
+            };
 
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-        match me.actions.recv.send_pending_refusal(dst)? {
-            BufferStatus::Complete => Poll::Ready(Ok(())),
-            BufferStatus::CodecFull => Poll::Pending,
+            match status {
+                BufferStatus::Complete => return Poll::Ready(Ok(())),
+                BufferStatus::CodecFull => ready!(dst.poll_ready(cx))?,
+            }
         }
     }
 

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1,6 +1,6 @@
 use super::recv::RecvHeaderBlockError;
 use super::store::{self, Entry, Resolve, Store};
-use super::{Buffer, Config, Counts, Prioritized, Recv, Send, Stream, StreamId};
+use super::{Buffer, BufferStatus, Config, Counts, Prioritized, Recv, Send, Stream, StreamId};
 use crate::codec::{Codec, SendError, UserError};
 use crate::ext::Protocol;
 use crate::frame::{self, Frame, Reason};
@@ -165,10 +165,9 @@ where
 
         let mut me = self.inner.lock().unwrap();
         let me = &mut *me;
-        if me.actions.recv.send_pending_refusal(dst)? {
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Pending
+        match me.actions.recv.send_pending_refusal(dst)? {
+            BufferStatus::Complete => Poll::Ready(Ok(())),
+            BufferStatus::CodecFull => Poll::Pending,
         }
     }
 
@@ -192,13 +191,14 @@ where
             // Make any required socket progress before taking stream locks.
             ready!(dst.poll_ready(cx))?;
 
-            let drained = {
+            let status = {
                 let mut me = self.inner.lock().unwrap();
                 me.buffer_pending(&self.send_buffer, dst)?
             };
 
-            if !drained {
-                continue;
+            match status {
+                BufferStatus::Complete => {}
+                BufferStatus::CodecFull => continue,
             }
 
             // Flush any frames staged by `buffer_pending` without holding the
@@ -940,7 +940,7 @@ impl Inner {
         &mut self,
         send_buffer: &SendBuffer<B>,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> io::Result<bool>
+    ) -> io::Result<BufferStatus>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
@@ -952,24 +952,26 @@ impl Inner {
         //
         // TODO: It would probably be better to interleave updates w/ data
         // frames.
-        if !self
+        if self
             .actions
             .recv
             .buffer_pending(&mut self.store, &mut self.counts, dst)?
+            == BufferStatus::CodecFull
         {
-            return Ok(false);
+            return Ok(BufferStatus::CodecFull);
         }
 
         // Send any other pending frames
-        if !self
+        if self
             .actions
             .send
             .buffer_pending(send_buffer, &mut self.store, &mut self.counts, dst)?
+            == BufferStatus::CodecFull
         {
-            return Ok(false);
+            return Ok(BufferStatus::CodecFull);
         }
 
-        Ok(true)
+        Ok(BufferStatus::Complete)
     }
 
     fn reclaim_written_frame<T, B>(

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -161,9 +161,15 @@ where
     where
         T: AsyncWrite + Unpin,
     {
+        ready!(dst.poll_ready(cx))?;
+
         let mut me = self.inner.lock().unwrap();
         let me = &mut *me;
-        me.actions.recv.send_pending_refusal(cx, dst)
+        if me.actions.recv.send_pending_refusal(dst)? {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
     }
 
     pub fn clear_expired_reset_streams(&mut self) {
@@ -182,8 +188,36 @@ where
     where
         T: AsyncWrite + Unpin,
     {
-        let mut me = self.inner.lock().unwrap();
-        me.poll_complete(&self.send_buffer, cx, dst)
+        loop {
+            // Make any required socket progress before taking stream locks.
+            ready!(dst.poll_ready(cx))?;
+
+            let drained = {
+                let mut me = self.inner.lock().unwrap();
+                me.buffer_pending(&self.send_buffer, dst)?
+            };
+
+            if !drained {
+                continue;
+            }
+
+            // Flush any frames staged by `buffer_pending` without holding the
+            // stream-state or send-buffer mutexes.
+            ready!(dst.flush(cx))?;
+
+            let reclaimed = {
+                let mut me = self.inner.lock().unwrap();
+                let reclaimed = me.reclaim_written_frame(&self.send_buffer, dst);
+                if !reclaimed {
+                    me.actions.task = Some(cx.waker().clone());
+                }
+                reclaimed
+            };
+
+            if !reclaimed {
+                return Poll::Ready(Ok(()));
+            }
+        }
     }
 
     pub fn apply_remote_settings(
@@ -902,12 +936,11 @@ impl Inner {
         Ok(())
     }
 
-    fn poll_complete<T, B>(
+    fn buffer_pending<T, B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
-        cx: &mut Context,
         dst: &mut Codec<T, Prioritized<B>>,
-    ) -> Poll<io::Result<()>>
+    ) -> io::Result<bool>
     where
         T: AsyncWrite + Unpin,
         B: Buf,
@@ -919,24 +952,40 @@ impl Inner {
         //
         // TODO: It would probably be better to interleave updates w/ data
         // frames.
-        ready!(self
+        if !self
             .actions
             .recv
-            .poll_complete(cx, &mut self.store, &mut self.counts, dst))?;
+            .buffer_pending(&mut self.store, &mut self.counts, dst)?
+        {
+            return Ok(false);
+        }
 
         // Send any other pending frames
-        ready!(self.actions.send.poll_complete(
-            cx,
-            send_buffer,
-            &mut self.store,
-            &mut self.counts,
-            dst
-        ))?;
+        if !self
+            .actions
+            .send
+            .buffer_pending(send_buffer, &mut self.store, &mut self.counts, dst)?
+        {
+            return Ok(false);
+        }
 
-        // Nothing else to do, track the task
-        self.actions.task = Some(cx.waker().clone());
+        Ok(true)
+    }
 
-        Poll::Ready(Ok(()))
+    fn reclaim_written_frame<T, B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        dst: &mut Codec<T, Prioritized<B>>,
+    ) -> bool
+    where
+        B: Buf,
+    {
+        let mut send_buffer = send_buffer.inner.lock().unwrap();
+        let send_buffer = &mut *send_buffer;
+
+        self.actions
+            .send
+            .reclaim_written_frame(send_buffer, &mut self.store, dst)
     }
 
     fn send_reset<B>(

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -1,7 +1,104 @@
 use futures::{StreamExt, TryStreamExt};
 use h2_support::prelude::*;
 use h2_support::util::yield_once;
+use std::pin::Pin;
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc, Barrier,
+};
+use std::task::{Context, Poll};
 use tokio::sync::oneshot;
+
+const LOST_WAKE_FIRST_DATA: &[u8] = b"lost-wakeup-first-data";
+const LOST_WAKE_SECOND_DATA: &[u8] = b"lost-wakeup-second-data";
+
+#[derive(Clone)]
+struct FlushInterleave {
+    state: Arc<AtomicU8>,
+    entered: Arc<Barrier>,
+    resume: Arc<Barrier>,
+}
+
+impl FlushInterleave {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(0)),
+            entered: Arc::new(Barrier::new(2)),
+            resume: Arc::new(Barrier::new(2)),
+        }
+    }
+
+    fn arm(&self) {
+        assert_eq!(self.state.swap(1, Ordering::SeqCst), 0);
+    }
+
+    fn observe_write(&self, buf: &[u8]) {
+        if buf
+            .windows(LOST_WAKE_FIRST_DATA.len())
+            .any(|window| window == LOST_WAKE_FIRST_DATA)
+        {
+            let _ = self
+                .state
+                .compare_exchange(1, 2, Ordering::SeqCst, Ordering::SeqCst);
+        }
+    }
+
+    fn block_flush(&self) {
+        if self
+            .state
+            .compare_exchange(2, 0, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self.entered.wait();
+            self.resume.wait();
+        }
+    }
+
+    fn wait_for_flush(&self) {
+        self.entered.wait();
+    }
+
+    fn resume_flush(&self) {
+        self.resume.wait();
+    }
+}
+
+struct FlushInterleaveIo {
+    inner: mock::Mock,
+    interleave: FlushInterleave,
+}
+
+impl AsyncRead for FlushInterleaveIo {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio_io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for FlushInterleaveIo {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        this.interleave.observe_write(buf);
+        Pin::new(&mut this.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        this.interleave.block_flush();
+        Pin::new(&mut this.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
 
 // In this case, the stream & connection both have capacity, but capacity is not
 // explicitly requested.
@@ -867,6 +964,75 @@ async fn small_data_frames_reclaimed_before_buffering_next() {
             .await;
         srv.recv_frame(frames::data(1, "hello")).await;
         srv.recv_frame(frames::data(1, "world").eos()).await;
+        srv.send_frame(frames::headers(1).response(204).eos()).await;
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
+async fn send_enqueued_during_unlocked_flush_wakes_connection() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+    let interleave = FlushInterleave::new();
+    let io = FlushInterleaveIo {
+        inner: io,
+        interleave: interleave.clone(),
+    };
+    let (headers_received_tx, headers_received_rx) = oneshot::channel();
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("https://http2.akamai.com/")
+            .body(())
+            .unwrap();
+
+        let (response, mut stream) = client.send_request(request, false).unwrap();
+
+        // Ensure the connection has finished flushing HEADERS and registered
+        // its stream waker before the first DATA frame consumes that waker.
+        h2.drive(headers_received_rx).await.unwrap();
+
+        interleave.arm();
+        stream
+            .send_data(LOST_WAKE_FIRST_DATA.into(), false)
+            .unwrap();
+
+        let producer_interleave = interleave.clone();
+        let producer = thread::spawn(move || {
+            producer_interleave.wait_for_flush();
+            let result = stream.send_data(LOST_WAKE_SECOND_DATA.into(), true);
+            producer_interleave.resume_flush();
+            result.unwrap();
+        });
+
+        let response = {
+            // Suppress unrelated/spurious connection polls so only a wake
+            // registered during the critical flush interval can make progress.
+            let mut woken_h2 = (&mut h2).wakened();
+            tokio::time::timeout(Duration::from_secs(5), woken_h2.drive(response))
+                .await
+                .expect("connection was not woken for DATA queued during flush")
+                .unwrap()
+        };
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        producer.join().unwrap();
+        drop(client);
+        h2.await.unwrap();
+    };
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(frames::headers(1).request("POST", "https://http2.akamai.com/"))
+            .await;
+        headers_received_tx.send(()).unwrap();
+        srv.recv_frame(frames::data(1, LOST_WAKE_FIRST_DATA)).await;
+        srv.recv_frame(frames::data(1, LOST_WAKE_SECOND_DATA).eos())
+            .await;
         srv.send_frame(frames::headers(1).response(204).eos()).await;
     };
 

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -837,6 +837,43 @@ async fn recv_window_update_on_stream_closed_by_data_frame() {
 }
 
 #[tokio::test]
+async fn small_data_frames_reclaimed_before_buffering_next() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("https://http2.akamai.com/")
+            .body(())
+            .unwrap();
+
+        let (response, mut stream) = client.send_request(request, false).unwrap();
+
+        stream.send_data("hello".into(), false).unwrap();
+        stream.send_data("world".into(), true).unwrap();
+
+        let response = h2.drive(response).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        h2.await.unwrap();
+    };
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(frames::headers(1).request("POST", "https://http2.akamai.com/"))
+            .await;
+        srv.recv_frame(frames::data(1, "hello")).await;
+        srv.recv_frame(frames::data(1, "world").eos()).await;
+        srv.send_frame(frames::headers(1).response(204).eos()).await;
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
 async fn reserved_capacity_assigned_in_multi_window_updates() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();


### PR DESCRIPTION
# Avoid flushing h2 socket while holding stream locks

Related: #531

There is also an active broader draft refactor in #917. This PR is intentionally smaller: it targets the specific path discussed in #531 where `Streams::poll_complete` can hold stream/send-buffer locks while the codec flush path reaches the socket.

## Summary

This change splits HTTP/2 stream draining into two phases so the connection task no longer holds the shared stream-state and send-buffer mutexes while flushing or polling writes on the underlying socket.

Previously, `Streams::poll_complete` held `Inner` and `SendBuffer` locks while `Prioritize::poll_complete` could call into `Codec::poll_ready` / `Codec::flush`, which can reach `poll_write_buf` on the socket. Under high write concurrency on one HTTP/2 connection, stream producer tasks contend with the connection task while the connection task is doing I/O progress.

The new flow is:

- ensure codec/socket write readiness before taking stream locks
- lock stream state and buffer pending frames only while the codec has local buffer capacity
- release the locks
- flush the codec/socket
- briefly re-lock to reclaim partially/fully written DATA frames and requeue as needed

The patch also adds a targeted write-contention benchmark that sends many response body chunks concurrently over a single HTTP/2 connection. It can be run with:

```sh
H2_BENCH=write-contention cargo bench --bench main
```

The benchmark is configurable:

```sh
H2_WRITE_CONTENTION_STREAMS=512
H2_WRITE_CONTENTION_CHUNKS_PER_STREAM=128
H2_WRITE_CONTENTION_CHUNK_SIZE=16384
H2_WRITE_CONTENTION_WORKER_THREADS=4
```

## Benchmark

Run environment:

- WSL Ubuntu 24.04
- Rust 1.96.1 stable
- workload: 512 streams x 128 chunks x 16 KiB = 1 GiB over one HTTP/2 connection

Median elapsed time over 3 alternating runs per worker-thread count:

| Worker threads | Baseline median | Patched median | Change |
| ---: | ---: | ---: | ---: |
| 1 | 336 ms | 337 ms | roughly flat |
| 2 | 358 ms | 238 ms | 33.5% faster |
| 4 | 382 ms | 337 ms | 11.8% faster |
| 8 | 407 ms | 340 ms | 16.5% faster |

Median throughput:

| Worker threads | Baseline | Patched |
| ---: | ---: | ---: |
| 1 | 3043 MiB/s | 3038 MiB/s |
| 2 | 2853 MiB/s | 4294 MiB/s |
| 4 | 2679 MiB/s | 3037 MiB/s |
| 8 | 2513 MiB/s | 3004 MiB/s |

The one-worker case is effectively flat, as expected: there is little cross-thread lock contention. The multi-worker runs show the intended effect.

## Testing

```sh
cargo fmt --all --check
cargo check
cargo test -p h2-tests reserved_capacity_assigned_in_multi_window_updates -- --exact --nocapture
cargo test -p h2-tests small_data_frames_reclaimed_before_buffering_next -- --exact
```

The new `small_data_frames_reclaimed_before_buffering_next` regression test fails on the pre-fix PR commit (`3a42547`) with the `in_flight_data_frame` assertion, and passes after reclaiming the DATA frame before buffering another frame.

The write-contention benchmark was run before/after this change in WSL Ubuntu 24.04. On this Windows machine, checking the benchmark target currently stops in the existing `tokio-rustls` dev-dependency chain because `aws-lc-sys` needs additional native build tools (`cmake`/NASM) before it reaches h2 code.
