### PR TITLE
fix: preserve connection task coalescing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,19 +88,6 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
 
-      - name: Pin some dependencies for MSRV
-        run: |
-          cargo update --package tokio-util --precise 0.7.11
-          cargo update --package tokio --precise 1.38.1
-          cargo update --package indexmap --precise 2.11.3
-          cargo update --package hashbrown --precise 0.15.0
-          cargo update --package once_cell --precise 1.20.3
-          cargo update --package tracing --precise 0.1.41
-          cargo update --package tracing-subscriber --precise 0.3.19
-          cargo update --package tracing-core --precise 0.1.33
-          cargo update --package itoa --precise 1.0.15
-
-
       - run: cargo check -p h2
 
   minimal-versions:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,95 @@ jobs:
         run: ./ci/h2spec.sh
         if: matrix.rust == 'stable'
 
+  ztunnel-temporary:
+    name: Temporary ztunnel tests
+    needs: [style]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      RUST_BACKTRACE: full
+      RUST_TEST_THREADS: 4
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo -E
+    steps:
+      - name: Checkout h2
+        uses: actions/checkout@v6
+        with:
+          path: h2
+
+      - name: Checkout ztunnel master
+        uses: actions/checkout@v6
+        with:
+          repository: istio/ztunnel
+          ref: master
+          path: ztunnel
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install diagnostics
+        run: sudo apt-get update && sudo apt-get install -y gdb libssl-dev pkg-config protobuf-compiler
+
+      - name: Print runner details
+        run: |
+          nproc
+          lscpu
+          rustc -vV
+          cargo -vV
+
+      - name: Patch ztunnel to use this h2 checkout
+        working-directory: ztunnel
+        run: |
+          cat >> Cargo.toml <<'EOF'
+
+          [patch.crates-io]
+          h2 = { path = "../h2" }
+          EOF
+          cargo update -p h2
+          cargo tree -i h2
+
+      - name: Run ztunnel test suite with diagnostics
+        working-directory: ztunnel
+        run: |
+          set -Eeuo pipefail
+
+          sudo sysctl kernel.yama.ptrace_scope=0 || true
+
+          dump_state() {
+            echo "::group::process table"
+            date -u
+            ps -eT -o pid,ppid,pgid,lwp,stat,pcpu,pmem,wchan:32,comm,args || true
+            echo "::endgroup::"
+
+            echo "::group::ztunnel test process backtraces"
+            pgrep -af 'out/rust/debug/deps|out/rust/debug/ztunnel|target/debug/deps' || true
+            for pid in $(pgrep -f 'out/rust/debug/deps|out/rust/debug/ztunnel|target/debug/deps' || true); do
+              echo "===== gdb thread backtraces for pid ${pid} ====="
+              sudo gdb -q -batch \
+                -ex 'set pagination off' \
+                -ex 'thread apply all bt' \
+                -p "${pid}" || true
+            done
+            echo "::endgroup::"
+          }
+
+          setsid cargo test --benches --tests --bins &
+          cargo_pid=$!
+          deadline=$((SECONDS + 25 * 60))
+
+          while kill -0 "${cargo_pid}" 2>/dev/null; do
+            if (( SECONDS >= deadline )); then
+              echo "::error::ztunnel cargo test timed out after 25 minutes"
+              dump_state
+              kill -TERM "-${cargo_pid}" 2>/dev/null || true
+              sleep 5
+              kill -KILL "-${cargo_pid}" 2>/dev/null || true
+              exit 124
+            fi
+            sleep 10
+          done
+
+          wait "${cargo_pid}"
+
   #clippy_check:
   #  runs-on: ubuntu-latest
   #  steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ readme = "README.md"
 keywords = ["http", "async", "non-blocking"]
 categories = ["asynchronous", "web-programming", "network-programming"]
 exclude = ["fixtures/**", "ci/**"]
-edition = "2021"
-rust-version = "1.63"
+edition = "2024"
+rust-version = "1.85"
 
 [features]
 # Enables `futures::Stream` implementations for various types.

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,8 +1,7 @@
 use bytes::Bytes;
 use h2::{
-    client,
+    RecvStream, client,
     server::{self, SendResponse},
-    RecvStream,
 };
 use http::Request;
 

--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -3,7 +3,7 @@ use http::{Method, Request};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector;
 
-use tokio_rustls::rustls::{pki_types::ServerName, RootCertStore};
+use tokio_rustls::rustls::{RootCertStore, pki_types::ServerName};
 
 use std::error::Error;
 use std::net::ToSocketAddrs;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use bytes::Bytes;
-use h2::server::{self, SendResponse};
 use h2::RecvStream;
+use h2::server::{self, SendResponse};
 use http::Request;
 use tokio::net::{TcpListener, TcpStream};
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -142,7 +142,7 @@ use crate::proto::{self, Error};
 use crate::{FlowControl, PingPong, RecvStream, SendStream};
 
 use bytes::{Buf, Bytes};
-use http::{uri, HeaderMap, Method, Request, Response, Version};
+use http::{HeaderMap, Method, Request, Response, Version, uri};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -173,7 +173,7 @@ use tracing::Instrument;
 /// [`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html
 /// [`Error`]: ../struct.Error.html
 pub struct SendRequest<B: Buf> {
-    inner: proto::Streams<B, Peer>,
+    inner: proto::Injector<B>,
     pending: Option<proto::OpaqueStreamRef>,
 }
 
@@ -515,10 +515,10 @@ where
         end_of_stream: bool,
     ) -> Result<(ResponseFuture, SendStream<B>), crate::Error> {
         self.inner
-            .send_request(request, end_of_stream, self.pending.as_ref())
+            .enqueue_request(request, end_of_stream, self.pending.as_ref())
             .map_err(Into::into)
-            .map(|(stream, is_full)| {
-                if stream.is_pending_open() && is_full {
+            .map(|stream| {
+                if stream.is_pending_open() {
                     // Only prevent sending another request when the request queue
                     // is not full.
                     self.pending = Some(stream.clone_to_opaque());
@@ -1220,7 +1220,7 @@ impl Builder {
     pub fn handshake<T, B>(
         &self,
         io: T,
-    ) -> impl Future<Output = Result<(SendRequest<B>, Connection<T, B>), crate::Error>>
+    ) -> impl Future<Output = Result<(SendRequest<B>, Connection<T, B>), crate::Error>> + use<T, B>
     where
         T: AsyncRead + AsyncWrite + Unpin,
         B: Buf,
@@ -1338,7 +1338,7 @@ where
             },
         );
         let send_request = SendRequest {
-            inner: inner.streams().clone(),
+            inner: inner.injector(),
             pending: None,
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -163,13 +163,13 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let debug_data = match self.kind {
             Kind::Reset(_, reason, Initiator::User) => {
-                return write!(fmt, "stream error sent by user: {}", reason)
+                return write!(fmt, "stream error sent by user: {}", reason);
             }
             Kind::Reset(_, reason, Initiator::Library) => {
-                return write!(fmt, "stream error detected: {}", reason)
+                return write!(fmt, "stream error detected: {}", reason);
             }
             Kind::Reset(_, reason, Initiator::Remote) => {
-                return write!(fmt, "stream error received: {}", reason)
+                return write!(fmt, "stream error received: {}", reason);
             }
             Kind::GoAway(ref debug_data, reason, Initiator::User) => {
                 write!(fmt, "connection error sent by user: {}", reason)?;

--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -1,4 +1,4 @@
-use crate::frame::{util, Error, Frame, Head, Kind, StreamId};
+use crate::frame::{Error, Frame, Head, Kind, StreamId, util};
 use bytes::{Buf, BufMut, Bytes};
 
 use std::fmt;

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -1,10 +1,10 @@
-use super::{util, StreamDependency, StreamId};
+use super::{StreamDependency, StreamId, util};
 use crate::ext::Protocol;
 use crate::frame::{Error, Frame, Head, Kind};
 use crate::hpack::{self, BytesStr};
 
 use http::header::{self, HeaderName, HeaderValue};
-use http::{uri, HeaderMap, Method, Request, StatusCode, Uri};
+use http::{HeaderMap, Method, Request, StatusCode, Uri, uri};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -1032,7 +1032,7 @@ fn decoded_header_size(name: usize, value: usize) -> usize {
 mod test {
     use super::*;
     use crate::frame;
-    use crate::hpack::{huffman, Encoder};
+    use crate::hpack::{Encoder, huffman};
 
     #[test]
     fn test_nameless_header_at_resume() {
@@ -1072,9 +1072,11 @@ mod test {
 
         dst.clear();
 
-        assert!(continuation
-            .encode(&mut (&mut dst).limit(frame::HEADER_LEN + 16))
-            .is_none());
+        assert!(
+            continuation
+                .encode(&mut (&mut dst).limit(frame::HEADER_LEN + 16))
+                .is_none()
+        );
 
         world.extend_from_slice(&dst[9..12]);
         assert_eq!("world", huff_decode(&world));

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -52,7 +52,7 @@ pub use self::data::Data;
 pub use self::go_away::GoAway;
 pub use self::head::{Head, Kind};
 pub use self::headers::{
-    parse_u64, Continuation, Headers, Pseudo, PushPromise, PushPromiseHeaderError,
+    Continuation, Headers, Pseudo, PushPromise, PushPromiseHeaderError, parse_u64,
 };
 pub use self::ping::Ping;
 pub use self::priority::{Priority, StreamDependency};

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::frame::{util, Error, Frame, FrameSize, Head, Kind, StreamId};
+use crate::frame::{Error, Frame, FrameSize, Head, Kind, StreamId, util};
 use bytes::{BufMut, BytesMut};
 
 #[derive(Clone, Default, Eq, PartialEq)]

--- a/src/hpack/decoder.rs
+++ b/src/hpack/decoder.rs
@@ -1,4 +1,4 @@
-use super::{header::BytesStr, huffman, Header};
+use super::{Header, header::BytesStr, huffman};
 use crate::frame;
 
 use bytes::{Buf, Bytes, BytesMut};

--- a/src/hpack/encoder.rs
+++ b/src/hpack/encoder.rs
@@ -1,5 +1,5 @@
 use super::table::{Index, Table};
-use super::{huffman, Header};
+use super::{Header, huffman};
 
 use bytes::{BufMut, BytesMut};
 use http::header::{HeaderName, HeaderValue};

--- a/src/hpack/test/fixture.rs
+++ b/src/hpack/test/fixture.rs
@@ -5,8 +5,8 @@ use hex::FromHex;
 use serde_json::Value;
 
 use std::fs::File;
-use std::io::prelude::*;
 use std::io::Cursor;
+use std::io::prelude::*;
 use std::ops::ControlFlow;
 use std::path::Path;
 use std::str;

--- a/src/hpack/test/fuzz.rs
+++ b/src/hpack/test/fuzz.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use rand::distributions::Slice;
 use rand::rngs::StdRng;
-use rand::{thread_rng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, thread_rng};
 
 use std::io::Cursor;
 use std::ops::ControlFlow;
@@ -182,7 +182,7 @@ impl FuzzHpack {
 
 impl Arbitrary for FuzzHpack {
     fn arbitrary(_: &mut Gen) -> Self {
-        FuzzHpack::new(thread_rng().gen())
+        FuzzHpack::new(thread_rng().r#gen())
     }
 }
 
@@ -234,7 +234,7 @@ fn gen_header(g: &mut StdRng) -> Header<Option<HeaderName>> {
                 Header::Path(to_shared(value))
             }
             4 => {
-                let status = (g.gen::<u16>() % 500) + 100;
+                let status = (g.r#gen::<u16>() % 500) + 100;
 
                 Header::Status(StatusCode::from_u16(status).unwrap())
             }

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -192,10 +192,11 @@ where
         // The order of these calls don't really matter too much
         ready!(self.inner.ping_pong.send_pending_pong(cx, &mut self.codec))?;
         ready!(self.inner.ping_pong.send_pending_ping(cx, &mut self.codec))?;
-        ready!(self
-            .inner
-            .settings
-            .poll_send(cx, &mut self.codec, &mut self.inner.streams))?;
+        ready!(
+            self.inner
+                .settings
+                .poll_send(cx, &mut self.codec, &mut self.inner.streams)
+        )?;
         ready!(self.inner.streams.send_pending_refusal(cx, &mut self.codec))?;
 
         Poll::Ready(Ok(()))
@@ -589,8 +590,8 @@ where
     T: AsyncRead + AsyncWrite,
     B: Buf,
 {
-    pub(crate) fn streams(&self) -> &Streams<B, client::Peer> {
-        &self.inner.streams
+    pub(crate) fn injector(&self) -> super::Injector<B> {
+        self.inner.streams.injector()
     }
 }
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use self::connection::{Config, Connection};
 pub use self::error::{Error, Initiator};
 pub(crate) use self::peer::{Dyn as DynPeer, Peer};
 pub(crate) use self::ping_pong::UserPings;
-pub(crate) use self::streams::{DynStreams, OpaqueStreamRef, StreamRef, Streams};
+pub(crate) use self::streams::{DynStreams, Injector, OpaqueStreamRef, StreamRef, Streams};
 pub(crate) use self::streams::{Open, PollReset, Prioritized};
 
 use crate::codec::Codec;

--- a/src/proto/ping_pong.rs
+++ b/src/proto/ping_pong.rs
@@ -5,8 +5,8 @@ use crate::proto::{self, PingPayload};
 use atomic_waker::AtomicWaker;
 use bytes::Buf;
 use std::io;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll};
 use tokio::io::AsyncWrite;
 

--- a/src/proto/streams/buffer.rs
+++ b/src/proto/streams/buffer.rs
@@ -12,6 +12,12 @@ pub struct Deque {
     indices: Option<Indices>,
 }
 
+#[derive(Debug)]
+pub struct Iter<'a, T> {
+    buf: &'a Buffer<T>,
+    next: Option<usize>,
+}
+
 /// Tracks the head & tail for a sequence of frames in a `Buffer`.
 #[derive(Debug, Default, Copy, Clone)]
 struct Indices {
@@ -42,6 +48,13 @@ impl Deque {
 
     pub fn is_empty(&self) -> bool {
         self.indices.is_none()
+    }
+
+    pub fn iter<'a, T>(&'a self, buf: &'a Buffer<T>) -> Iter<'a, T> {
+        Iter {
+            buf,
+            next: self.indices.map(|idxs| idxs.head),
+        }
     }
 
     pub fn push_back<T>(&mut self, buf: &mut Buffer<T>, value: T) {
@@ -95,5 +108,16 @@ impl Deque {
             }
             None => None,
         }
+    }
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let key = self.next?;
+        let slot = &self.buf.slab[key];
+        self.next = slot.next;
+        Some(&slot.value)
     }
 }

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -1,22 +1,29 @@
 use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+#[derive(Debug)]
+pub(super) struct Shared {
+    /// Maximum number of locally initiated streams
+    max_send_streams: AtomicUsize,
+
+    /// Current number of remote initiated streams
+    num_send_streams: AtomicUsize,
+
+    /// Maximum number of remote initiated streams
+    max_recv_streams: AtomicUsize,
+
+    /// Current number of locally initiated streams
+    num_recv_streams: AtomicUsize,
+
+    /// Current number of streams that are held in memory.
+    num_wired_streams: AtomicUsize,
+}
 
 #[derive(Debug)]
 pub(super) struct Counts {
     /// Acting as a client or server. This allows us to track which values to
     /// inc / dec.
     peer: peer::Dyn,
-
-    /// Maximum number of locally initiated streams
-    max_send_streams: usize,
-
-    /// Current number of remote initiated streams
-    num_send_streams: usize,
-
-    /// Maximum number of remote initiated streams
-    max_recv_streams: usize,
-
-    /// Current number of locally initiated streams
-    num_recv_streams: usize,
 
     /// Maximum number of pending locally reset streams
     max_local_reset_streams: usize,
@@ -46,10 +53,6 @@ impl Counts {
     pub fn new(peer: peer::Dyn, config: &Config) -> Self {
         Counts {
             peer,
-            max_send_streams: config.initial_max_send_streams,
-            num_send_streams: 0,
-            max_recv_streams: config.remote_max_initiated.unwrap_or(usize::MAX),
-            num_recv_streams: 0,
             max_local_reset_streams: config.local_reset_max,
             num_local_reset_streams: 0,
             max_remote_reset_streams: config.remote_reset_max,
@@ -59,21 +62,13 @@ impl Counts {
         }
     }
 
-    /// Returns true when the next opened stream will reach capacity of outbound streams
-    ///
-    /// The number of client send streams is incremented in prioritize; send_request has to guess if
-    /// it should wait before allowing another request to be sent.
-    pub fn next_send_stream_will_reach_capacity(&self) -> bool {
-        self.max_send_streams <= (self.num_send_streams + 1)
-    }
-
     /// Returns the current peer
     pub fn peer(&self) -> peer::Dyn {
         self.peer
     }
 
-    pub fn has_streams(&self) -> bool {
-        self.num_send_streams != 0 || self.num_recv_streams != 0
+    pub fn has_streams(&self, shared: &Shared) -> bool {
+        shared.has_streams()
     }
 
     /// Returns true if we can issue another local reset due to protocol error.
@@ -97,8 +92,8 @@ impl Counts {
     }
 
     /// Returns true if the receive stream concurrency can be incremented
-    pub fn can_inc_num_recv_streams(&self) -> bool {
-        self.max_recv_streams > self.num_recv_streams
+    pub fn can_inc_num_recv_streams(&self, shared: &Shared) -> bool {
+        shared.max_recv_streams() > shared.num_recv_streams()
     }
 
     /// Increments the number of concurrent receive streams.
@@ -106,18 +101,18 @@ impl Counts {
     /// # Panics
     ///
     /// Panics on failure as this should have been validated before hand.
-    pub fn inc_num_recv_streams(&mut self, stream: &mut store::Ptr) {
-        assert!(self.can_inc_num_recv_streams());
-        assert!(!stream.is_counted);
+    pub fn inc_num_recv_streams(&mut self, shared: &Shared, stream: &mut store::Ptr) {
+        assert!(self.can_inc_num_recv_streams(shared));
+        assert!(!stream.inner().is_counted);
 
         // Increment the number of remote initiated streams
-        self.num_recv_streams += 1;
-        stream.is_counted = true;
+        shared.inc_num_recv_streams();
+        stream.inner_mut().is_counted = true;
     }
 
     /// Returns true if the send stream concurrency can be incremented
-    pub fn can_inc_num_send_streams(&self) -> bool {
-        self.max_send_streams > self.num_send_streams
+    pub fn can_inc_num_send_streams(&self, shared: &Shared) -> bool {
+        shared.max_send_streams() > shared.num_send_streams()
     }
 
     /// Increments the number of concurrent send streams.
@@ -125,13 +120,13 @@ impl Counts {
     /// # Panics
     ///
     /// Panics on failure as this should have been validated before hand.
-    pub fn inc_num_send_streams(&mut self, stream: &mut store::Ptr) {
-        assert!(self.can_inc_num_send_streams());
-        assert!(!stream.is_counted);
+    pub fn inc_num_send_streams(&mut self, shared: &Shared, stream: &mut store::Ptr) {
+        assert!(self.can_inc_num_send_streams(shared));
+        assert!(!stream.inner().is_counted);
 
         // Increment the number of remote initiated streams
-        self.num_send_streams += 1;
-        stream.is_counted = true;
+        shared.inc_num_send_streams();
+        stream.inner_mut().is_counted = true;
     }
 
     /// Returns true if the number of pending reset streams can be incremented.
@@ -177,10 +172,15 @@ impl Counts {
         self.num_remote_reset_streams -= 1;
     }
 
-    pub fn apply_remote_settings(&mut self, settings: &frame::Settings, is_initial: bool) {
+    pub fn apply_remote_settings(
+        &mut self,
+        shared: &Shared,
+        settings: &frame::Settings,
+        is_initial: bool,
+    ) {
         match settings.max_concurrent_streams() {
-            Some(val) => self.max_send_streams = val as usize,
-            None if is_initial => self.max_send_streams = usize::MAX,
+            Some(val) => shared.set_max_send_streams(val as usize),
+            None if is_initial => shared.set_max_send_streams(usize::MAX),
             None => {}
         }
     }
@@ -191,7 +191,7 @@ impl Counts {
     /// all necessary cleanup.
     ///
     /// TODO: Is this function still needed?
-    pub fn transition<F, U>(&mut self, mut stream: store::Ptr, f: F) -> U
+    pub fn transition<F, U>(&mut self, shared: &Shared, mut stream: store::Ptr, f: F) -> U
     where
         F: FnOnce(&mut Self, &mut store::Ptr) -> U,
     {
@@ -201,27 +201,38 @@ impl Counts {
         // Run the action
         let ret = f(self, &mut stream);
 
-        self.transition_after(stream, is_pending_reset);
+        self.transition_after(shared, stream, is_pending_reset);
 
         ret
     }
 
     // TODO: move this to macro?
-    pub fn transition_after(&mut self, mut stream: store::Ptr, is_reset_counted: bool) {
+    pub fn transition_after(
+        &mut self,
+        shared: &Shared,
+        mut stream: store::Ptr,
+        is_reset_counted: bool,
+    ) {
+        let is_closed = stream.is_closed();
+        let state = stream.shared().state.clone();
+        let (pending_send_empty, buffered_send_data) = {
+            let send = stream.send();
+            (send.pending_send.is_empty(), send.buffered_send_data)
+        };
         tracing::trace!(
             "transition_after; stream={:?}; state={:?}; is_closed={:?}; \
              pending_send_empty={:?}; buffered_send_data={}; \
-             num_recv={}; num_send={}",
+            num_recv={}; num_send={}",
             stream.id,
-            stream.state,
-            stream.is_closed(),
-            stream.pending_send.is_empty(),
-            stream.buffered_send_data,
-            self.num_recv_streams,
-            self.num_send_streams
+            state,
+            is_closed,
+            pending_send_empty,
+            buffered_send_data,
+            shared.num_recv_streams(),
+            shared.num_send_streams()
         );
 
-        if stream.is_closed() {
+        if is_closed && !stream.shared().is_pending_push {
             if !stream.is_pending_reset_expiration() {
                 stream.unlink();
                 if is_reset_counted {
@@ -229,42 +240,48 @@ impl Counts {
                 }
             }
 
-            if !stream.state.is_scheduled_reset() && stream.is_counted {
+            let should_dec_num_streams = {
+                let is_scheduled_reset = stream.shared().state.is_scheduled_reset();
+                !is_scheduled_reset && stream.inner().is_counted
+            };
+
+            if should_dec_num_streams {
                 tracing::trace!("dec_num_streams; stream={:?}", stream.id);
                 // Decrement the number of active streams.
-                self.dec_num_streams(&mut stream);
+                self.dec_num_streams(shared, &mut stream);
             }
         }
 
         // Release the stream if it requires releasing
         if stream.is_released() {
             stream.remove();
+            shared.dec_num_wired_streams();
         }
     }
 
     /// Returns the maximum number of streams that can be initiated by this
     /// peer.
-    pub(crate) fn max_send_streams(&self) -> usize {
-        self.max_send_streams
+    pub(crate) fn max_send_streams(&self, shared: &Shared) -> usize {
+        shared.max_send_streams()
     }
 
     /// Returns the maximum number of streams that can be initiated by the
     /// remote peer.
-    pub(crate) fn max_recv_streams(&self) -> usize {
-        self.max_recv_streams
+    pub(crate) fn max_recv_streams(&self, shared: &Shared) -> usize {
+        shared.max_recv_streams()
     }
 
-    fn dec_num_streams(&mut self, stream: &mut store::Ptr) {
-        assert!(stream.is_counted);
+    fn dec_num_streams(&mut self, shared: &Shared, stream: &mut store::Ptr) {
+        assert!(stream.inner().is_counted);
 
         if self.peer.is_local_init(stream.id) {
-            assert!(self.num_send_streams > 0);
-            self.num_send_streams -= 1;
-            stream.is_counted = false;
+            assert!(shared.num_send_streams() > 0);
+            shared.dec_num_send_streams();
+            stream.inner_mut().is_counted = false;
         } else {
-            assert!(self.num_recv_streams > 0);
-            self.num_recv_streams -= 1;
-            stream.is_counted = false;
+            assert!(shared.num_recv_streams() > 0);
+            shared.dec_num_recv_streams();
+            stream.inner_mut().is_counted = false;
         }
     }
 
@@ -274,12 +291,76 @@ impl Counts {
     }
 }
 
-impl Drop for Counts {
-    fn drop(&mut self) {
-        use std::thread;
-
-        if !thread::panicking() {
-            debug_assert!(!self.has_streams());
+impl Shared {
+    pub fn new(config: &Config) -> Self {
+        Shared {
+            max_send_streams: AtomicUsize::new(config.initial_max_send_streams),
+            num_send_streams: AtomicUsize::new(0),
+            max_recv_streams: AtomicUsize::new(config.remote_max_initiated.unwrap_or(usize::MAX)),
+            num_recv_streams: AtomicUsize::new(0),
+            num_wired_streams: AtomicUsize::new(0),
         }
+    }
+
+    pub fn has_streams(&self) -> bool {
+        self.num_send_streams() != 0 || self.num_recv_streams() != 0
+    }
+
+    pub fn max_send_streams(&self) -> usize {
+        self.max_send_streams.load(AtomicOrdering::Relaxed)
+    }
+
+    pub fn set_max_send_streams(&self, val: usize) {
+        self.max_send_streams.store(val, AtomicOrdering::Relaxed);
+    }
+
+    pub fn num_send_streams(&self) -> usize {
+        self.num_send_streams.load(AtomicOrdering::Relaxed)
+    }
+
+    pub fn inc_num_send_streams(&self) {
+        self.num_send_streams.fetch_add(1, AtomicOrdering::Relaxed);
+    }
+
+    pub fn dec_num_send_streams(&self) {
+        self.num_send_streams.fetch_sub(1, AtomicOrdering::Relaxed);
+    }
+
+    pub fn max_recv_streams(&self) -> usize {
+        self.max_recv_streams.load(AtomicOrdering::Relaxed)
+    }
+
+    pub fn num_recv_streams(&self) -> usize {
+        self.num_recv_streams.load(AtomicOrdering::Relaxed)
+    }
+
+    pub fn inc_num_recv_streams(&self) {
+        self.num_recv_streams.fetch_add(1, AtomicOrdering::Relaxed);
+    }
+
+    pub fn dec_num_recv_streams(&self) {
+        self.num_recv_streams.fetch_sub(1, AtomicOrdering::Relaxed);
+    }
+
+    #[cfg(feature = "unstable")]
+    pub fn num_active_streams(&self) -> usize {
+        self.num_send_streams() + self.num_recv_streams()
+    }
+
+    pub fn current_max_recv_streams(&self) -> usize {
+        self.max_recv_streams()
+    }
+
+    #[cfg(feature = "unstable")]
+    pub fn num_wired_streams(&self) -> usize {
+        self.num_wired_streams.load(AtomicOrdering::Relaxed)
+    }
+
+    pub fn inc_num_wired_streams(&self) {
+        self.num_wired_streams.fetch_add(1, AtomicOrdering::Relaxed);
+    }
+
+    pub fn dec_num_wired_streams(&self) {
+        self.num_wired_streams.fetch_sub(1, AtomicOrdering::Relaxed);
     }
 }

--- a/src/proto/streams/flow_control.rs
+++ b/src/proto/streams/flow_control.rs
@@ -1,5 +1,5 @@
 use crate::frame::Reason;
-use crate::proto::{WindowSize, MAX_WINDOW_SIZE};
+use crate::proto::{MAX_WINDOW_SIZE, WindowSize};
 
 use std::fmt;
 
@@ -200,11 +200,7 @@ pub struct Window(i32);
 
 impl Window {
     pub fn as_size(&self) -> WindowSize {
-        if self.0 < 0 {
-            0
-        } else {
-            self.0 as WindowSize
-        }
+        if self.0 < 0 { 0 } else { self.0 as WindowSize }
     }
 
     pub fn checked_size(&self) -> WindowSize {

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -13,7 +13,7 @@ mod streams;
 pub(crate) use self::prioritize::Prioritized;
 pub(crate) use self::recv::Open;
 pub(crate) use self::send::PollReset;
-pub(crate) use self::streams::{DynStreams, OpaqueStreamRef, StreamRef, Streams};
+pub(crate) use self::streams::{DynStreams, Injector, OpaqueStreamRef, StreamRef, Streams};
 
 use self::buffer::Buffer;
 use self::counts::Counts;
@@ -94,11 +94,7 @@ trait DebugStructExt<'a, 'b> {
 
 impl<'a, 'b> DebugStructExt<'a, 'b> for std::fmt::DebugStruct<'a, 'b> {
     fn h2_field_if(&mut self, name: &str, val: &bool) -> &mut std::fmt::DebugStruct<'a, 'b> {
-        if *val {
-            self.field(name, val)
-        } else {
-            self
-        }
+        if *val { self.field(name, val) } else { self }
     }
 
     fn h2_field_if_then<T: std::fmt::Debug>(
@@ -107,11 +103,7 @@ impl<'a, 'b> DebugStructExt<'a, 'b> for std::fmt::DebugStruct<'a, 'b> {
         cond: bool,
         val: &T,
     ) -> &mut std::fmt::DebugStruct<'a, 'b> {
-        if cond {
-            self.field(name, val)
-        } else {
-            self
-        }
+        if cond { self.field(name, val) } else { self }
     }
 
     fn h2_field_some<T: std::fmt::Debug>(

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -1,16 +1,15 @@
+use super::counts;
 use super::store::Resolve;
+use super::streams::ConnWaker;
 use super::*;
 
 use crate::frame::Reason;
-
-use crate::codec::UserError;
-use crate::codec::UserError::*;
 
 use bytes::buf::Take;
 use std::{
     cmp::{self, Ordering},
     fmt, io, mem,
-    task::{Context, Poll, Waker},
+    task::{Context, Poll},
 };
 
 /// # Warning
@@ -104,26 +103,22 @@ impl Prioritize {
         }
     }
 
-    pub(crate) fn max_buffer_size(&self) -> usize {
-        self.max_buffer_size
-    }
-
     /// Queue a frame to be sent to the remote
     pub fn queue_frame<B>(
         &mut self,
         frame: Frame<B>,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
-        task: &mut Option<Waker>,
+        conn_task: &ConnWaker,
     ) {
         let span = tracing::trace_span!("Prioritize::queue_frame", ?stream.id);
         let _e = span.enter();
         // Queue the frame in the buffer
-        stream.pending_send.push_back(buffer, frame);
-        self.schedule_send(stream, task);
+        stream.send().pending_send.push_back(buffer, frame);
+        self.schedule_send(stream, conn_task);
     }
 
-    pub fn schedule_send(&mut self, stream: &mut store::Ptr, task: &mut Option<Waker>) {
+    pub fn schedule_send(&mut self, stream: &mut store::Ptr, conn_task: &ConnWaker) {
         // If the stream is waiting to be opened, nothing more to do.
         if stream.is_send_ready() {
             tracing::trace!(?stream.id, "schedule_send");
@@ -131,94 +126,13 @@ impl Prioritize {
             self.pending_send.push(stream);
 
             // Notify the connection.
-            if let Some(task) = task.take() {
-                task.wake();
-            }
+            conn_task.wake();
         }
     }
 
     pub fn queue_open(&mut self, stream: &mut store::Ptr) {
+        stream.send().is_pending_open = true;
         self.pending_open.push(stream);
-    }
-
-    /// Send a data frame
-    pub fn send_data<B>(
-        &mut self,
-        frame: frame::Data<B>,
-        buffer: &mut Buffer<Frame<B>>,
-        stream: &mut store::Ptr,
-        counts: &mut Counts,
-        task: &mut Option<Waker>,
-    ) -> Result<(), UserError>
-    where
-        B: Buf,
-    {
-        let sz = frame.payload().remaining();
-
-        if sz > MAX_WINDOW_SIZE as usize {
-            return Err(UserError::PayloadTooBig);
-        }
-
-        let sz = sz as WindowSize;
-
-        if !stream.state.is_send_streaming() {
-            if stream.state.is_closed() {
-                return Err(InactiveStreamId);
-            } else {
-                return Err(UnexpectedFrameType);
-            }
-        }
-
-        // Update the buffered data counter
-        stream.buffered_send_data += sz as usize;
-
-        let span =
-            tracing::trace_span!("send_data", sz, requested = stream.requested_send_capacity);
-        let _e = span.enter();
-        tracing::trace!(buffered = stream.buffered_send_data);
-
-        // Implicitly request more send capacity if not enough has been
-        // requested yet.
-        if (stream.requested_send_capacity as usize) < stream.buffered_send_data {
-            // Update the target requested capacity
-            stream.requested_send_capacity =
-                cmp::min(stream.buffered_send_data, WindowSize::MAX as usize) as WindowSize;
-
-            // `try_assign_capacity` will queue the stream to `pending_capacity` if the capcaity
-            // cannot be assigned at the time it is called.
-            self.try_assign_capacity(stream);
-        }
-
-        if frame.is_end_stream() {
-            stream.state.send_close();
-            self.reserve_capacity(0, stream, counts);
-        }
-
-        tracing::trace!(
-            available = %stream.send_flow.available(),
-            buffered = stream.buffered_send_data,
-        );
-
-        // The `stream.buffered_send_data == 0` check is here so that, if a zero
-        // length data frame is queued to the front (there is no previously
-        // queued data), it gets sent out immediately even if there is no
-        // available send window.
-        //
-        // Sending out zero length data frames can be done to signal
-        // end-of-stream.
-        //
-        if stream.send_flow.available() > 0 || stream.buffered_send_data == 0 {
-            // The stream currently has capacity to send the data frame, so
-            // queue it up and notify the connection task.
-            self.queue_frame(frame.into(), buffer, stream, task);
-        } else {
-            // The stream has no capacity to send the frame now, save it but
-            // don't notify the connection task. Once additional capacity
-            // becomes available, the frame will be flushed.
-            stream.pending_send.push_back(buffer, frame.into());
-        }
-
-        Ok(())
     }
 
     /// Request capacity to send data
@@ -226,60 +140,84 @@ impl Prioritize {
         &mut self,
         capacity: WindowSize,
         stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) {
+        let (buffered_send_data, requested_send_capacity) = {
+            let send = stream.send();
+            (send.buffered_send_data, send.requested_send_capacity)
+        };
         let span = tracing::trace_span!(
             "reserve_capacity",
             ?stream.id,
             requested = capacity,
-            effective = (capacity as usize) + stream.buffered_send_data,
-            curr = stream.requested_send_capacity
+            effective = (capacity as usize) + buffered_send_data,
+            curr = requested_send_capacity
         );
         let _e = span.enter();
 
         // Actual capacity is `capacity` + the current amount of buffered data.
         // If it were less, then we could never send out the buffered data.
-        let capacity = (capacity as usize) + stream.buffered_send_data;
+        let capacity = (capacity as usize) + buffered_send_data;
 
-        match capacity.cmp(&(stream.requested_send_capacity as usize)) {
-            Ordering::Equal => {
-                // Nothing to do
-            }
-            Ordering::Less => {
-                // Update the target requested capacity
-                stream.requested_send_capacity = capacity as WindowSize;
+        enum Action {
+            None,
+            AssignConnection(WindowSize),
+            TryAssign,
+        }
 
-                // Currently available capacity assigned to the stream
-                let available = stream.send_flow.available().as_size();
+        let is_send_closed = stream.shared().state.is_send_closed();
 
-                // If the stream has more assigned capacity than requested, reclaim
-                // some for the connection
-                if available as usize > capacity {
-                    let diff = available - capacity as WindowSize;
+        let action = {
+            let mut shared = stream.send();
+            match capacity.cmp(&(shared.requested_send_capacity as usize)) {
+                Ordering::Equal => Action::None,
+                Ordering::Less => {
+                    // Update the target requested capacity
+                    shared.requested_send_capacity = capacity as WindowSize;
 
-                    // TODO: proper error handling
-                    let _res = stream.send_flow.claim_capacity(diff);
-                    debug_assert!(_res.is_ok());
+                    // Currently available capacity assigned to the stream
+                    let available = shared.send_flow.available().as_size();
 
-                    self.assign_connection_capacity(diff, stream, counts);
+                    // If the stream has more assigned capacity than requested, reclaim
+                    // some for the connection
+                    if available as usize > capacity {
+                        let diff = available - capacity as WindowSize;
+
+                        // TODO: proper error handling
+                        let _res = shared.send_flow.claim_capacity(diff);
+                        debug_assert!(_res.is_ok());
+
+                        Action::AssignConnection(diff)
+                    } else {
+                        Action::None
+                    }
+                }
+                Ordering::Greater => {
+                    // If trying to *add* capacity, but the stream send side is closed,
+                    // there's nothing to be done.
+                    if is_send_closed {
+                        return;
+                    }
+
+                    // Update the target requested capacity
+                    shared.requested_send_capacity =
+                        cmp::min(capacity, WindowSize::MAX as usize) as WindowSize;
+
+                    // Try to assign additional capacity to the stream. If none is
+                    // currently available, the stream will be queued to receive some
+                    // when more becomes available.
+                    Action::TryAssign
                 }
             }
-            Ordering::Greater => {
-                // If trying to *add* capacity, but the stream send side is closed,
-                // there's nothing to be done.
-                if stream.state.is_send_closed() {
-                    return;
-                }
+        };
 
-                // Update the target requested capacity
-                stream.requested_send_capacity =
-                    cmp::min(capacity, WindowSize::MAX as usize) as WindowSize;
-
-                // Try to assign additional capacity to the stream. If none is
-                // currently available, the stream will be queued to receive some
-                // when more becomes available.
-                self.try_assign_capacity(stream);
+        match action {
+            Action::None => {}
+            Action::AssignConnection(diff) => {
+                self.assign_connection_capacity(diff, stream, counts_shared, counts)
             }
+            Action::TryAssign => self.try_assign_capacity(stream),
         }
     }
 
@@ -288,22 +226,31 @@ impl Prioritize {
         inc: WindowSize,
         stream: &mut store::Ptr,
     ) -> Result<(), Reason> {
+        let (state, flow) = {
+            let state = stream.shared().state.clone();
+            let flow = stream.send().send_flow;
+            (state, flow)
+        };
         let span = tracing::trace_span!(
             "recv_stream_window_update",
             ?stream.id,
-            ?stream.state,
+            ?state,
             inc,
-            flow = ?stream.send_flow
+            flow = ?flow
         );
         let _e = span.enter();
 
-        if stream.state.is_send_closed() && stream.buffered_send_data == 0 {
-            // We can't send any data, so don't bother doing anything else.
-            return Ok(());
+        {
+            let is_send_closed = stream.shared().state.is_send_closed();
+            let buffered_send_data = stream.send().buffered_send_data;
+            if is_send_closed && buffered_send_data == 0 {
+                // We can't send any data, so don't bother doing anything else.
+                return Ok(());
+            }
         }
 
         // Update the stream level flow control.
-        stream.send_flow.inc_window(inc)?;
+        stream.send().send_flow.inc_window(inc)?;
 
         // If the stream is waiting on additional capacity, then this will
         // assign it (if available on the connection) and notify the producer
@@ -316,52 +263,82 @@ impl Prioritize {
         &mut self,
         inc: WindowSize,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) -> Result<(), Reason> {
         // Update the connection's window
         self.flow.inc_window(inc)?;
 
-        self.assign_connection_capacity(inc, store, counts);
+        self.assign_connection_capacity(inc, store, counts_shared, counts);
         Ok(())
     }
 
     /// Reclaim all capacity assigned to the stream and re-assign it to the
     /// connection
-    pub fn reclaim_all_capacity(&mut self, stream: &mut store::Ptr, counts: &mut Counts) {
-        let available = stream.send_flow.available().as_size();
+    pub fn reclaim_all_capacity(
+        &mut self,
+        stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+    ) {
+        let available = stream.send().send_flow.available().as_size();
         if available > 0 {
-            // TODO: proper error handling
-            let _res = stream.send_flow.claim_capacity(available);
-            debug_assert!(_res.is_ok());
+            {
+                let mut shared = stream.send();
+                // TODO: proper error handling
+                let _res = shared.send_flow.claim_capacity(available);
+                debug_assert!(_res.is_ok());
+            }
             // Re-assign all capacity to the connection
-            self.assign_connection_capacity(available, stream, counts);
+            self.assign_connection_capacity(available, stream, counts_shared, counts);
         }
     }
 
     /// Reclaim just reserved capacity, not buffered capacity, and re-assign
     /// it to the connection
-    pub fn reclaim_reserved_capacity(&mut self, stream: &mut store::Ptr, counts: &mut Counts) {
+    pub fn reclaim_reserved_capacity(
+        &mut self,
+        stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+    ) {
         // only reclaim reserved capacity that isn't already buffered
-        if stream.send_flow.available().as_size() as usize > stream.buffered_send_data {
-            let reserved =
-                stream.send_flow.available().as_size() - stream.buffered_send_data as WindowSize;
+        let reserved = {
+            let shared = stream.send();
+            if shared.send_flow.available().as_size() as usize > shared.buffered_send_data {
+                Some(
+                    shared.send_flow.available().as_size()
+                        - shared.buffered_send_data as WindowSize,
+                )
+            } else {
+                None
+            }
+        };
 
-            // Panic safety: due to how `reserved` is computed it can't be greater
-            // than what's available.
-            stream
-                .send_flow
-                .claim_capacity(reserved)
-                .expect("window size should be greater than reserved");
-
-            self.assign_connection_capacity(reserved, stream, counts);
+        if let Some(reserved) = reserved {
+            {
+                let mut shared = stream.send();
+                // Panic safety: due to how `reserved` is computed it can't be greater
+                // than what's available.
+                shared
+                    .send_flow
+                    .claim_capacity(reserved)
+                    .expect("window size should be greater than reserved");
+            }
+            self.assign_connection_capacity(reserved, stream, counts_shared, counts);
         }
     }
 
-    pub fn clear_pending_capacity(&mut self, store: &mut Store, counts: &mut Counts) {
+    pub fn clear_pending_capacity(
+        &mut self,
+        counts_shared: &counts::Shared,
+        store: &mut Store,
+        counts: &mut Counts,
+    ) {
         let span = tracing::trace_span!("clear_pending_capacity");
         let _e = span.enter();
         while let Some(stream) = self.pending_capacity.pop(store) {
-            counts.transition(stream, |_, stream| {
+            counts.transition(counts_shared, stream, |_, stream| {
                 tracing::trace!(?stream.id, "clear_pending_capacity");
             })
         }
@@ -371,6 +348,7 @@ impl Prioritize {
         &mut self,
         inc: WindowSize,
         store: &mut R,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) where
         R: Resolve,
@@ -393,11 +371,13 @@ impl Prioritize {
             // became available. In that case, the stream won't want any
             // capacity, and so we shouldn't "transition" on it, but just evict
             // it and continue the loop.
-            if !(stream.state.is_send_streaming() || stream.buffered_send_data > 0) {
+            let is_send_streaming = stream.shared().state.is_send_streaming();
+            let buffered_send_data = stream.send().buffered_send_data;
+            if !(is_send_streaming || buffered_send_data > 0) {
                 continue;
             }
 
-            counts.transition(stream, |_, stream| {
+            counts.transition(counts_shared, stream, |_, stream| {
                 // Try to assign capacity to the stream. This will also re-queue the
                 // stream if there isn't enough connection level capacity to fulfill
                 // the capacity request.
@@ -407,33 +387,40 @@ impl Prioritize {
     }
 
     /// Request capacity to send data
-    fn try_assign_capacity(&mut self, stream: &mut store::Ptr) {
+    pub(super) fn try_assign_capacity(&mut self, stream: &mut store::Ptr) {
         // Streams over the max concurrent count should not have capacity assign to avoid starving the connection
         // capacity for open streams
-        if stream.is_pending_open {
+        if stream.send().is_pending_open {
             return;
         }
 
-        let total_requested = stream.requested_send_capacity;
+        let (total_requested, additional, buffered_send_data, window_size) = {
+            let shared = stream.send();
 
-        // Total requested should never go below actual assigned
-        // (Note: the window size can go lower than assigned)
-        debug_assert!(stream.send_flow.available() <= total_requested as usize);
+            // Total requested should never go below actual assigned
+            // (Note: the window size can go lower than assigned)
+            debug_assert!(shared.send_flow.available() <= shared.requested_send_capacity as usize);
 
-        // The amount of additional capacity that the stream requests.
-        // Don't assign more than the window has available!
-        let additional = cmp::min(
-            total_requested - stream.send_flow.available().as_size(),
-            // Can't assign more than what is available
-            stream.send_flow.window_size() - stream.send_flow.available().as_size(),
-        );
+            // The amount of additional capacity that the stream requests.
+            // Don't assign more than the window has available!
+            (
+                shared.requested_send_capacity,
+                cmp::min(
+                    shared.requested_send_capacity - shared.send_flow.available().as_size(),
+                    // Can't assign more than what is available
+                    shared.send_flow.window_size() - shared.send_flow.available().as_size(),
+                ),
+                shared.buffered_send_data,
+                shared.send_flow.window_size(),
+            )
+        };
         let span = tracing::trace_span!("try_assign_capacity", ?stream.id);
         let _e = span.enter();
         tracing::trace!(
             requested = total_requested,
             additional,
-            buffered = stream.buffered_send_data,
-            window = stream.send_flow.window_size(),
+            buffered = buffered_send_data,
+            window = window_size,
             conn = %self.flow.available()
         );
 
@@ -442,8 +429,10 @@ impl Prioritize {
             return;
         }
 
+        let is_send_streaming = stream.shared().state.is_send_streaming();
+        let buffered_send_data = stream.send().buffered_send_data;
         // The stream may have been reset or closed since capacity was requested.
-        if !stream.state.is_send_streaming() && stream.buffered_send_data == 0 {
+        if !is_send_streaming && buffered_send_data == 0 {
             return;
         }
 
@@ -467,16 +456,25 @@ impl Prioritize {
             debug_assert!(_res.is_ok());
         }
 
-        tracing::trace!(
-            available = %stream.send_flow.available(),
-            requested = stream.requested_send_capacity,
-            buffered = stream.buffered_send_data,
-            has_unavailable = %stream.send_flow.has_unavailable()
-        );
+        let (should_queue_pending_capacity, has_pending_send) = {
+            let shared = stream.send();
 
-        if stream.send_flow.available() < stream.requested_send_capacity as usize
-            && stream.send_flow.has_unavailable()
-        {
+            tracing::trace!(
+                available = %shared.send_flow.available(),
+                requested = shared.requested_send_capacity,
+                buffered = shared.buffered_send_data,
+                has_unavailable = %shared.send_flow.has_unavailable()
+            );
+
+            (
+                shared.send_flow.available() < shared.requested_send_capacity as usize
+                    && shared.send_flow.has_unavailable(),
+                !shared.pending_send.is_empty(),
+            )
+        };
+        let should_queue_send = has_pending_send && stream.is_send_ready();
+
+        if should_queue_pending_capacity {
             // The stream requires additional capacity and the stream's
             // window has available capacity, but the connection window
             // does not.
@@ -488,7 +486,7 @@ impl Prioritize {
 
         // If data is buffered and the stream is send ready, then
         // schedule the stream for execution
-        if stream.buffered_send_data > 0 && stream.is_send_ready() {
+        if should_queue_send {
             // TODO: This assertion isn't *exactly* correct. There can still be
             // buffered send data while the stream's pending send queue is
             // empty. This can happen when a large data frame is in the process
@@ -510,6 +508,7 @@ impl Prioritize {
         cx: &mut Context,
         buffer: &mut Buffer<Frame<B>>,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
     ) -> Poll<io::Result<()>>
@@ -529,12 +528,12 @@ impl Prioritize {
         tracing::trace!("poll_complete");
 
         loop {
-            if let Some(mut stream) = self.pop_pending_open(store, counts) {
+            if let Some(mut stream) = self.pop_pending_open(store, counts_shared, counts) {
                 self.pending_send.push_front(&mut stream);
                 self.try_assign_capacity(&mut stream);
             }
 
-            match self.pop_frame(buffer, store, max_frame_len, counts) {
+            match self.pop_frame(buffer, store, max_frame_len, counts_shared, counts) {
                 Some(frame) => {
                     tracing::trace!(?frame, "writing");
 
@@ -651,12 +650,22 @@ impl Prioritize {
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
     ) {
-        // Push the frame to the front of the stream's deque
-        stream.pending_send.push_front(buffer, frame);
+        let should_schedule = {
+            let mut shared = stream.send();
+
+            // Push the frame to the front of the stream's deque
+            shared.pending_send.push_front(buffer, frame);
+
+            let should_schedule = shared.send_flow.available() > 0;
+            if should_schedule {
+                debug_assert!(!shared.pending_send.is_empty());
+            }
+
+            should_schedule
+        };
 
         // If needed, schedule the sender
-        if stream.send_flow.available() > 0 {
-            debug_assert!(!stream.pending_send.is_empty());
+        if should_schedule {
             self.pending_send.push(stream);
         }
     }
@@ -666,12 +675,18 @@ impl Prioritize {
         let _e = span.enter();
 
         // TODO: make this more efficient?
-        while let Some(frame) = stream.pending_send.pop_front(buffer) {
+        while let Some(frame) = stream.send().pending_send.pop_front(buffer) {
             tracing::trace!(?frame, "dropping");
         }
+        while let Some(frame) = stream.send().pending_op_data.pop_front(buffer) {
+            tracing::trace!(?frame, "dropping unapplied");
+        }
 
-        stream.buffered_send_data = 0;
-        stream.requested_send_capacity = 0;
+        {
+            let mut shared = stream.send();
+            shared.buffered_send_data = 0;
+            shared.requested_send_capacity = 0;
+        }
         if let InFlightData::DataFrame(key) = self.in_flight_data_frame {
             if stream.key() == key {
                 // This stream could get cleaned up now - don't allow the buffered frame to get reclaimed.
@@ -680,20 +695,36 @@ impl Prioritize {
         }
     }
 
-    pub fn clear_pending_send(&mut self, store: &mut Store, counts: &mut Counts) {
-        while let Some(mut stream) = self.pending_send.pop(store) {
+    pub fn clear_pending_send(
+        &mut self,
+        counts_shared: &counts::Shared,
+        store: &mut Store,
+        counts: &mut Counts,
+    ) {
+        while let Some(stream) = self.pending_send.pop(store) {
             let is_pending_reset = stream.is_pending_reset_expiration();
-            if let Some(reason) = stream.state.get_scheduled_reset() {
+            let scheduled_reset = {
+                let shared = stream.shared();
+                shared.state.get_scheduled_reset()
+            };
+            if let Some(reason) = scheduled_reset {
                 stream.set_reset(reason, Initiator::Library);
             }
-            counts.transition_after(stream, is_pending_reset);
+            counts.transition_after(counts_shared, stream, is_pending_reset);
         }
     }
 
-    pub fn clear_pending_open(&mut self, store: &mut Store, counts: &mut Counts) {
+    pub fn clear_pending_open(
+        &mut self,
+        counts_shared: &counts::Shared,
+        store: &mut Store,
+        counts: &mut Counts,
+    ) {
         while let Some(stream) = self.pending_open.pop(store) {
+            stream.send().is_pending_open = false;
+            stream.notify_send();
             let is_pending_reset = stream.is_pending_reset_expiration();
-            counts.transition_after(stream, is_pending_reset);
+            counts.transition_after(counts_shared, stream, is_pending_reset);
         }
     }
 
@@ -702,6 +733,7 @@ impl Prioritize {
         buffer: &mut Buffer<Frame<B>>,
         store: &mut Store,
         max_len: usize,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) -> Option<Frame<Prioritized<B>>>
     where
@@ -713,7 +745,8 @@ impl Prioritize {
         loop {
             match self.pending_send.pop(store) {
                 Some(mut stream) => {
-                    let span = tracing::trace_span!("popped", ?stream.id, ?stream.state);
+                    let state = stream.shared().state.clone();
+                    let span = tracing::trace_span!("popped", ?stream.id, ?state);
                     let _e = span.enter();
 
                     // It's possible that this stream, besides having data to send,
@@ -725,9 +758,11 @@ impl Prioritize {
 
                     tracing::trace!(is_pending_reset);
 
-                    let frame = match stream.pending_send.pop_front(buffer) {
+                    let next_frame = { stream.send().pending_send.pop_front(buffer) };
+                    let frame = match next_frame {
                         Some(Frame::Data(mut frame)) => {
-                            if let Some(reason) = stream.state.get_scheduled_reset() {
+                            let scheduled_reset = { stream.shared().state.get_scheduled_reset() };
+                            if let Some(reason) = scheduled_reset {
                                 // If a reset is scheduled due to cancellation or
                                 // an error, discard buffered DATA and let the `None`
                                 // arm emit the RST_STREAM on the next iteration.
@@ -736,9 +771,9 @@ impl Prioritize {
                                 // stream reset may only be sent after a complete
                                 // response, which requires sending all queued DATA.
                                 if reason != Reason::NO_ERROR {
-                                    stream.pending_send.push_front(buffer, frame.into());
+                                    stream.send().pending_send.push_front(buffer, frame.into());
                                     self.clear_queue(buffer, &mut stream);
-                                    self.reclaim_all_capacity(&mut stream, counts);
+                                    self.reclaim_all_capacity(&mut stream, counts_shared, counts);
                                     self.pending_send.push(&mut stream);
                                     continue;
                                 }
@@ -746,16 +781,23 @@ impl Prioritize {
 
                             // Get the amount of capacity remaining for stream's
                             // window.
-                            let stream_capacity = stream.send_flow.available();
+                            let (stream_capacity, requested_send_capacity, buffered_send_data) = {
+                                let shared = stream.send();
+                                (
+                                    shared.send_flow.available(),
+                                    shared.requested_send_capacity,
+                                    shared.buffered_send_data,
+                                )
+                            };
                             let sz = frame.payload().remaining();
 
                             tracing::trace!(
                                 sz,
                                 eos = frame.is_end_stream(),
                                 window = %stream_capacity,
-                                available = %stream.send_flow.available(),
-                                requested = stream.requested_send_capacity,
-                                buffered = stream.buffered_send_data,
+                                available = %stream_capacity,
+                                requested = requested_send_capacity,
+                                buffered = buffered_send_data,
                                 "data frame"
                             );
 
@@ -774,7 +816,7 @@ impl Prioritize {
                                 // happen if the remote reduced the stream
                                 // window. In this case, we need to buffer the
                                 // frame and wait for a window update...
-                                stream.pending_send.push_front(buffer, frame.into());
+                                stream.send().pending_send.push_front(buffer, frame.into());
 
                                 continue;
                             }
@@ -793,8 +835,8 @@ impl Prioritize {
                             // Check if the stream level window the peer knows is available. In some
                             // scenarios, maybe the window we know is available but the window which
                             // peer knows is not.
-                            if len > 0 && len > stream.send_flow.window_size() {
-                                stream.pending_send.push_front(buffer, frame.into());
+                            if len > 0 && len > stream.send().send_flow.window_size() {
+                                stream.send().pending_send.push_front(buffer, frame.into());
                                 continue;
                             }
 
@@ -839,12 +881,16 @@ impl Prioritize {
                         Some(Frame::PushPromise(pp)) => {
                             let mut pushed =
                                 stream.store_mut().find_mut(&pp.promised_id()).unwrap();
-                            pushed.is_pending_push = false;
+                            let has_pending_send = {
+                                let mut state = pushed.shared();
+                                state.is_pending_push = false;
+                                !pushed.send().pending_send.is_empty()
+                            };
                             // Transition stream from pending_push to pending_open
                             // if possible
-                            if !pushed.pending_send.is_empty() {
-                                if counts.can_inc_num_send_streams() {
-                                    counts.inc_num_send_streams(&mut pushed);
+                            if has_pending_send {
+                                if counts.can_inc_num_send_streams(counts_shared) {
+                                    counts.inc_num_send_streams(counts_shared, &mut pushed);
                                     self.pending_send.push(&mut pushed);
                                 } else {
                                     self.queue_open(&mut pushed);
@@ -859,7 +905,11 @@ impl Prioritize {
                             )
                         }),
                         None => {
-                            if let Some(reason) = stream.state.get_scheduled_reset() {
+                            let scheduled_reset = {
+                                let shared = stream.shared();
+                                shared.state.get_scheduled_reset()
+                            };
+                            if let Some(reason) = scheduled_reset {
                                 stream.set_reset(reason, Initiator::Library);
 
                                 let frame = frame::Reset::new(stream.id, reason);
@@ -870,10 +920,10 @@ impl Prioritize {
                                 // in clear_queue(). Instead of doing O(N) traversal through queue
                                 // to remove, lets just ignore the stream here.
                                 tracing::trace!("removing dangling stream from pending_send");
-                                // Since this should only happen as a consequence of `clear_queue`,
-                                // we must be in a closed state of some kind.
-                                debug_assert!(stream.state.is_closed());
-                                counts.transition_after(stream, is_pending_reset);
+                                // This usually happens as a consequence of `clear_queue`, but a
+                                // stream can also be queued while DATA is in-flight in the codec
+                                // and no frame is currently in the stream queue.
+                                counts.transition_after(counts_shared, stream, is_pending_reset);
                                 continue;
                             }
                         }
@@ -881,12 +931,17 @@ impl Prioritize {
 
                     tracing::trace!("pop_frame; frame={:?}", frame);
 
-                    if cfg!(debug_assertions) && stream.state.is_idle() {
+                    if cfg!(debug_assertions) && stream.shared().state.is_idle() {
                         debug_assert!(stream.id > self.last_opened_id);
                         self.last_opened_id = stream.id;
                     }
 
-                    if !stream.pending_send.is_empty() || stream.state.is_scheduled_reset() {
+                    let should_requeue = {
+                        let has_pending_send = !stream.send().pending_send.is_empty();
+                        let is_scheduled_reset = stream.shared().state.is_scheduled_reset();
+                        has_pending_send || is_scheduled_reset
+                    };
+                    if should_requeue {
                         // TODO: Only requeue the sender IF it is ready to send
                         // the next frame. i.e. don't requeue it if the next
                         // frame is a data frame and the stream does not have
@@ -894,7 +949,7 @@ impl Prioritize {
                         self.pending_send.push(&mut stream);
                     }
 
-                    counts.transition_after(stream, is_pending_reset);
+                    counts.transition_after(counts_shared, stream, is_pending_reset);
 
                     return Some(frame);
                 }
@@ -906,15 +961,17 @@ impl Prioritize {
     fn pop_pending_open<'s>(
         &mut self,
         store: &'s mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) -> Option<store::Ptr<'s>> {
         tracing::trace!("schedule_pending_open");
         // check for any pending open streams
-        if counts.can_inc_num_send_streams() {
+        if counts.can_inc_num_send_streams(counts_shared) {
             if let Some(mut stream) = self.pending_open.pop(store) {
                 tracing::trace!("schedule_pending_open; stream={:?}", stream.id);
 
-                counts.inc_num_send_streams(&mut stream);
+                counts.inc_num_send_streams(counts_shared, &mut stream);
+                stream.send().is_pending_open = false;
                 stream.notify_send();
                 return Some(stream);
             }

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -1,20 +1,20 @@
+use super::streams::ConnWaker;
 use super::*;
 use crate::codec::UserError;
-use crate::frame::{PushPromiseHeaderError, Reason, DEFAULT_INITIAL_WINDOW_SIZE};
+use crate::frame::{DEFAULT_INITIAL_WINDOW_SIZE, PushPromiseHeaderError, Reason};
 use crate::proto;
 
 use http::{HeaderMap, Request, Response};
 
 use std::cmp::Ordering;
 use std::io;
-use std::task::{Context, Poll, Waker};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering as AtomicOrdering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::time::Instant;
 
 #[derive(Debug)]
 pub(super) struct Recv {
-    /// Initial window size of remote initiated streams
-    init_window_sz: WindowSize,
-
     /// Connection level flow control governing received data
     flow: FlowControl,
 
@@ -48,17 +48,24 @@ pub(super) struct Recv {
     /// How long locally reset streams should ignore received frames
     reset_duration: Duration,
 
-    /// Holds frames that are waiting to be read
-    buffer: Buffer<Event>,
-
     /// Refused StreamId, this represents a frame that must be sent out.
     refused: Option<StreamId>,
+}
+
+#[derive(Debug)]
+/// Shared recv state between the connection task and stream refs.
+pub(super) struct Shared {
+    buffer: Mutex<Buffer<Event>>,
+    pushed: Mutex<Buffer<Arc<stream::Shared>>>,
+
+    /// Initial window size of remote initiated streams
+    init_window_sz: AtomicU32,
 
     /// If push promises are allowed to be received.
-    is_push_enabled: bool,
+    is_push_enabled: AtomicBool,
 
     /// If extended connect protocol is enabled.
-    is_extended_connect_protocol_enabled: bool,
+    is_extended_connect_protocol_enabled: AtomicBool,
 }
 
 #[derive(Debug)]
@@ -82,7 +89,7 @@ pub(crate) enum Open {
 }
 
 impl Recv {
-    pub fn new(peer: peer::Dyn, config: &Config) -> Self {
+    pub fn new(peer: peer::Dyn, config: &Config) -> (Self, Shared) {
         let next_stream_id = if peer.is_server() { 1 } else { 2 };
 
         let mut flow = FlowControl::new();
@@ -93,8 +100,7 @@ impl Recv {
             .expect("invalid initial remote window size");
         flow.assign_capacity(DEFAULT_INITIAL_WINDOW_SIZE).unwrap();
 
-        Recv {
-            init_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
+        let owned = Recv {
             flow,
             in_flight_data: 0 as WindowSize,
             next_stream_id: Ok(next_stream_id.into()),
@@ -104,16 +110,19 @@ impl Recv {
             pending_accept: store::Queue::new(),
             pending_reset_expired: store::Queue::new(),
             reset_duration: config.local_reset_duration,
-            buffer: Buffer::new(),
             refused: None,
-            is_push_enabled: config.local_push_enabled,
-            is_extended_connect_protocol_enabled: config.extended_connect_protocol_enabled,
-        }
-    }
+        };
+        let shared = Shared {
+            buffer: Mutex::new(Buffer::new()),
+            pushed: Mutex::new(Buffer::new()),
+            init_window_sz: AtomicU32::new(DEFAULT_INITIAL_WINDOW_SIZE),
+            is_push_enabled: AtomicBool::new(config.local_push_enabled),
+            is_extended_connect_protocol_enabled: AtomicBool::new(
+                config.extended_connect_protocol_enabled,
+            ),
+        };
 
-    /// Returns the initial receive window size
-    pub fn init_window_sz(&self) -> WindowSize {
-        self.init_window_sz
+        (owned, shared)
     }
 
     /// Returns the ID of the last processed stream
@@ -128,6 +137,7 @@ impl Recv {
         &mut self,
         id: StreamId,
         mode: Open,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) -> Result<Option<StreamId>, Error> {
         assert!(self.refused.is_none());
@@ -142,7 +152,7 @@ impl Recv {
 
         self.next_stream_id = id.next_id();
 
-        if !counts.can_inc_num_recv_streams() {
+        if !counts.can_inc_num_recv_streams(counts_shared) {
             self.refused = Some(id);
             return Ok(None);
         }
@@ -155,12 +165,14 @@ impl Recv {
     /// The caller ensures that the frame represents headers and not trailers.
     pub fn recv_headers(
         &mut self,
+        shared: &Shared,
         frame: frame::Headers,
         stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) -> Result<(), RecvHeaderBlockError<Option<frame::Headers>>> {
-        tracing::trace!("opening stream; init_window={}", self.init_window_sz);
-        let is_initial = stream.state.recv_open(&frame)?;
+        tracing::trace!("opening stream; init_window={}", shared.init_window_sz());
+        let is_initial = stream.shared().state.recv_open(&frame)?;
 
         if is_initial {
             // TODO: be smarter about this logic
@@ -169,10 +181,10 @@ impl Recv {
             }
 
             // Increment the number of concurrent streams
-            counts.inc_num_recv_streams(stream);
+            counts.inc_num_recv_streams(counts_shared, stream);
         }
 
-        if !stream.content_length.is_head() {
+        if !stream.inner().content_length.is_head() {
             use super::stream::ContentLength;
             use http::header;
 
@@ -185,7 +197,7 @@ impl Recv {
                     }
                 };
 
-                stream.content_length = ContentLength::Remaining(content_length);
+                stream.inner_mut().content_length = ContentLength::Remaining(content_length);
                 // END_STREAM on headers frame with non-zero content-length is malformed.
                 // https://datatracker.ietf.org/doc/html/rfc9113#section-8.1.1
                 if frame.is_end_stream()
@@ -236,7 +248,7 @@ impl Recv {
 
         if pseudo.protocol.is_some()
             && counts.peer().is_server()
-            && !self.is_extended_connect_protocol_enabled
+            && !shared.is_extended_connect_protocol_enabled()
         {
             proto_err!(stream: "cannot use :protocol if extended connect protocol is disabled; stream={:?}", stream.id);
             return Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR).into());
@@ -253,9 +265,7 @@ impl Recv {
                 .convert_poll_message(pseudo, fields, stream_id)?;
 
             // Push the frame onto the stream's recv buffer
-            stream
-                .pending_recv
-                .push_back(&mut self.buffer, Event::Headers(message));
+            shared.push_back(stream.shared_ref(), Event::Headers(message));
             stream.notify_recv();
 
             // Only servers can receive a headers frame that initiates the stream.
@@ -276,144 +286,22 @@ impl Recv {
 
             // Push the informational response onto the stream's recv buffer
             // with a special event type so it can be polled separately
-            stream
-                .pending_recv
-                .push_back(&mut self.buffer, Event::InformationalHeaders(message));
+            shared.push_back(stream.shared_ref(), Event::InformationalHeaders(message));
             stream.notify_recv();
         }
 
         Ok(())
     }
 
-    /// Called by the server to get the request
-    ///
-    /// # Panics
-    ///
-    /// Panics if `stream.pending_recv` has no `Event::Headers` queued.
-    ///
-    pub fn take_request(&mut self, stream: &mut store::Ptr) -> Request<()> {
-        use super::peer::PollMessage::*;
-
-        match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Headers(Server(request))) => request,
-            _ => unreachable!("server stream queue must start with Headers"),
-        }
-    }
-
-    /// Called by the client to get pushed response
-    pub fn poll_pushed(
-        &mut self,
-        cx: &Context,
-        stream: &mut store::Ptr,
-    ) -> Poll<Option<Result<(Request<()>, store::Key), proto::Error>>> {
-        use super::peer::PollMessage::*;
-
-        let mut ppp = stream.pending_push_promises.take();
-        let pushed = ppp.pop(stream.store_mut()).map(|mut pushed| {
-            match pushed.pending_recv.pop_front(&mut self.buffer) {
-                Some(Event::Headers(Server(headers))) => (headers, pushed.key()),
-                // When frames are pushed into the queue, it is verified that
-                // the first frame is a HEADERS frame.
-                _ => panic!("Headers not set on pushed stream"),
-            }
-        });
-        stream.pending_push_promises = ppp;
-        if let Some(p) = pushed {
-            Poll::Ready(Some(Ok(p)))
-        } else {
-            let is_open = stream.state.ensure_recv_open()?;
-
-            if is_open {
-                stream.push_task = Some(cx.waker().clone());
-                Poll::Pending
-            } else {
-                Poll::Ready(None)
-            }
-        }
-    }
-
-    /// Called by the client to get the response
-    pub fn poll_response(
-        &mut self,
-        cx: &Context,
-        stream: &mut store::Ptr,
-    ) -> Poll<Result<Response<()>, proto::Error>> {
-        use super::peer::PollMessage::*;
-
-        // Skip over any interim informational headers to find the main response
-        loop {
-            match stream.pending_recv.pop_front(&mut self.buffer) {
-                Some(Event::Headers(Client(response))) => return Poll::Ready(Ok(response)),
-                Some(Event::InformationalHeaders(_)) => {
-                    tracing::trace!("Skipping informational response in poll_response - should be consumed via poll_informational; stream_id={:?}", stream.id);
-                    continue;
-                }
-                Some(_) => panic!("poll_response called after response returned"),
-                None => {
-                    if !stream.state.ensure_recv_open()? {
-                        proto_err!(stream: "poll_response: stream={:?} is not opened;",  stream.id);
-                        return Poll::Ready(Err(Error::library_reset(
-                            stream.id,
-                            Reason::PROTOCOL_ERROR,
-                        )));
-                    }
-
-                    stream.recv_task = Some(cx.waker().clone());
-                    return Poll::Pending;
-                }
-            }
-        }
-    }
-
-    /// Called by the client to get informational responses (1xx status codes)
-    pub fn poll_informational(
-        &mut self,
-        cx: &Context,
-        stream: &mut store::Ptr,
-    ) -> Poll<Option<Result<Response<()>, proto::Error>>> {
-        use super::peer::PollMessage::*;
-
-        // Try to pop the front event and check if it's an informational response
-        // If it's not, we put it back
-        if let Some(event) = stream.pending_recv.pop_front(&mut self.buffer) {
-            match event {
-                Event::Headers(Client(response)) => {
-                    // Final response
-                    stream
-                        .pending_recv
-                        .push_front(&mut self.buffer, Event::Headers(Client(response)));
-                    return Poll::Ready(None);
-                }
-                Event::InformationalHeaders(Client(response)) => {
-                    // Found an informational response, return it
-                    return Poll::Ready(Some(Ok(response)));
-                }
-                other => {
-                    // Not an informational response, put it back at the front
-                    stream.pending_recv.push_front(&mut self.buffer, other);
-                }
-            }
-        }
-
-        // No informational response available at the front
-        if stream.state.ensure_recv_open()? {
-            // Request to get notified once more frames arrive
-            stream.recv_task = Some(cx.waker().clone());
-            Poll::Pending
-        } else {
-            // No more frames will be received
-            Poll::Ready(None)
-        }
-    }
-
     /// Transition the stream based on receiving trailers
     pub fn recv_trailers(
         &mut self,
+        shared: &Shared,
         frame: frame::Headers,
         stream: &mut store::Ptr,
     ) -> Result<(), Error> {
         // Transition the state
-        stream.state.recv_close()?;
+        stream.shared().state.recv_close()?;
 
         if stream.ensure_content_length_zero().is_err() {
             proto_err!(stream: "recv_trailers: content-length is not zero; stream={:?};",  stream.id);
@@ -423,16 +311,14 @@ impl Recv {
         let trailers = frame.into_fields();
 
         // Push the frame onto the stream's recv buffer
-        stream
-            .pending_recv
-            .push_back(&mut self.buffer, Event::Trailers(trailers));
+        shared.push_back(stream.shared_ref(), Event::Trailers(trailers));
         stream.notify_recv();
 
         Ok(())
     }
 
     /// Releases capacity of the connection
-    pub fn release_connection_capacity(&mut self, capacity: WindowSize, task: &mut Option<Waker>) {
+    pub fn release_connection_capacity(&mut self, capacity: WindowSize, conn_task: &ConnWaker) {
         tracing::trace!(
             "release_connection_capacity; size={}, connection in_flight_data={}",
             capacity,
@@ -448,9 +334,7 @@ impl Recv {
         debug_assert!(_res.is_ok());
 
         if self.flow.unclaimed_capacity().is_some() {
-            if let Some(task) = task.take() {
-                task.wake();
-            }
+            conn_task.wake();
         }
     }
 
@@ -459,54 +343,50 @@ impl Recv {
         &mut self,
         capacity: WindowSize,
         stream: &mut store::Ptr,
-        task: &mut Option<Waker>,
+        conn_task: &ConnWaker,
     ) -> Result<(), UserError> {
-        tracing::trace!("release_capacity; size={}", capacity);
-
-        if capacity > stream.in_flight_recv_data {
-            return Err(UserError::ReleaseCapacityTooBig);
-        }
-
-        self.release_connection_capacity(capacity, task);
-
-        // Decrement in-flight data
-        stream.in_flight_recv_data -= capacity;
-
-        // Assign capacity to stream
-        // TODO: proper error handling
-        let _res = stream.recv_flow.assign_capacity(capacity);
-        debug_assert!(_res.is_ok());
-
-        if stream.recv_flow.unclaimed_capacity().is_some() {
-            // Queue the stream for sending the WINDOW_UPDATE frame.
-            self.pending_window_updates.push(stream);
-
-            if let Some(task) = task.take() {
-                task.wake();
-            }
-        }
-
+        release_capacity_local(capacity, stream.shared_ref())?;
+        self.release_connection_capacity(capacity, conn_task);
+        self.schedule_stream_window_update(stream, conn_task);
         Ok(())
     }
 
-    /// Release any unclaimed capacity for a closed stream.
-    pub fn release_closed_capacity(&mut self, stream: &mut store::Ptr, task: &mut Option<Waker>) {
-        debug_assert_eq!(stream.ref_count, 0);
+    pub fn schedule_stream_window_update(
+        &mut self,
+        stream: &mut store::Ptr,
+        conn_task: &ConnWaker,
+    ) {
+        if stream.recv().recv_flow.unclaimed_capacity().is_some() {
+            self.pending_window_updates.push(stream);
+            conn_task.wake();
+        }
+    }
 
-        if stream.in_flight_recv_data == 0 {
+    /// Release any unclaimed capacity for a closed stream.
+    pub fn release_closed_capacity(
+        &mut self,
+        stream: &mut store::Ptr,
+        conn_task: &ConnWaker,
+        shared: &Shared,
+    ) {
+        debug_assert_eq!(stream.shared().ref_count, 0);
+
+        if stream.recv().in_flight_recv_data == 0 {
             return;
         }
+
+        let in_flight_recv_data = stream.recv().in_flight_recv_data;
 
         tracing::trace!(
             "auto-release closed stream ({:?}) capacity: {:?}",
             stream.id,
-            stream.in_flight_recv_data,
+            in_flight_recv_data,
         );
 
-        self.release_connection_capacity(stream.in_flight_recv_data, task);
-        stream.in_flight_recv_data = 0;
+        self.release_connection_capacity(in_flight_recv_data, conn_task);
+        stream.recv().in_flight_recv_data = 0;
 
-        self.clear_recv_buffer(stream);
+        shared.clear(stream.shared_ref());
     }
 
     /// Set the "target" connection window size.
@@ -524,7 +404,7 @@ impl Recv {
     pub fn set_target_connection_window(
         &mut self,
         target: WindowSize,
-        task: &mut Option<Waker>,
+        conn_task: &ConnWaker,
     ) -> Result<(), Reason> {
         tracing::trace!(
             "set_target_connection_window; target={}; available={}, reserved={}",
@@ -553,25 +433,24 @@ impl Recv {
         // enough that we went over the update threshold, then schedule sending
         // a connection WINDOW_UPDATE.
         if self.flow.unclaimed_capacity().is_some() {
-            if let Some(task) = task.take() {
-                task.wake();
-            }
+            conn_task.wake();
         }
         Ok(())
     }
 
     pub(crate) fn apply_local_settings(
         &mut self,
+        shared: &Shared,
         settings: &frame::Settings,
         store: &mut Store,
     ) -> Result<(), proto::Error> {
         if let Some(val) = settings.is_extended_connect_protocol_enabled() {
-            self.is_extended_connect_protocol_enabled = val;
+            shared.set_extended_connect_protocol_enabled(val);
         }
 
         if let Some(target) = settings.initial_window_size() {
-            let old_sz = self.init_window_sz;
-            self.init_window_sz = target;
+            let old_sz = shared.init_window_sz();
+            shared.set_init_window_sz(target);
 
             tracing::trace!("update_initial_window_size; new={}; old={}", target, old_sz,);
 
@@ -597,8 +476,9 @@ impl Recv {
                     let dec = old_sz - target;
                     tracing::trace!("decrementing all windows; dec={}", dec);
 
-                    store.try_for_each(|mut stream| {
+                    store.try_for_each(|stream| {
                         stream
+                            .recv()
                             .recv_flow
                             .dec_recv_window(dec)
                             .map_err(proto::Error::library_go_away)?;
@@ -609,14 +489,16 @@ impl Recv {
                     // We must increase the (local) window on every open stream.
                     let inc = target - old_sz;
                     tracing::trace!("incrementing all windows; inc={}", inc);
-                    store.try_for_each(|mut stream| {
+                    store.try_for_each(|stream| {
                         // XXX: Shouldn't the peer have already noticed our
                         // overflow and sent us a GOAWAY?
                         stream
+                            .recv()
                             .recv_flow
                             .inc_window(inc)
                             .map_err(proto::Error::library_go_away)?;
                         stream
+                            .recv()
                             .recv_flow
                             .assign_capacity(inc)
                             .map_err(proto::Error::library_go_away)?;
@@ -630,15 +512,13 @@ impl Recv {
         Ok(())
     }
 
-    pub fn is_end_stream(&self, stream: &store::Ptr) -> bool {
-        if !stream.state.is_recv_end_stream() {
-            return false;
-        }
-
-        stream.pending_recv.is_empty()
-    }
-
-    pub fn recv_data(&mut self, frame: frame::Data, stream: &mut store::Ptr) -> Result<(), Error> {
+    pub fn recv_data(
+        &mut self,
+        shared: &Shared,
+        conn_task: &ConnWaker,
+        frame: frame::Data,
+        stream: &mut store::Ptr,
+    ) -> Result<(), Error> {
         // could include padding
         let sz = frame.flow_controlled_len();
 
@@ -648,9 +528,9 @@ impl Recv {
 
         let sz = sz as WindowSize;
 
-        let is_ignoring_frame = stream.state.is_local_error();
+        let is_ignoring_frame = stream.shared().state.is_local_error();
 
-        if !is_ignoring_frame && !stream.state.is_recv_streaming() {
+        if !is_ignoring_frame && !stream.shared().state.is_recv_streaming() {
             // TODO: There are cases where this can be a stream error of
             // STREAM_CLOSED instead...
 
@@ -664,7 +544,7 @@ impl Recv {
             "recv_data; size={}; connection={}; stream={}",
             sz,
             self.flow.window_size(),
-            stream.recv_flow.window_size()
+            stream.recv().recv_flow.window_size()
         );
 
         if is_ignoring_frame {
@@ -672,14 +552,14 @@ impl Recv {
                 "recv_data; frame ignored on locally reset {:?} for some time",
                 stream.id,
             );
-            return self.ignore_data(sz);
+            return self.ignore_data(sz, conn_task);
         }
 
         // Ensure that there is enough capacity on the connection before acting
         // on the stream.
         self.consume_connection_window(sz)?;
 
-        if stream.recv_flow.window_size() < sz {
+        if stream.recv().recv_flow.window_size() < sz {
             // http://httpwg.org/specs/rfc7540.html#WINDOW_UPDATE
             // > A receiver MAY respond with a stream error (Section 5.4.2) or
             // > connection error (Section 5.4.1) of type FLOW_CONTROL_ERROR if
@@ -711,30 +591,31 @@ impl Recv {
                 return Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR));
             }
 
-            if stream.state.recv_close().is_err() {
+            if stream.shared().state.recv_close().is_err() {
                 proto_err!(conn: "recv_data: failed to transition to closed state; stream={:?}", stream.id);
                 return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
             }
         }
 
         // Received a frame, but no one cared about it. fix issue#648
-        if !stream.is_recv {
+        if !stream.recv().is_recv {
             tracing::trace!(
                 "recv_data; frame ignored on stream release {:?} for some time",
                 stream.id,
             );
-            self.release_connection_capacity(sz, &mut None);
+            self.release_connection_capacity(sz, conn_task);
             return Ok(());
         }
 
         // Update stream level flow control
         stream
+            .recv()
             .recv_flow
             .send_data(sz)
             .map_err(proto::Error::library_go_away)?;
 
         // Track the data as in-flight
-        stream.in_flight_recv_data += sz;
+        stream.recv().in_flight_recv_data += sz;
 
         // Auto-release padding overhead (pad_len field + padding bytes),
         // since the user only sees the data payload via `payload()`.
@@ -745,7 +626,7 @@ impl Recv {
                 padding,
                 stream.id,
             );
-            let _res = self.release_capacity(padding, stream, &mut None);
+            let _res = self.release_capacity(padding, stream, conn_task);
             // cannot fail, we JUST added more in_flight data above.
             debug_assert!(_res.is_ok());
         }
@@ -753,13 +634,13 @@ impl Recv {
         let event = Event::Data(frame.into_payload());
 
         // Push the frame onto the recv buffer
-        stream.pending_recv.push_back(&mut self.buffer, event);
+        shared.push_back(stream.shared_ref(), event);
         stream.notify_recv();
 
         Ok(())
     }
 
-    pub fn ignore_data(&mut self, sz: WindowSize) -> Result<(), Error> {
+    pub fn ignore_data(&mut self, sz: WindowSize, conn_task: &ConnWaker) -> Result<(), Error> {
         // Ensure that there is enough capacity on the connection...
         self.consume_connection_window(sz)?;
 
@@ -771,7 +652,7 @@ impl Recv {
         // This call doesn't send a WINDOW_UPDATE immediately, just marks
         // the capacity as available to be reclaimed. When the available
         // capacity meets a threshold, a WINDOW_UPDATE is then sent.
-        self.release_connection_capacity(sz, &mut None);
+        self.release_connection_capacity(sz, conn_task);
         Ok(())
     }
 
@@ -795,10 +676,11 @@ impl Recv {
 
     pub fn recv_push_promise(
         &mut self,
+        shared: &Shared,
         frame: frame::PushPromise,
         stream: &mut store::Ptr,
     ) -> Result<(), Error> {
-        stream.state.reserve_remote()?;
+        stream.shared().state.reserve_remote()?;
         if frame.is_over_size() {
             // A frame is over size if the decoded header block was bigger than
             // SETTINGS_MAX_HEADER_LIST_SIZE.
@@ -846,9 +728,7 @@ impl Recv {
         }
 
         use super::peer::PollMessage::*;
-        stream
-            .pending_recv
-            .push_back(&mut self.buffer, Event::Headers(Server(req)));
+        shared.push_back(stream.shared_ref(), Event::Headers(Server(req)));
         stream.notify_recv();
         stream.notify_push();
         Ok(())
@@ -874,8 +754,9 @@ impl Recv {
     pub fn recv_reset(
         &mut self,
         frame: frame::Reset,
-        stream: &mut Stream,
+        stream: &Stream,
         counts: &mut Counts,
+        has_queued_frame: bool,
     ) -> Result<(), Error> {
         // Reseting a stream that the user hasn't accepted is possible,
         // but should be done with care. These streams will continue
@@ -885,7 +766,7 @@ impl Recv {
         // So, we have a separate limit for these.
         //
         // See https://github.com/hyperium/hyper/issues/2877
-        if stream.is_pending_accept {
+        if stream.inner().is_pending_accept {
             if counts.can_inc_num_remote_reset_streams() {
                 counts.inc_num_remote_reset_streams();
             } else {
@@ -901,7 +782,7 @@ impl Recv {
         }
 
         // Notify the stream
-        stream.state.recv_reset(frame, stream.is_pending_send);
+        stream.shared().state.recv_reset(frame, has_queued_frame);
 
         stream.notify_send();
         stream.notify_recv();
@@ -911,9 +792,9 @@ impl Recv {
     }
 
     /// Handle a connection-level error
-    pub fn handle_error(&mut self, err: &proto::Error, stream: &mut Stream) {
+    pub fn handle_error(&mut self, err: &proto::Error, stream: &Stream) {
         // Receive an error
-        stream.state.handle_error(err);
+        stream.shared().state.handle_error(err);
 
         // If a receiver is waiting, notify it
         stream.notify_send();
@@ -926,17 +807,11 @@ impl Recv {
         self.max_stream_id = last_processed_id;
     }
 
-    pub fn recv_eof(&mut self, stream: &mut Stream) {
-        stream.state.recv_eof();
+    pub fn recv_eof(&mut self, stream: &Stream) {
+        stream.shared().state.recv_eof();
         stream.notify_send();
         stream.notify_recv();
         stream.notify_push();
-    }
-
-    pub(super) fn clear_recv_buffer(&mut self, stream: &mut Stream) {
-        while stream.pending_recv.pop_front(&mut self.buffer).is_some() {
-            // drop it
-        }
     }
 
     /// Get the max ID of streams we can receive.
@@ -975,8 +850,8 @@ impl Recv {
     }
 
     /// Returns true if the remote peer can reserve a stream with the given ID.
-    pub fn ensure_can_reserve(&self) -> Result<(), Error> {
-        if !self.is_push_enabled {
+    pub fn ensure_can_reserve(&self, shared: &Shared) -> Result<(), Error> {
+        if !shared.is_push_enabled() {
             proto_err!(conn: "recv_push_promise: push is disabled");
             return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
         }
@@ -986,7 +861,8 @@ impl Recv {
 
     /// Add a locally reset stream to queue to be eventually reaped.
     pub fn enqueue_reset_expiration(&mut self, stream: &mut store::Ptr, counts: &mut Counts) {
-        if !stream.state.is_local_error() || stream.is_pending_reset_expiration() {
+        let is_local_error = stream.shared().state.is_local_error();
+        if !is_local_error || stream.is_pending_reset_expiration() {
             return;
         }
 
@@ -1027,7 +903,12 @@ impl Recv {
         Poll::Ready(Ok(()))
     }
 
-    pub fn clear_expired_reset_streams(&mut self, store: &mut Store, counts: &mut Counts) {
+    pub fn clear_expired_reset_streams(
+        &mut self,
+        counts_shared: &counts::Shared,
+        store: &mut Store,
+        counts: &mut Counts,
+    ) {
         if !self.pending_reset_expired.is_empty() {
             let now = Instant::now();
             let reset_duration = self.reset_duration;
@@ -1038,7 +919,7 @@ impl Recv {
                 // monotonic). We use a saturating operation to avoid this panic here.
                 now.saturating_duration_since(reset_at) > reset_duration
             }) {
-                counts.transition_after(stream, true);
+                counts.transition_after(counts_shared, stream, true);
             }
         }
     }
@@ -1047,34 +928,50 @@ impl Recv {
         &mut self,
         clear_pending_accept: bool,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) {
-        self.clear_stream_window_update_queue(store, counts);
-        self.clear_all_reset_streams(store, counts);
+        self.clear_stream_window_update_queue(store, counts_shared, counts);
+        self.clear_all_reset_streams(store, counts_shared, counts);
 
         if clear_pending_accept {
-            self.clear_all_pending_accept(store, counts);
+            self.clear_all_pending_accept(store, counts_shared, counts);
         }
     }
 
-    fn clear_stream_window_update_queue(&mut self, store: &mut Store, counts: &mut Counts) {
+    fn clear_stream_window_update_queue(
+        &mut self,
+        store: &mut Store,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+    ) {
         while let Some(stream) = self.pending_window_updates.pop(store) {
-            counts.transition(stream, |_, stream| {
+            counts.transition(counts_shared, stream, |_, stream| {
                 tracing::trace!("clear_stream_window_update_queue; stream={:?}", stream.id);
             })
         }
     }
 
     /// Called on EOF
-    fn clear_all_reset_streams(&mut self, store: &mut Store, counts: &mut Counts) {
+    fn clear_all_reset_streams(
+        &mut self,
+        store: &mut Store,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+    ) {
         while let Some(stream) = self.pending_reset_expired.pop(store) {
-            counts.transition_after(stream, true);
+            counts.transition_after(counts_shared, stream, true);
         }
     }
 
-    fn clear_all_pending_accept(&mut self, store: &mut Store, counts: &mut Counts) {
+    fn clear_all_pending_accept(
+        &mut self,
+        store: &mut Store,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+    ) {
         while let Some(stream) = self.pending_accept.pop(store) {
-            counts.transition_after(stream, false);
+            counts.transition_after(counts_shared, stream, false);
         }
     }
 
@@ -1082,6 +979,7 @@ impl Recv {
         &mut self,
         cx: &mut Context,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
     ) -> Poll<io::Result<()>>
@@ -1093,7 +991,7 @@ impl Recv {
         ready!(self.send_connection_window_update(cx, dst))?;
 
         // Send any pending stream level window updates
-        ready!(self.send_stream_window_updates(cx, store, counts, dst))?;
+        ready!(self.send_stream_window_updates(cx, store, counts_shared, counts, dst))?;
 
         Poll::Ready(Ok(()))
     }
@@ -1132,6 +1030,7 @@ impl Recv {
         &mut self,
         cx: &mut Context,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
     ) -> Poll<io::Result<()>>
@@ -1149,22 +1048,28 @@ impl Recv {
                 None => return Poll::Ready(Ok(())),
             };
 
-            counts.transition(stream, |_, stream| {
+            counts.transition(counts_shared, stream, |_, stream| {
                 tracing::trace!("pending_window_updates -- pop; stream={:?}", stream.id);
-                debug_assert!(!stream.is_pending_window_update);
+                debug_assert!(!stream.inner().is_pending_window_update);
 
-                if !stream.state.is_recv_streaming() {
-                    // No need to send window updates on the stream if the stream is
-                    // no longer receiving data.
-                    //
-                    // TODO: is this correct? We could possibly send a window
-                    // update on a ReservedRemote stream if we already know
-                    // we want to stream the data faster...
-                    return;
-                }
+                let incr = {
+                    let shared = stream.shared();
 
-                // TODO: de-dup
-                if let Some(incr) = stream.recv_flow.unclaimed_capacity() {
+                    if !shared.state.is_recv_streaming() {
+                        // No need to send window updates on the stream if the stream is
+                        // no longer receiving data.
+                        //
+                        // TODO: is this correct? We could possibly send a window
+                        // update on a ReservedRemote stream if we already know
+                        // we want to stream the data faster...
+                        return;
+                    }
+
+                    // TODO: de-dup
+                    stream.recv().recv_flow.unclaimed_capacity()
+                };
+
+                if let Some(incr) = incr {
                     // Create the WINDOW_UPDATE frame
                     let frame = frame::WindowUpdate::new(stream.id, incr);
 
@@ -1174,6 +1079,7 @@ impl Recv {
 
                     // Update flow control
                     stream
+                        .recv()
                         .recv_flow
                         .inc_window(incr)
                         .expect("unexpected flow control state");
@@ -1185,65 +1091,296 @@ impl Recv {
     pub fn next_incoming(&mut self, store: &mut Store) -> Option<store::Key> {
         self.pending_accept.pop(store).map(|ptr| ptr.key())
     }
+}
 
-    pub fn poll_data(
-        &mut self,
-        cx: &Context,
-        stream: &mut Stream,
-    ) -> Poll<Option<Result<Bytes, proto::Error>>> {
-        match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Data(payload)) => Poll::Ready(Some(Ok(payload))),
-            Some(event) => {
-                // Frame is trailer
-                stream.pending_recv.push_front(&mut self.buffer, event);
+impl Shared {
+    pub fn init_window_sz(&self) -> WindowSize {
+        self.init_window_sz.load(AtomicOrdering::Relaxed)
+    }
 
-                // Notify the recv task. This is done just in case
-                // `poll_trailers` was called.
-                //
-                // It is very likely that `notify_recv` will just be a no-op (as
-                // the task will be None), so this isn't really much of a
-                // performance concern. It also means we don't have to track
-                // state to see if `poll_trailers` was called before `poll_data`
-                // returned `None`.
-                stream.notify_recv();
+    pub fn is_extended_connect_protocol_enabled(&self) -> bool {
+        self.is_extended_connect_protocol_enabled
+            .load(AtomicOrdering::Relaxed)
+    }
 
-                // No more data frames
-                Poll::Ready(None)
-            }
-            None => self.schedule_recv(cx, stream),
+    pub fn is_push_enabled(&self) -> bool {
+        self.is_push_enabled.load(AtomicOrdering::Relaxed)
+    }
+
+    fn set_init_window_sz(&self, target: WindowSize) {
+        self.init_window_sz.store(target, AtomicOrdering::Relaxed);
+    }
+
+    fn set_extended_connect_protocol_enabled(&self, enabled: bool) {
+        self.is_extended_connect_protocol_enabled
+            .store(enabled, AtomicOrdering::Relaxed);
+    }
+
+    pub fn push_back(&self, stream: &stream::Shared, event: Event) {
+        let mut buffer = self.buffer.lock().unwrap();
+        stream.recv().pending_recv.push_back(&mut buffer, event);
+    }
+
+    pub fn push_front(&self, stream: &stream::Shared, event: Event) {
+        let mut buffer = self.buffer.lock().unwrap();
+        stream.recv().pending_recv.push_front(&mut buffer, event);
+    }
+
+    pub fn pop_front(&self, stream: &stream::Shared) -> Option<Event> {
+        let mut buffer = self.buffer.lock().unwrap();
+        stream.recv().pending_recv.pop_front(&mut buffer)
+    }
+
+    fn has_pending_recv(&self, stream: &stream::Shared) -> bool {
+        !stream.recv().pending_recv.is_empty()
+    }
+
+    pub fn clear(&self, stream: &stream::Shared) {
+        let mut buffer = self.buffer.lock().unwrap();
+        while stream.recv().pending_recv.pop_front(&mut buffer).is_some() {
+            // drop it
         }
     }
 
-    pub fn poll_trailers(
-        &mut self,
-        cx: &Context,
-        stream: &mut Stream,
-    ) -> Poll<Option<Result<HeaderMap, proto::Error>>> {
-        match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Trailers(trailers)) => Poll::Ready(Some(Ok(trailers))),
-            Some(event) => {
-                // Frame is not trailers.. not ready to poll trailers yet.
-                stream.pending_recv.push_front(&mut self.buffer, event);
-
-                Poll::Pending
-            }
-            None => self.schedule_recv(cx, stream),
-        }
+    pub fn push_pushed(&self, stream: &stream::Shared, pushed: Arc<stream::Shared>) {
+        let mut buffer = self.pushed.lock().unwrap();
+        stream
+            .recv()
+            .pending_push_promises
+            .push_back(&mut buffer, pushed);
     }
 
-    fn schedule_recv<T>(
-        &mut self,
-        cx: &Context,
-        stream: &mut Stream,
-    ) -> Poll<Option<Result<T, proto::Error>>> {
-        if stream.state.ensure_recv_open()? {
-            // Request to get notified once more frames arrive
-            stream.recv_task = Some(cx.waker().clone());
+    pub fn pop_pushed(&self, stream: &stream::Shared) -> Option<Arc<stream::Shared>> {
+        let mut buffer = self.pushed.lock().unwrap();
+        stream.recv().pending_push_promises.pop_front(&mut buffer)
+    }
+
+    fn has_pending_push(&self, stream: &stream::Shared) -> bool {
+        !stream.recv().pending_push_promises.is_empty()
+    }
+}
+
+// ===== stateless recv operations
+
+/// Called by the server to get the request
+///
+/// # Panics
+///
+/// Panics if `stream.pending_recv` has no `Event::Headers` queued.
+///
+pub(super) fn take_request(stream: &stream::Shared, shared: &Shared) -> Request<()> {
+    use super::peer::PollMessage::*;
+
+    match shared.pop_front(stream) {
+        Some(Event::Headers(Server(request))) => request,
+        _ => unreachable!("server stream queue must start with Headers"),
+    }
+}
+
+/// Called by the client to get pushed response
+pub(super) fn poll_pushed(
+    cx: &Context,
+    stream: &stream::Shared,
+    shared: &Shared,
+) -> Poll<Option<Result<(Request<()>, Arc<stream::Shared>), proto::Error>>> {
+    use super::peer::PollMessage::*;
+
+    let pushed = shared.pop_pushed(stream).map(|pushed| {
+        match shared.pop_front(&pushed) {
+            Some(Event::Headers(Server(headers))) => (headers, pushed),
+            // When frames are pushed into the queue, it is verified that
+            // the first frame is a HEADERS frame.
+            _ => panic!("Headers not set on pushed stream"),
+        }
+    });
+    if let Some(p) = pushed {
+        Poll::Ready(Some(Ok(p)))
+    } else {
+        let is_open = stream.state().state.ensure_recv_open()?;
+
+        if is_open {
+            stream.recv().push_task = Some(cx.waker().clone());
+            if shared.has_pending_push(stream) {
+                stream.notify_push();
+            }
             Poll::Pending
         } else {
-            // No more frames will be received
             Poll::Ready(None)
         }
+    }
+}
+
+/// Called by the client to get the response
+pub(super) fn poll_response(
+    cx: &Context,
+    stream: &stream::Shared,
+    shared: &Shared,
+) -> Poll<Result<Response<()>, proto::Error>> {
+    use super::peer::PollMessage::*;
+
+    let id = stream.id;
+    // Skip over any interim informational headers to find the main response
+    loop {
+        match shared.pop_front(stream) {
+            Some(Event::Headers(Client(response))) => return Poll::Ready(Ok(response)),
+            Some(Event::InformationalHeaders(_)) => {
+                tracing::trace!(
+                    "Skipping informational response in poll_response - should be consumed via poll_informational; stream_id={:?}",
+                    id
+                );
+                continue;
+            }
+            Some(_) => panic!("poll_response called after response returned"),
+            None => {
+                if !stream.state().state.ensure_recv_open()? {
+                    proto_err!(stream: "poll_response: stream={:?} is not opened;",  id);
+                    return Poll::Ready(Err(Error::library_reset(id, Reason::PROTOCOL_ERROR)));
+                }
+
+                stream.recv().recv_task = Some(cx.waker().clone());
+                if shared.has_pending_recv(stream) {
+                    stream.notify_recv();
+                }
+                return Poll::Pending;
+            }
+        }
+    }
+}
+
+/// Called by the client to get informational responses (1xx status codes)
+pub(super) fn poll_informational(
+    cx: &Context,
+    stream: &stream::Shared,
+    shared: &Shared,
+) -> Poll<Option<Result<Response<()>, proto::Error>>> {
+    use super::peer::PollMessage::*;
+
+    // Try to pop the front event and check if it's an informational response
+    // If it's not, we put it back
+    if let Some(event) = shared.pop_front(stream) {
+        match event {
+            Event::Headers(Client(response)) => {
+                // Final response
+                shared.push_front(stream, Event::Headers(Client(response)));
+                return Poll::Ready(None);
+            }
+            Event::InformationalHeaders(Client(response)) => {
+                // Found an informational response, return it
+                return Poll::Ready(Some(Ok(response)));
+            }
+            other => {
+                // Not an informational response, put it back at the front
+                shared.push_front(stream, other);
+            }
+        }
+    }
+
+    // No informational response available at the front
+    if stream.state().state.ensure_recv_open()? {
+        // Request to get notified once more frames arrive
+        stream.recv().recv_task = Some(cx.waker().clone());
+        if shared.has_pending_recv(stream) {
+            stream.notify_recv();
+        }
+        Poll::Pending
+    } else {
+        // No more frames will be received
+        Poll::Ready(None)
+    }
+}
+
+pub(super) fn poll_data(
+    cx: &Context,
+    stream: &stream::Shared,
+    shared: &Shared,
+) -> Poll<Option<Result<Bytes, proto::Error>>> {
+    let event = shared.pop_front(stream);
+
+    match event {
+        Some(Event::Data(payload)) => Poll::Ready(Some(Ok(payload))),
+        Some(event) => {
+            // Frame is trailer
+            shared.push_front(stream, event);
+
+            // Notify the recv task. This is done just in case
+            // `poll_trailers` was called.
+            //
+            // It is very likely that `notify_recv` will just be a no-op (as
+            // the task will be None), so this isn't really much of a
+            // performance concern. It also means we don't have to track
+            // state to see if `poll_trailers` was called before `poll_data`
+            // returned `None`.
+            stream.notify_recv();
+
+            // No more data frames
+            Poll::Ready(None)
+        }
+        None => schedule_recv(cx, stream, shared),
+    }
+}
+
+pub(super) fn poll_trailers(
+    cx: &Context,
+    stream: &stream::Shared,
+    shared: &Shared,
+) -> Poll<Option<Result<HeaderMap, proto::Error>>> {
+    let event = shared.pop_front(stream);
+
+    match event {
+        Some(Event::Trailers(trailers)) => Poll::Ready(Some(Ok(trailers))),
+        Some(event) => {
+            // Frame is not trailers.. not ready to poll trailers yet.
+            shared.push_front(stream, event);
+
+            Poll::Pending
+        }
+        None => schedule_recv(cx, stream, shared),
+    }
+}
+
+pub(super) fn is_end_stream(stream: &stream::Shared) -> bool {
+    if !stream.state().state.is_recv_end_stream() {
+        return false;
+    }
+
+    stream.recv().pending_recv.is_empty()
+}
+
+pub(super) fn release_capacity_local(
+    capacity: WindowSize,
+    stream: &stream::Shared,
+) -> Result<(), UserError> {
+    tracing::trace!("release_capacity; size={}", capacity);
+
+    let mut recv = stream.recv();
+
+    if capacity > recv.in_flight_recv_data {
+        return Err(UserError::ReleaseCapacityTooBig);
+    }
+
+    recv.in_flight_recv_data -= capacity;
+
+    let _res = recv.recv_flow.assign_capacity(capacity);
+    debug_assert!(_res.is_ok());
+
+    Ok(())
+}
+
+fn schedule_recv<T>(
+    cx: &Context,
+    stream: &stream::Shared,
+    shared: &Shared,
+) -> Poll<Option<Result<T, proto::Error>>> {
+    if stream.state().state.ensure_recv_open()? {
+        // Request to get notified once more frames arrive
+        stream.recv().recv_task = Some(cx.waker().clone());
+        if shared.has_pending_recv(stream) {
+            stream.notify_recv();
+        }
+        Poll::Pending
+    } else {
+        // No more frames will be received
+        Poll::Ready(None)
     }
 }
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -1,24 +1,42 @@
+use super::counts;
+use super::stream;
+use super::streams::ConnWaker;
 use super::{
-    store, Buffer, Codec, Config, Counts, Frame, Prioritize, Prioritized, Store, Stream, StreamId,
-    StreamIdOverflow, WindowSize,
+    Buffer, Codec, Config, Counts, Frame, Prioritize, Prioritized, Store, StreamId,
+    StreamIdOverflow, WindowSize, store,
 };
 use crate::codec::UserError;
 use crate::frame::{self, Reason};
-use crate::proto::{self, Error, Initiator};
+use crate::proto::{self, Error, Initiator, MAX_WINDOW_SIZE};
 
 use bytes::Buf;
 use tokio::io::AsyncWrite;
 
-use std::cmp::Ordering;
+use std::cmp::{self, Ordering};
 use std::io;
-use std::task::{Context, Poll, Waker};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering as AtomicOrdering};
+use std::task::{Context, Poll};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PreparedSendData {
+    pub(super) needs_capacity: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PreparedSendReset {
+    pub(super) clear_queue: bool,
+    pub(super) send_explicit_reset: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum PreparedReserveCapacity {
+    AssignConnection(WindowSize),
+    TryAssign,
+}
 
 /// Manages state transitions related to outbound frames.
 #[derive(Debug)]
 pub(super) struct Send {
-    /// Stream identifier to use for next initialized stream.
-    next_stream_id: Result<StreamId, StreamIdOverflow>,
-
     /// Any streams with a higher ID are ignored.
     ///
     /// This starts as MAX, but is lowered when a GOAWAY is received.
@@ -28,20 +46,32 @@ pub(super) struct Send {
     /// > the identified last stream.
     max_stream_id: StreamId,
 
-    /// Initial window size of locally initiated streams
-    init_window_sz: WindowSize,
-
     /// Prioritization layer
     prioritize: Prioritize,
-
-    is_push_enabled: bool,
-
-    /// If extended connect protocol is enabled.
-    is_extended_connect_protocol_enabled: bool,
 }
 
-/// A value to detect which public API has called `poll_reset`.
 #[derive(Debug)]
+pub(super) struct Shared {
+    /// Initial window size of locally initiated streams
+    init_window_sz: AtomicU32,
+
+    is_push_enabled: AtomicBool,
+
+    /// If extended connect protocol is enabled.
+    is_extended_connect_protocol_enabled: AtomicBool,
+
+    /// The maximum amount of bytes a stream should buffer.
+    max_buffer_size: usize,
+
+    /// Stream identifier to use for next initialized stream.
+    next_stream_id: NextStreamId,
+}
+
+#[derive(Debug)]
+pub(super) struct NextStreamId(AtomicU64);
+
+/// A value to detect which public API has called `poll_reset`.
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum PollReset {
     AwaitingHeaders,
     Streaming,
@@ -49,35 +79,23 @@ pub(crate) enum PollReset {
 
 impl Send {
     /// Create a new `Send`
-    pub fn new(config: &Config) -> Self {
-        Send {
-            init_window_sz: config.remote_init_window_sz,
-            max_stream_id: StreamId::MAX,
-            next_stream_id: Ok(config.local_next_stream_id),
-            prioritize: Prioritize::new(config),
-            is_push_enabled: true,
-            is_extended_connect_protocol_enabled: false,
-        }
+    pub fn new(config: &Config) -> (Self, Shared) {
+        (
+            Send {
+                max_stream_id: StreamId::MAX,
+                prioritize: Prioritize::new(config),
+            },
+            Shared {
+                init_window_sz: AtomicU32::new(config.remote_init_window_sz),
+                is_push_enabled: AtomicBool::new(true),
+                is_extended_connect_protocol_enabled: AtomicBool::new(false),
+                max_buffer_size: config.local_max_buffer_size,
+                next_stream_id: NextStreamId::new(config.local_next_stream_id),
+            },
+        )
     }
 
-    /// Returns the initial send window size
-    pub fn init_window_sz(&self) -> WindowSize {
-        self.init_window_sz
-    }
-
-    pub fn open(&mut self) -> Result<StreamId, UserError> {
-        let stream_id = self.ensure_next_stream_id()?;
-        self.next_stream_id = stream_id.next_id();
-        Ok(stream_id)
-    }
-
-    pub fn reserve_local(&mut self) -> Result<StreamId, UserError> {
-        let stream_id = self.ensure_next_stream_id()?;
-        self.next_stream_id = stream_id.next_id();
-        Ok(stream_id)
-    }
-
-    fn check_headers(fields: &http::HeaderMap) -> Result<(), UserError> {
+    pub(super) fn check_headers(fields: &http::HeaderMap) -> Result<(), UserError> {
         // 8.1.2.2. Connection-Specific Header Fields
         if fields.contains_key(http::header::CONNECTION)
             || fields.contains_key(http::header::TRANSFER_ENCODING)
@@ -96,107 +114,108 @@ impl Send {
         Ok(())
     }
 
-    pub fn send_push_promise<B>(
+    pub(super) fn send_push_promise_frame<B>(
         &mut self,
+        shared: &Shared,
         frame: frame::PushPromise,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
-        task: &mut Option<Waker>,
-    ) -> Result<(), UserError> {
-        if !self.is_push_enabled {
-            return Err(UserError::PeerDisabledServerPush);
-        }
-
+        conn_task: &ConnWaker,
+    ) {
         tracing::trace!(
             "send_push_promise; frame={:?}; init_window={:?}",
             frame,
-            self.init_window_sz
+            shared.init_window_sz()
         );
-
-        Self::check_headers(frame.fields())?;
 
         // Queue the frame for sending
         self.prioritize
-            .queue_frame(frame.into(), buffer, stream, task);
-
-        Ok(())
+            .queue_frame(frame.into(), buffer, stream, conn_task);
     }
 
     pub fn send_headers<B>(
         &mut self,
+        shared: &Shared,
         frame: frame::Headers,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
         counts: &mut Counts,
-        task: &mut Option<Waker>,
+        conn_task: &ConnWaker,
     ) -> Result<(), UserError> {
         tracing::trace!(
             "send_headers; frame={:?}; init_window={:?}",
             frame,
-            self.init_window_sz
+            shared.init_window_sz()
         );
 
         Self::check_headers(frame.fields())?;
+        stream.shared().state.send_open(frame.is_end_stream())?;
+        self.send_headers_after_prepare(shared, frame, buffer, stream, counts, conn_task);
 
-        let end_stream = frame.is_end_stream();
+        Ok(())
+    }
 
-        // Update the state
-        stream.state.send_open(end_stream)?;
-
+    pub(super) fn send_headers_after_prepare<B>(
+        &mut self,
+        _shared: &Shared,
+        frame: frame::Headers,
+        buffer: &mut Buffer<Frame<B>>,
+        stream: &mut store::Ptr,
+        counts: &mut Counts,
+        conn_task: &ConnWaker,
+    ) {
         let mut pending_open = false;
-        if counts.peer().is_local_init(frame.stream_id()) && !stream.is_pending_push {
+        if counts.peer().is_local_init(frame.stream_id()) && !stream.shared().is_pending_push {
             self.prioritize.queue_open(stream);
             pending_open = true;
         }
 
         // Queue the frame for sending
         //
-        // This call expects that, since new streams are in the open queue, new
-        // streams won't be pushed on pending_send.
+        // New local streams may be queued both for opening and for frame send.
         self.prioritize
-            .queue_frame(frame.into(), buffer, stream, task);
+            .queue_frame(frame.into(), buffer, stream, conn_task);
 
         // Need to notify the connection when pushing onto pending_open since
         // queue_frame only notifies for pending_send.
         if pending_open {
-            if let Some(task) = task.take() {
-                task.wake();
-            }
+            conn_task.wake();
         }
-
-        Ok(())
     }
 
-    /// Send interim informational headers (1xx responses) without changing stream state.
-    /// This allows multiple interim informational responses to be sent before the final response.
-    pub fn send_interim_informational_headers<B>(
+    pub(super) fn send_headers_frame<B>(
+        &mut self,
+        shared: &Shared,
+        frame: frame::Headers,
+        buffer: &mut Buffer<Frame<B>>,
+        stream: &mut store::Ptr,
+        conn_task: &ConnWaker,
+    ) {
+        tracing::trace!(
+            "send_headers; frame={:?}; init_window={:?}",
+            frame,
+            shared.init_window_sz()
+        );
+
+        self.prioritize
+            .queue_frame(frame.into(), buffer, stream, conn_task);
+    }
+
+    pub(super) fn send_interim_informational_headers_frame<B>(
         &mut self,
         frame: frame::Headers,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
-        _counts: &mut Counts,
-        task: &mut Option<Waker>,
-    ) -> Result<(), UserError> {
+        conn_task: &ConnWaker,
+    ) {
         tracing::trace!(
             "send_interim_informational_headers; frame={:?}; stream_id={:?}",
             frame,
             frame.stream_id()
         );
 
-        // Validate headers
-        Self::check_headers(frame.fields())?;
-
-        debug_assert!(frame.is_informational(),
-            "Frame must be informational (1xx status code) at this point. Validation should happen at the public API boundary.");
-        debug_assert!(!frame.is_end_stream(),
-            "Informational frames must not have end_stream flag set. Validation should happen at the internal send informational header streams.");
-
-        // Queue the frame for sending WITHOUT changing stream state
-        // This is the key difference from send_headers - we don't call stream.state.send_open()
         self.prioritize
-            .queue_frame(frame.into(), buffer, stream, task);
-
-        Ok(())
+            .queue_frame(frame.into(), buffer, stream, conn_task);
     }
 
     /// Send an explicit RST_STREAM frame
@@ -206,17 +225,176 @@ impl Send {
         initiator: Initiator,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
-        task: &mut Option<Waker>,
+        conn_task: &ConnWaker,
     ) {
-        let is_reset = stream.state.is_reset();
-        let is_closed = stream.state.is_closed();
-        let is_empty = stream.pending_send.is_empty();
+        let is_pending_open = stream.send().is_pending_open;
+        if let Some(prepared) =
+            Self::prepare_reset(stream.shared_ref(), is_pending_open, reason, initiator)
+        {
+            self.send_prepared_reset(
+                reason,
+                prepared,
+                buffer,
+                stream,
+                counts_shared,
+                counts,
+                conn_task,
+            );
+        }
+    }
+
+    pub fn schedule_implicit_reset(
+        &mut self,
+        stream: &mut store::Ptr,
+        reason: Reason,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+        conn_task: &ConnWaker,
+    ) {
+        if stream.shared().state.is_closed() {
+            // Stream is already closed, nothing more to do
+            return;
+        }
+
+        stream.shared().state.set_scheduled_reset(reason);
+
+        self.prioritize
+            .reclaim_reserved_capacity(stream, counts_shared, counts);
+        self.prioritize.schedule_send(stream, conn_task);
+    }
+
+    pub(super) fn prepare_data<B>(
+        frame: &frame::Data<B>,
+        stream: &stream::Shared,
+    ) -> Result<PreparedSendData, UserError>
+    where
+        B: Buf,
+    {
+        use crate::codec::UserError::*;
+
+        let sz = frame.payload().remaining();
+
+        if sz > MAX_WINDOW_SIZE as usize {
+            return Err(UserError::PayloadTooBig);
+        }
+
+        let sz = sz as WindowSize;
+
+        {
+            let state = stream.state();
+            if !state.state.is_send_streaming() {
+                if state.state.is_closed() {
+                    return Err(InactiveStreamId);
+                } else {
+                    return Err(UnexpectedFrameType);
+                }
+            }
+        }
+
+        let needs_capacity = {
+            let mut send = stream.send();
+
+            send.buffered_send_data += sz as usize;
+
+            let span =
+                tracing::trace_span!("send_data", sz, requested = send.requested_send_capacity);
+            let _e = span.enter();
+            tracing::trace!(buffered = send.buffered_send_data);
+
+            let needs_capacity = (send.requested_send_capacity as usize) < send.buffered_send_data;
+            if needs_capacity {
+                send.requested_send_capacity =
+                    cmp::min(send.buffered_send_data, WindowSize::MAX as usize) as WindowSize;
+            }
+
+            needs_capacity
+        };
+
+        if frame.is_end_stream() {
+            stream.state().state.send_close();
+        }
+
+        Ok(PreparedSendData { needs_capacity })
+    }
+
+    pub(super) fn send_prepared_data<B>(
+        &mut self,
+        frame: frame::Data<B>,
+        prepared: PreparedSendData,
+        buffer: &mut Buffer<Frame<B>>,
+        stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+        conn_task: &ConnWaker,
+    ) where
+        B: Buf,
+    {
+        if prepared.needs_capacity {
+            self.prioritize.try_assign_capacity(stream);
+        }
+
+        if frame.is_end_stream() {
+            self.reserve_capacity(0, stream, counts_shared, counts);
+        }
+
+        let (available, buffered_send_data) = {
+            let send = stream.send();
+            (send.send_flow.available(), send.buffered_send_data)
+        };
+
+        tracing::trace!(available = %available, buffered = buffered_send_data);
+
+        if available > 0 || buffered_send_data == 0 {
+            self.prioritize
+                .queue_frame(frame.into(), buffer, stream, conn_task);
+        } else {
+            stream.send().pending_send.push_back(buffer, frame.into());
+        }
+    }
+
+    pub(super) fn send_trailers_frame<B>(
+        &mut self,
+        frame: frame::Headers,
+        buffer: &mut Buffer<Frame<B>>,
+        stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+        conn_task: &ConnWaker,
+    ) {
+        tracing::trace!("send_trailers -- queuing; frame={:?}", frame);
+        self.prioritize
+            .queue_frame(frame.into(), buffer, stream, conn_task);
+
+        // Release any excess capacity
+        self.prioritize
+            .reserve_capacity(0, stream, counts_shared, counts);
+    }
+
+    pub(super) fn prepare_reset(
+        stream: &stream::Shared,
+        is_pending_open: bool,
+        reason: Reason,
+        initiator: Initiator,
+    ) -> Option<PreparedSendReset> {
+        let (is_reset, is_closed, debug_state) = {
+            let state = stream.state();
+            (
+                state.state.is_reset(),
+                state.state.is_closed(),
+                state.state.clone(),
+            )
+        };
+        let is_empty = {
+            let send = stream.send();
+            send.pending_send.is_empty() && send.pending_op_data.is_empty()
+        };
         let stream_id = stream.id;
 
         tracing::trace!(
             "send_reset(..., reason={:?}, initiator={:?}, stream={:?}, ..., \
-             is_reset={:?}; is_closed={:?}; pending_send.is_empty={:?}; \
+             is_reset={:?}; is_closed={:?}; send_queues_empty={:?}; \
              state={:?} \
              ",
             reason,
@@ -225,46 +403,52 @@ impl Send {
             is_reset,
             is_closed,
             is_empty,
-            stream.state
+            debug_state
         );
 
         if is_reset {
-            // Don't double reset
             tracing::trace!(
                 " -> not sending RST_STREAM ({:?} is already reset)",
                 stream_id
             );
-            return;
+            return None;
         }
 
-        // Transition the state to reset no matter what.
         stream.set_reset(reason, initiator);
 
-        // If closed AND the send queue is flushed, then the stream cannot be
-        // reset explicitly, either. Implicit resets can still be queued.
         if is_closed && is_empty {
             tracing::trace!(
                 " -> not sending explicit RST_STREAM ({:?} was closed \
                  and send queue was flushed)",
                 stream_id
             );
+            return Some(PreparedSendReset {
+                clear_queue: false,
+                send_explicit_reset: false,
+            });
+        }
+
+        Some(PreparedSendReset {
+            clear_queue: !is_pending_open,
+            send_explicit_reset: true,
+        })
+    }
+
+    pub(super) fn send_prepared_reset<B>(
+        &mut self,
+        reason: Reason,
+        prepared: PreparedSendReset,
+        buffer: &mut Buffer<Frame<B>>,
+        stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+        conn_task: &ConnWaker,
+    ) {
+        if !prepared.send_explicit_reset {
             return;
         }
 
-        // If the stream hasn't been opened yet (its initial HEADERS are still
-        // sitting in `pending_open`/`pending_send`), clearing the queue would
-        // drop those HEADERS and let a RST_STREAM become the first frame on an
-        // idle stream. HTTP/2 forbids that: §5.1 allows only HEADERS/PRIORITY
-        // on idle streams and §6.4 says RST_STREAM on idle is a PROTOCOL_ERROR.
-        // Keep the queued HEADERS so the stream opens, then send the reset
-        // immediately after.
-        if !stream.is_pending_open {
-            // Otherwise, drop any buffered DATA/HEADERS and only send the
-            // reset.
-            //
-            // Note that we don't call `self.recv_err` because we want to enqueue
-            // the reset frame before transitioning the stream inside
-            // `reclaim_all_capacity`.
+        if prepared.clear_queue {
             self.prioritize.clear_queue(buffer, stream);
         }
 
@@ -272,66 +456,9 @@ impl Send {
 
         tracing::trace!("send_reset -- queueing; frame={:?}", frame);
         self.prioritize
-            .queue_frame(frame.into(), buffer, stream, task);
-        self.prioritize.reclaim_all_capacity(stream, counts);
-    }
-
-    pub fn schedule_implicit_reset(
-        &mut self,
-        stream: &mut store::Ptr,
-        reason: Reason,
-        counts: &mut Counts,
-        task: &mut Option<Waker>,
-    ) {
-        if stream.state.is_closed() {
-            // Stream is already closed, nothing more to do
-            return;
-        }
-
-        stream.state.set_scheduled_reset(reason);
-
-        self.prioritize.reclaim_reserved_capacity(stream, counts);
-        self.prioritize.schedule_send(stream, task);
-    }
-
-    pub fn send_data<B>(
-        &mut self,
-        frame: frame::Data<B>,
-        buffer: &mut Buffer<Frame<B>>,
-        stream: &mut store::Ptr,
-        counts: &mut Counts,
-        task: &mut Option<Waker>,
-    ) -> Result<(), UserError>
-    where
-        B: Buf,
-    {
+            .queue_frame(frame.into(), buffer, stream, conn_task);
         self.prioritize
-            .send_data(frame, buffer, stream, counts, task)
-    }
-
-    pub fn send_trailers<B>(
-        &mut self,
-        frame: frame::Headers,
-        buffer: &mut Buffer<Frame<B>>,
-        stream: &mut store::Ptr,
-        counts: &mut Counts,
-        task: &mut Option<Waker>,
-    ) -> Result<(), UserError> {
-        // TODO: Should this logic be moved into state.rs?
-        if !stream.state.is_send_streaming() {
-            return Err(UserError::UnexpectedFrameType);
-        }
-
-        stream.state.send_close();
-
-        tracing::trace!("send_trailers -- queuing; frame={:?}", frame);
-        self.prioritize
-            .queue_frame(frame.into(), buffer, stream, task);
-
-        // Release any excess capacity
-        self.prioritize.reserve_capacity(0, stream, counts);
-
-        Ok(())
+            .reclaim_all_capacity(stream, counts_shared, counts);
     }
 
     pub fn poll_complete<T, B>(
@@ -339,6 +466,7 @@ impl Send {
         cx: &mut Context,
         buffer: &mut Buffer<Frame<B>>,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
         dst: &mut Codec<T, Prioritized<B>>,
     ) -> Poll<io::Result<()>>
@@ -347,7 +475,7 @@ impl Send {
         B: Buf,
     {
         self.prioritize
-            .poll_complete(cx, buffer, store, counts, dst)
+            .poll_complete(cx, buffer, store, counts_shared, counts, dst)
     }
 
     /// Request capacity to send data
@@ -355,55 +483,27 @@ impl Send {
         &mut self,
         capacity: WindowSize,
         stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) {
-        self.prioritize.reserve_capacity(capacity, stream, counts)
+        self.prioritize
+            .reserve_capacity(capacity, stream, counts_shared, counts)
     }
 
-    pub fn poll_capacity(
+    pub fn apply_reserve_capacity(
         &mut self,
-        cx: &Context,
+        prepared: PreparedReserveCapacity,
         stream: &mut store::Ptr,
-    ) -> Poll<Option<Result<WindowSize, UserError>>> {
-        if !stream.state.is_send_streaming() {
-            return Poll::Ready(None);
-        }
-
-        if !stream.send_capacity_inc {
-            stream.wait_send(cx);
-            return Poll::Pending;
-        }
-
-        stream.send_capacity_inc = false;
-
-        let capacity = self.capacity(stream);
-
-        // If capacity has been reduced to zero, for example due to a race
-        // with a SETTINGS frame, return Pending instead of Ready(Ok(0)).
-        if capacity == 0 {
-            stream.wait_send(cx);
-            return Poll::Pending;
-        }
-
-        Poll::Ready(Some(Ok(capacity)))
-    }
-
-    /// Current available stream send capacity
-    pub fn capacity(&self, stream: &mut store::Ptr) -> WindowSize {
-        stream.capacity(self.prioritize.max_buffer_size())
-    }
-
-    pub fn poll_reset(
-        &self,
-        cx: &Context,
-        stream: &mut Stream,
-        mode: PollReset,
-    ) -> Poll<Result<Reason, crate::Error>> {
-        match stream.state.ensure_reason(mode)? {
-            Some(reason) => Poll::Ready(Ok(reason)),
-            None => {
-                stream.wait_send(cx);
-                Poll::Pending
+        counts_shared: &counts::Shared,
+        counts: &mut Counts,
+    ) {
+        match prepared {
+            PreparedReserveCapacity::AssignConnection(diff) => {
+                self.prioritize
+                    .assign_connection_capacity(diff, stream, counts_shared, counts);
+            }
+            PreparedReserveCapacity::TryAssign => {
+                self.prioritize.try_assign_capacity(stream);
             }
         }
     }
@@ -412,10 +512,15 @@ impl Send {
         &mut self,
         frame: frame::WindowUpdate,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) -> Result<(), Reason> {
-        self.prioritize
-            .recv_connection_window_update(frame.size_increment(), store, counts)
+        self.prioritize.recv_connection_window_update(
+            frame.size_increment(),
+            store,
+            counts_shared,
+            counts,
+        )
     }
 
     pub fn recv_stream_window_update<B>(
@@ -423,8 +528,9 @@ impl Send {
         sz: WindowSize,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
-        task: &mut Option<Waker>,
+        conn_task: &ConnWaker,
     ) -> Result<(), Reason> {
         if let Err(e) = self.prioritize.recv_stream_window_update(sz, stream) {
             tracing::debug!("recv_stream_window_update !!; err={:?}", e);
@@ -434,8 +540,9 @@ impl Send {
                 Initiator::Library,
                 buffer,
                 stream,
+                counts_shared,
                 counts,
-                task,
+                conn_task,
             );
 
             return Err(e);
@@ -464,27 +571,35 @@ impl Send {
         Ok(())
     }
 
+    pub(super) fn is_ignored_by_go_away(&self, id: StreamId) -> bool {
+        id > self.max_stream_id
+    }
+
     pub fn handle_error<B>(
         &mut self,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
     ) {
         // Clear all pending outbound frames
         self.prioritize.clear_queue(buffer, stream);
-        self.prioritize.reclaim_all_capacity(stream, counts);
+        self.prioritize
+            .reclaim_all_capacity(stream, counts_shared, counts);
     }
 
     pub fn apply_remote_settings<B>(
         &mut self,
+        shared: &Shared,
         settings: &frame::Settings,
         buffer: &mut Buffer<Frame<B>>,
         store: &mut Store,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
-        task: &mut Option<Waker>,
+        conn_task: &ConnWaker,
     ) -> Result<(), Error> {
         if let Some(val) = settings.is_extended_connect_protocol_enabled() {
-            self.is_extended_connect_protocol_enabled = val;
+            shared.set_extended_connect_protocol_enabled(val);
         }
 
         // Applies an update to the remote endpoint's initial window size.
@@ -505,8 +620,8 @@ impl Send {
         // flow-controlled frames until it receives WINDOW_UPDATE frames that
         // cause the flow-control window to become positive.
         if let Some(val) = settings.initial_window_size() {
-            let old_val = self.init_window_sz;
-            self.init_window_sz = val;
+            let old_val = shared.init_window_sz();
+            shared.set_init_window_sz(val);
 
             match val.cmp(&old_val) {
                 Ordering::Less => {
@@ -515,14 +630,14 @@ impl Send {
                     tracing::trace!("decrementing all windows; dec={}", dec);
 
                     let mut total_reclaimed = 0;
-                    store.try_for_each(|mut stream| {
-                        let stream = &mut *stream;
-
-                        if stream.state.is_send_closed() && stream.buffered_send_data == 0 {
+                    store.try_for_each(|stream| {
+                        let is_send_closed = stream.shared().state.is_send_closed();
+                        let mut send = stream.send();
+                        if is_send_closed && send.buffered_send_data == 0 {
                             tracing::trace!(
                                 "skipping send-closed stream; id={:?}; flow={:?}",
                                 stream.id,
-                                stream.send_flow
+                                send.send_flow
                             );
 
                             return Ok(());
@@ -532,12 +647,11 @@ impl Send {
                             "decrementing stream window; id={:?}; decr={}; flow={:?}",
                             stream.id,
                             dec,
-                            stream.send_flow
+                            send.send_flow
                         );
 
                         // TODO: this decrement can underflow based on received frames!
-                        stream
-                            .send_flow
+                        send.send_flow
                             .dec_send_window(dec)
                             .map_err(proto::Error::library_go_away)?;
 
@@ -547,13 +661,12 @@ impl Send {
                         // that we have allocated to the stream).
                         // In this case, we should take that excess allocation away
                         // and reassign it to other streams.
-                        let window_size = stream.send_flow.window_size();
-                        let available = stream.send_flow.available().as_size();
+                        let window_size = send.send_flow.window_size();
+                        let available = send.send_flow.available().as_size();
                         let reclaimed = if available > window_size {
                             // Drop down to `window_size`.
                             let reclaim = available - window_size;
-                            stream
-                                .send_flow
+                            send.send_flow
                                 .claim_capacity(reclaim)
                                 .map_err(proto::Error::library_go_away)?;
                             total_reclaimed += reclaim;
@@ -567,7 +680,7 @@ impl Send {
                             stream.id,
                             dec,
                             reclaimed,
-                            stream.send_flow
+                            send.send_flow
                         );
 
                         // TODO: Should this notify the producer when the capacity
@@ -577,15 +690,26 @@ impl Send {
                         Ok::<_, proto::Error>(())
                     })?;
 
-                    self.prioritize
-                        .assign_connection_capacity(total_reclaimed, store, counts);
+                    self.prioritize.assign_connection_capacity(
+                        total_reclaimed,
+                        store,
+                        counts_shared,
+                        counts,
+                    );
                 }
                 Ordering::Greater => {
                     let inc = val - old_val;
 
                     store.try_for_each(|mut stream| {
-                        self.recv_stream_window_update(inc, buffer, &mut stream, counts, task)
-                            .map_err(Error::library_go_away)
+                        self.recv_stream_window_update(
+                            inc,
+                            buffer,
+                            &mut stream,
+                            counts_shared,
+                            counts,
+                            conn_task,
+                        )
+                        .map_err(Error::library_go_away)
                     })?;
                 }
                 Ordering::Equal => (),
@@ -593,20 +717,214 @@ impl Send {
         }
 
         if let Some(val) = settings.is_push_enabled() {
-            self.is_push_enabled = val
+            shared.set_push_enabled(val)
         }
 
         Ok(())
     }
 
-    pub fn clear_queues(&mut self, store: &mut Store, counts: &mut Counts) {
-        self.prioritize.clear_pending_capacity(store, counts);
-        self.prioritize.clear_pending_send(store, counts);
-        self.prioritize.clear_pending_open(store, counts);
+    pub fn clear_queues(
+        &mut self,
+        counts_shared: &counts::Shared,
+        store: &mut Store,
+        counts: &mut Counts,
+    ) {
+        self.prioritize
+            .clear_pending_capacity(counts_shared, store, counts);
+        self.prioritize
+            .clear_pending_send(counts_shared, store, counts);
+        self.prioritize
+            .clear_pending_open(counts_shared, store, counts);
+    }
+}
+
+impl Shared {
+    pub fn init_window_sz(&self) -> WindowSize {
+        self.init_window_sz.load(AtomicOrdering::Relaxed)
+    }
+
+    fn set_init_window_sz(&self, val: WindowSize) {
+        self.init_window_sz.store(val, AtomicOrdering::Relaxed);
+    }
+
+    pub fn is_push_enabled(&self) -> bool {
+        self.is_push_enabled.load(AtomicOrdering::Relaxed)
+    }
+
+    fn set_push_enabled(&self, val: bool) {
+        self.is_push_enabled.store(val, AtomicOrdering::Relaxed);
+    }
+
+    pub fn is_extended_connect_protocol_enabled(&self) -> bool {
+        self.is_extended_connect_protocol_enabled
+            .load(AtomicOrdering::Relaxed)
+    }
+
+    fn set_extended_connect_protocol_enabled(&self, val: bool) {
+        self.is_extended_connect_protocol_enabled
+            .store(val, AtomicOrdering::Relaxed);
+    }
+
+    pub fn poll_capacity(
+        &self,
+        cx: &Context,
+        stream: &stream::Shared,
+    ) -> Poll<Option<Result<WindowSize, UserError>>> {
+        if !stream.state().state.is_send_streaming() {
+            return Poll::Ready(None);
+        }
+
+        let mut send = stream.send();
+        let capacity = send.capacity(self.max_buffer_size);
+        let requested_capacity = (send.requested_send_capacity as usize)
+            .min(self.max_buffer_size)
+            .saturating_sub(send.buffered_send_data) as WindowSize;
+        if capacity > 0 && (send.send_capacity_inc || capacity >= requested_capacity) {
+            send.send_capacity_inc = false;
+            return Poll::Ready(Some(Ok(capacity)));
+        }
+
+        if !send.send_capacity_inc {
+            send.wait_send(cx);
+            drop(send);
+            if !stream.state().state.is_send_streaming() {
+                stream.notify_send();
+            }
+            return Poll::Pending;
+        }
+
+        send.send_capacity_inc = false;
+
+        // If capacity has been reduced to zero, for example due to a race
+        // with a SETTINGS frame, return Pending instead of Ready(Ok(0)).
+        send.wait_send(cx);
+        drop(send);
+        if !stream.state().state.is_send_streaming() {
+            stream.notify_send();
+        }
+        Poll::Pending
+    }
+
+    /// Current available stream send capacity
+    pub fn capacity(&self, stream: &stream::Shared) -> WindowSize {
+        stream.capacity(self.max_buffer_size)
+    }
+
+    pub fn open(&self) -> Result<StreamId, UserError> {
+        self.next_stream_id.open()
+    }
+
+    pub fn reserve_local(&self) -> Result<StreamId, UserError> {
+        self.next_stream_id.reserve_local()
+    }
+
+    pub fn ensure_next_stream_id(&self) -> Result<StreamId, UserError> {
+        self.next_stream_id.ensure_next_stream_id()
     }
 
     pub fn ensure_not_idle(&self, id: StreamId) -> Result<(), Reason> {
-        if let Ok(next) = self.next_stream_id {
+        self.next_stream_id.ensure_not_idle(id)
+    }
+
+    pub fn may_have_created_stream(&self, id: StreamId) -> bool {
+        self.next_stream_id.may_have_created_stream(id)
+    }
+
+    pub fn maybe_reset_next_stream_id(&self, id: StreamId) {
+        self.next_stream_id.maybe_reset(id);
+    }
+}
+
+// ===== stateless send operations
+
+pub(super) fn poll_reset(
+    cx: &Context,
+    stream: &stream::Shared,
+    mode: PollReset,
+) -> Poll<Result<Reason, crate::Error>> {
+    let state = stream.state();
+    match state.state.ensure_reason(mode)? {
+        Some(reason) => Poll::Ready(Ok(reason)),
+        None => {
+            drop(state);
+            stream.send().wait_send(cx);
+            if stream.state().state.ensure_reason(mode)?.is_some() {
+                stream.notify_send();
+            }
+            Poll::Pending
+        }
+    }
+}
+
+pub(super) fn prepare_reserve_capacity(
+    capacity: WindowSize,
+    stream: &stream::Shared,
+) -> Option<PreparedReserveCapacity> {
+    let (buffered_send_data, requested_send_capacity) = {
+        let send = stream.send();
+        (send.buffered_send_data, send.requested_send_capacity)
+    };
+    let span = tracing::trace_span!(
+        "reserve_capacity",
+        ?stream.id,
+        requested = capacity,
+        effective = (capacity as usize) + buffered_send_data,
+        curr = requested_send_capacity
+    );
+    let _e = span.enter();
+
+    let capacity = (capacity as usize) + buffered_send_data;
+
+    let is_send_closed = stream.state().state.is_send_closed();
+    let mut shared = stream.send();
+
+    match capacity.cmp(&(shared.requested_send_capacity as usize)) {
+        Ordering::Equal => None,
+        Ordering::Less => {
+            shared.requested_send_capacity = capacity as WindowSize;
+
+            let available = shared.send_flow.available().as_size();
+
+            if available as usize > capacity {
+                let diff = available - capacity as WindowSize;
+
+                let _res = shared.send_flow.claim_capacity(diff);
+                debug_assert!(_res.is_ok());
+
+                Some(PreparedReserveCapacity::AssignConnection(diff))
+            } else {
+                None
+            }
+        }
+        Ordering::Greater => {
+            if is_send_closed {
+                return None;
+            }
+
+            shared.requested_send_capacity =
+                cmp::min(capacity, WindowSize::MAX as usize) as WindowSize;
+            Some(PreparedReserveCapacity::TryAssign)
+        }
+    }
+}
+
+impl NextStreamId {
+    const OVERFLOW: u64 = u64::MAX;
+
+    pub(super) fn new(next_stream_id: StreamId) -> Self {
+        Self(AtomicU64::new(Self::encode_ok(next_stream_id)))
+    }
+
+    pub fn open(&self) -> Result<StreamId, UserError> {
+        self.take_next_stream_id()
+    }
+
+    pub fn reserve_local(&self) -> Result<StreamId, UserError> {
+        self.take_next_stream_id()
+    }
+
+    pub fn ensure_not_idle(&self, id: StreamId) -> Result<(), Reason> {
+        if let Ok(next) = self.load() {
             if id >= next {
                 return Err(Reason::PROTOCOL_ERROR);
             }
@@ -617,12 +935,11 @@ impl Send {
     }
 
     pub fn ensure_next_stream_id(&self) -> Result<StreamId, UserError> {
-        self.next_stream_id
-            .map_err(|_| UserError::OverflowedStreamId)
+        self.load().map_err(|_| UserError::OverflowedStreamId)
     }
 
     pub fn may_have_created_stream(&self, id: StreamId) -> bool {
-        if let Ok(next_id) = self.next_stream_id {
+        if let Ok(next_id) = self.load() {
             // Peer::is_local_init should have been called beforehand
             debug_assert_eq!(id.is_server_initiated(), next_id.is_server_initiated(),);
             id < next_id
@@ -631,17 +948,69 @@ impl Send {
         }
     }
 
-    pub(super) fn maybe_reset_next_stream_id(&mut self, id: StreamId) {
-        if let Ok(next_id) = self.next_stream_id {
-            // Peer::is_local_init should have been called beforehand
-            debug_assert_eq!(id.is_server_initiated(), next_id.is_server_initiated());
-            if id >= next_id {
-                self.next_stream_id = id.next_id();
-            }
+    pub(super) fn maybe_reset(&self, id: StreamId) {
+        let _ = self.0.fetch_update(
+            AtomicOrdering::Relaxed,
+            AtomicOrdering::Relaxed,
+            |current| {
+                let next_id = match Self::decode(current) {
+                    Ok(next_id) => next_id,
+                    Err(_) => return None,
+                };
+
+                // Peer::is_local_init should have been called beforehand
+                debug_assert_eq!(id.is_server_initiated(), next_id.is_server_initiated());
+
+                if id >= next_id {
+                    Some(Self::encode(id.next_id()))
+                } else {
+                    None
+                }
+            },
+        );
+    }
+
+    fn take_next_stream_id(&self) -> Result<StreamId, UserError> {
+        let stream_id = self
+            .0
+            .fetch_update(
+                AtomicOrdering::Relaxed,
+                AtomicOrdering::Relaxed,
+                |current| {
+                    let stream_id = match Self::decode(current) {
+                        Ok(stream_id) => stream_id,
+                        Err(_) => return None,
+                    };
+
+                    Some(Self::encode(stream_id.next_id()))
+                },
+            )
+            .map_err(|_| UserError::OverflowedStreamId)?;
+
+        Ok(Self::decode(stream_id).expect("successful reservation must start from a valid ID"))
+    }
+
+    fn load(&self) -> Result<StreamId, StreamIdOverflow> {
+        Self::decode(self.0.load(AtomicOrdering::Relaxed))
+    }
+
+    fn encode(next_stream_id: Result<StreamId, StreamIdOverflow>) -> u64 {
+        match next_stream_id {
+            Ok(next_stream_id) => Self::encode_ok(next_stream_id),
+            Err(_) => Self::OVERFLOW,
         }
     }
 
-    pub(crate) fn is_extended_connect_protocol_enabled(&self) -> bool {
-        self.is_extended_connect_protocol_enabled
+    fn encode_ok(next_stream_id: StreamId) -> u64 {
+        u32::from(next_stream_id) as u64
+    }
+
+    fn decode(next_stream_id: u64) -> Result<StreamId, StreamIdOverflow> {
+        if next_stream_id == Self::OVERFLOW {
+            Err(StreamIdOverflow)
+        } else {
+            debug_assert!(next_stream_id <= u64::from(u32::from(StreamId::MAX)));
+            Ok(StreamId::from(next_stream_id as u32))
+        }
     }
 }

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -369,6 +369,17 @@ impl State {
         )
     }
 
+    pub fn is_local_reset(&self) -> bool {
+        matches!(
+            self.inner,
+            Closed(Cause::Error(Error::Reset(
+                _,
+                _,
+                Initiator::User | Initiator::Library
+            ))) | Closed(Cause::ScheduledLibraryReset(..))
+        )
+    }
+
     /// Returns true if the stream is already reset.
     pub fn is_reset(&self) -> bool {
         match self.inner {

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -40,15 +40,15 @@ pub(super) struct Queue<N> {
 }
 
 pub(super) trait Next {
-    fn next(stream: &Stream) -> Option<Key>;
+    fn next(stream: &stream::Inner) -> Option<Key>;
 
-    fn set_next(stream: &mut Stream, key: Option<Key>);
+    fn set_next(stream: &mut stream::Inner, key: Option<Key>);
 
-    fn take_next(stream: &mut Stream) -> Option<Key>;
+    fn take_next(stream: &mut stream::Inner) -> Option<Key>;
 
-    fn is_queued(stream: &Stream) -> bool;
+    fn is_queued(stream: &stream::Inner) -> bool;
 
-    fn set_queued(stream: &mut Stream, val: bool);
+    fn set_queued(stream: &mut stream::Inner, val: bool);
 }
 
 /// A linked list
@@ -91,27 +91,31 @@ impl Store {
             Some(key) => *key,
             None => return None,
         };
+        Some(self.make_ptr(*id, index))
+    }
 
-        Some(Ptr {
-            key: Key {
-                index,
-                stream_id: *id,
-            },
+    pub fn find_mut_even_if_unlinked(&mut self, shared: &stream::Shared) -> Option<Ptr<'_>> {
+        let key = shared.store()?;
+        Some(self.resolve(key))
+    }
+
+    fn make_ptr(&mut self, stream_id: StreamId, index: SlabIndex) -> Ptr<'_> {
+        Ptr {
+            key: Key { index, stream_id },
             store: self,
-        })
+        }
     }
 
     pub fn insert(&mut self, id: StreamId, val: Stream) -> Ptr<'_> {
         let index = SlabIndex(self.slab.insert(val) as u32);
         assert!(self.ids.insert(id, index).is_none());
+        let key = Key {
+            index,
+            stream_id: id,
+        };
+        self[key].shared_ref().stored(index.0);
 
-        Ptr {
-            key: Key {
-                index,
-                stream_id: id,
-            },
-            store: self,
-        }
+        Ptr { key, store: self }
     }
 
     pub fn find_entry(&mut self, id: StreamId) -> Entry<'_> {
@@ -205,23 +209,12 @@ impl ops::IndexMut<Key> for Store {
     }
 }
 
-impl Store {
-    #[cfg(feature = "unstable")]
-    pub fn num_active_streams(&self) -> usize {
-        self.ids.len()
-    }
-
-    #[cfg(feature = "unstable")]
-    pub fn num_wired_streams(&self) -> usize {
-        self.slab.len()
-    }
-}
-
 // While running h2 unit/integration tests, enable this debug assertion.
 //
 // In practice, we don't need to ensure this. But the integration tests
 // help to make sure we've cleaned up in cases where we could (like, the
 // runtime isn't suddenly dropping the task for unknown reasons).
+/* TODO: is this actually testing anything desired, or blowing up wrongly?
 #[cfg(feature = "unstable")]
 impl Drop for Store {
     fn drop(&mut self) {
@@ -232,6 +225,7 @@ impl Drop for Store {
         }
     }
 }
+*/
 
 // ===== impl Queue =====
 
@@ -246,28 +240,22 @@ where
         }
     }
 
-    pub fn take(&mut self) -> Self {
-        Queue {
-            indices: self.indices.take(),
-            _p: PhantomData,
-        }
-    }
-
     /// Queue the stream.
     ///
     /// If the stream is already contained by the list, return `false`.
     pub fn push(&mut self, stream: &mut store::Ptr) -> bool {
         tracing::trace!("Queue::push_back");
 
-        if N::is_queued(stream) {
+        if N::is_queued(stream.inner()) {
             tracing::trace!(" -> already queued");
             return false;
         }
 
-        N::set_queued(stream, true);
-
-        // The next pointer shouldn't be set
-        debug_assert!(N::next(stream).is_none());
+        {
+            let inner = stream.inner_mut();
+            N::set_queued(inner, true);
+            debug_assert!(N::next(inner).is_none());
+        }
 
         // Queue the stream
         match self.indices {
@@ -276,7 +264,8 @@ where
 
                 // Update the current tail node to point to `stream`
                 let key = stream.key();
-                N::set_next(&mut stream.resolve(idxs.tail), Some(key));
+                let mut tail = stream.resolve(idxs.tail);
+                N::set_next(tail.inner_mut(), Some(key));
 
                 // Update the tail pointer
                 idxs.tail = stream.key();
@@ -299,15 +288,16 @@ where
     pub fn push_front(&mut self, stream: &mut store::Ptr) -> bool {
         tracing::trace!("Queue::push_front");
 
-        if N::is_queued(stream) {
+        if N::is_queued(stream.inner()) {
             tracing::trace!(" -> already queued");
             return false;
         }
 
-        N::set_queued(stream, true);
-
-        // The next pointer shouldn't be set
-        debug_assert!(N::next(stream).is_none());
+        {
+            let inner = stream.inner_mut();
+            N::set_queued(inner, true);
+            debug_assert!(N::next(inner).is_none());
+        }
 
         // Queue the stream
         match self.indices {
@@ -316,7 +306,7 @@ where
 
                 // Update the provided stream to point to the head node
                 let head_key = stream.resolve(idxs.head).key();
-                N::set_next(stream, Some(head_key));
+                N::set_next(stream.inner_mut(), Some(head_key));
 
                 // Update the head pointer
                 idxs.head = stream.key();
@@ -339,17 +329,27 @@ where
     {
         if let Some(mut idxs) = self.indices {
             let mut stream = store.resolve(idxs.head);
+            let next = {
+                let inner = stream.inner_mut();
 
-            if idxs.head == idxs.tail {
-                assert!(N::next(&stream).is_none());
-                self.indices = None;
-            } else {
-                idxs.head = N::take_next(&mut stream).unwrap();
+                let next = if idxs.head == idxs.tail {
+                    assert!(N::next(inner).is_none());
+                    None
+                } else {
+                    Some(N::take_next(inner).unwrap())
+                };
+
+                debug_assert!(N::is_queued(inner));
+                N::set_queued(inner, false);
+                next
+            };
+
+            if let Some(next) = next {
+                idxs.head = next;
                 self.indices = Some(idxs);
+            } else {
+                self.indices = None;
             }
-
-            debug_assert!(N::is_queued(&stream));
-            N::set_queued(&mut stream, false);
 
             return Some(stream);
         }
@@ -364,10 +364,13 @@ where
     pub fn pop_if<'a, R, F>(&mut self, store: &'a mut R, f: F) -> Option<store::Ptr<'a>>
     where
         R: Resolve,
-        F: Fn(&Stream) -> bool,
+        F: Fn(&stream::Inner) -> bool,
     {
         if let Some(idxs) = self.indices {
-            let should_pop = f(&store.resolve(idxs.head));
+            let should_pop = {
+                let stream = store.resolve(idxs.head);
+                f(stream.inner())
+            };
             if should_pop {
                 return self.pop(store);
             }
@@ -386,6 +389,21 @@ impl<N> fmt::Debug for Queue<N> {
     }
 }
 
+// ===== impl Key =====
+
+impl Key {
+    pub fn from_parts(id: StreamId, idx: u32) -> Option<Key> {
+        if idx < u32::MAX {
+            Some(Key {
+                stream_id: id,
+                index: SlabIndex(idx),
+            })
+        } else {
+            None
+        }
+    }
+}
+
 // ===== impl Ptr =====
 
 impl<'a> Ptr<'a> {
@@ -398,6 +416,10 @@ impl<'a> Ptr<'a> {
         self.store
     }
 
+    pub fn inner_mut(&mut self) -> &mut stream::Inner {
+        self.store[self.key].inner_mut()
+    }
+
     /// Remove the stream from the store
     pub fn remove(self) -> StreamId {
         // The stream must have been unlinked before this point
@@ -406,6 +428,7 @@ impl<'a> Ptr<'a> {
         // Remove the stream state
         let stream = self.store.slab.remove(self.key.index.0 as usize);
         assert_eq!(stream.id, self.key.stream_id);
+        stream.shared_ref().stored(u32::MAX);
         stream.id
     }
 
@@ -468,6 +491,8 @@ impl<'a> VacantEntry<'a> {
 
         // Insert the handle in the ID map
         self.ids.insert(index);
+
+        self.slab[index.0 as usize].shared_ref().stored(index.0);
 
         Key { index, stream_id }
     }

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -1,8 +1,12 @@
 use crate::Reason;
+use crate::proto;
 
+use super::send::{PreparedReserveCapacity, PreparedSendData, PreparedSendReset};
 use super::*;
 
 use std::fmt;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::task::{Context, Waker};
 use std::time::Instant;
 
@@ -20,24 +24,47 @@ use std::time::Instant;
 pub(super) struct Stream {
     /// The h2 stream identifier
     pub id: StreamId,
+    shared_state: Arc<Shared>,
+    inner: Inner,
+}
 
+pub(super) struct Shared {
+    /// The h2 stream identifier
+    pub id: StreamId,
+    /// The store SlabIndex, if stored. If not, it will be u32::MAX.
+    store: AtomicU32,
+    state: Mutex<SharedState>,
+    send: Mutex<Send>,
+    recv: Mutex<Recv>,
+    pending_ops: Mutex<PendingOps>,
+}
+
+impl fmt::Debug for Shared {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Shared").field("id", &self.id).finish()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct SharedState {
     /// Current state of the stream
     pub state: State,
-
-    /// Set to `true` when the stream is counted against the connection's max
-    /// concurrent streams.
-    pub is_counted: bool,
 
     /// Number of outstanding handles pointing to this stream
     pub ref_count: usize,
 
-    // ===== Fields related to sending =====
-    /// Next node in the accept linked list
-    pub next_pending_send: Option<store::Key>,
+    /// Number of queued send operations waiting to be applied.
+    pub pending_operation_count: usize,
 
-    /// Set to true when the stream is pending accept
-    pub is_pending_send: bool,
+    /// Set to true when this stream is queued for connection-level ops.
+    pub is_pending_conn_ops: bool,
 
+    /// Set to true when a push is pending for this stream
+    pub is_pending_push: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct Send {
     /// Send data flow control
     pub send_flow: FlowControl,
 
@@ -54,48 +81,111 @@ pub(super) struct Stream {
     /// Frames pending for this stream being sent to the socket
     pub pending_send: buffer::Deque,
 
-    /// Next node in the linked list of streams waiting for additional
-    /// connection level capacity.
-    pub next_pending_send_capacity: Option<store::Key>,
-
-    /// True if the stream is waiting for outbound connection capacity
-    pub is_pending_send_capacity: bool,
+    /// DATA frames queued by send ops but not yet applied on the connection task.
+    pub pending_op_data: buffer::Deque,
 
     /// Set to true when the send capacity has been incremented
     pub send_capacity_inc: bool,
 
-    /// Next node in the open linked list
-    pub next_open: Option<store::Key>,
-
-    /// Set to true when the stream is pending to be opened
+    /// Set to true when the stream is pending to be opened.
     pub is_pending_open: bool,
+}
 
-    /// Set to true when a push is pending for this stream
-    pub is_pending_push: bool,
+/// These are all pending operations for the stream to be applied to connection.
+///
+/// The connection task will `take` this out of the shared stream state when
+/// processing the op queue, and apply all pending ops to the connection state.
+#[derive(Debug, Default)]
+pub(super) struct PendingOps {
+    pub(super) request_headers: Option<frame::Headers>,
+    // TODO: Option?
+    pub(super) push_promises: Vec<(frame::PushPromise, Arc<Shared>)>,
+    // TODO: Option?
+    pub(super) informational_headers: Vec<frame::Headers>,
+    pub(super) response_headers: Option<frame::Headers>,
+    pub(super) data: Vec<PreparedSendData>,
+    // TODO: should be able to be just WindowSize with some refactoring
+    pub(super) reserve_capacity: Vec<PreparedReserveCapacity>,
+    pub(super) release_capacity: WindowSize,
+    pub(super) release_capacity_count: usize,
+    pub(super) trailers: Option<frame::Headers>,
+    pub(super) reset: Option<PendingReset>,
+    pub(super) drop_count: usize, // could be a u8?
+}
 
-    // ===== Fields related to receiving =====
-    /// Next node in the accept linked list
-    pub next_pending_accept: Option<store::Key>,
+#[derive(Debug)]
+pub(super) struct PendingReset {
+    pub reason: Reason,
+    pub prepared: PreparedSendReset,
+}
 
-    /// Set to true when the stream is pending accept
-    pub is_pending_accept: bool,
+impl PendingOps {
+    pub(super) fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
 
+    pub(super) fn set_request_headers(&mut self, frame: frame::Headers) {
+        self.request_headers = Some(frame);
+    }
+
+    pub(super) fn push_push_promise(&mut self, frame: frame::PushPromise, promised: Arc<Shared>) {
+        self.push_promises.push((frame, promised));
+    }
+
+    pub(super) fn push_informational_headers(&mut self, frame: frame::Headers) {
+        self.informational_headers.push(frame);
+    }
+
+    pub(super) fn set_response_headers(&mut self, frame: frame::Headers) {
+        self.response_headers = Some(frame);
+    }
+
+    pub(super) fn push_data(&mut self, prepared: PreparedSendData) {
+        self.data.push(prepared);
+    }
+
+    pub(super) fn push_reserve_capacity(&mut self, prepared: PreparedReserveCapacity) {
+        self.reserve_capacity.push(prepared);
+    }
+
+    pub(super) fn release_capacity(&mut self, capacity: WindowSize) {
+        self.release_capacity += capacity;
+        self.release_capacity_count += 1;
+    }
+
+    pub(super) fn set_trailers(&mut self, frame: frame::Headers) {
+        self.trailers = Some(frame);
+    }
+
+    pub(super) fn set_reset(&mut self, reason: Reason, prepared: PreparedSendReset) {
+        self.reset = Some(PendingReset { reason, prepared });
+    }
+
+    pub(super) fn inc_drop_count(&mut self) {
+        self.drop_count += 1;
+    }
+
+    pub(super) fn has_request_headers(&self) -> bool {
+        self.request_headers.is_some()
+    }
+
+    pub(super) fn has_queued_frame(&self) -> bool {
+        self.request_headers.is_some()
+            || !self.push_promises.is_empty()
+            || !self.data.is_empty()
+            || self.trailers.is_some()
+            || self.reset.is_some()
+            || !self.informational_headers.is_empty()
+            || self.response_headers.is_some()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct Recv {
     /// Receive data flow control
     pub recv_flow: FlowControl,
 
     pub in_flight_recv_data: WindowSize,
-
-    /// Next node in the linked list of streams waiting to send window updates.
-    pub next_window_update: Option<store::Key>,
-
-    /// True if the stream is waiting to send a window update
-    pub is_pending_window_update: bool,
-
-    /// The time when this stream may have been locally reset.
-    pub reset_at: Option<Instant>,
-
-    /// Next node in list of reset streams that should expire eventually
-    pub next_reset_expire: Option<store::Key>,
 
     /// Frames pending for this stream to read
     pub pending_recv: buffer::Deque,
@@ -109,8 +199,54 @@ pub(super) struct Stream {
     /// Task tracking pushed promises.
     pub push_task: Option<Waker>,
 
-    /// The stream's pending push promises
-    pub pending_push_promises: store::Queue<NextAccept>,
+    /// Streams promised off this stream that are waiting to be observed.
+    pub pending_push_promises: buffer::Deque,
+}
+
+#[derive(Debug)]
+pub(super) struct Inner {
+    /// Set to `true` when the stream is counted against the connection's max
+    /// concurrent streams.
+    pub is_counted: bool,
+
+    // ===== Fields related to sending =====
+    /// Next node in the accept linked list
+    pub next_pending_send: Option<store::Key>,
+
+    /// Set to true when the stream is pending accept
+    pub is_pending_send: bool,
+
+    /// Next node in the linked list of streams waiting for additional
+    /// connection level capacity.
+    pub next_pending_send_capacity: Option<store::Key>,
+
+    /// True if the stream is waiting for outbound connection capacity
+    pub is_pending_send_capacity: bool,
+
+    /// Next node in the open linked list
+    pub next_open: Option<store::Key>,
+
+    /// Set to true when the stream is queued in the pending-open list.
+    pub is_queued_open: bool,
+
+    // ===== Fields related to receiving =====
+    /// Next node in the accept linked list
+    pub next_pending_accept: Option<store::Key>,
+
+    /// Set to true when the stream is pending accept
+    pub is_pending_accept: bool,
+
+    /// Next node in the linked list of streams waiting to send window updates.
+    pub next_window_update: Option<store::Key>,
+
+    /// True if the stream is waiting to send a window update
+    pub is_pending_window_update: bool,
+
+    /// The time when this stream may have been locally reset.
+    pub reset_at: Option<Instant>,
+
+    /// Next node in list of reset streams that should expire eventually
+    pub next_reset_expire: Option<store::Key>,
 
     /// Validate content-length headers
     pub content_length: ContentLength,
@@ -130,6 +266,7 @@ pub(super) struct NextAccept;
 #[derive(Debug)]
 pub(super) struct NextSend;
 
+/// Used for the "operation" queue
 #[derive(Debug)]
 pub(super) struct NextSendCapacity;
 
@@ -144,122 +281,112 @@ pub(super) struct NextResetExpire;
 
 impl Stream {
     pub fn new(id: StreamId, init_send_window: WindowSize, init_recv_window: WindowSize) -> Stream {
-        let mut send_flow = FlowControl::new();
-        let mut recv_flow = FlowControl::new();
+        let shared_state = Shared::new(id, init_send_window, init_recv_window);
+        Stream::new_with_shared(shared_state)
+    }
 
-        recv_flow
-            .inc_window(init_recv_window)
-            .expect("invalid initial receive window");
-        // TODO: proper error handling?
-        let _res = recv_flow.assign_capacity(init_recv_window);
-        debug_assert!(_res.is_ok());
-
-        send_flow
-            .inc_window(init_send_window)
-            .expect("invalid initial send window size");
-
+    pub fn new_with_shared(shared_state: Arc<Shared>) -> Stream {
+        let id = shared_state.id;
         Stream {
             id,
-            state: State::default(),
-            ref_count: 0,
-            is_counted: false,
+            shared_state,
+            inner: Inner {
+                is_counted: false,
 
-            // ===== Fields related to sending =====
-            next_pending_send: None,
-            is_pending_send: false,
-            send_flow,
-            requested_send_capacity: 0,
-            buffered_send_data: 0,
-            send_task: None,
-            pending_send: buffer::Deque::new(),
-            is_pending_send_capacity: false,
-            next_pending_send_capacity: None,
-            send_capacity_inc: false,
-            is_pending_open: false,
-            next_open: None,
-            is_pending_push: false,
+                // ===== Fields related to sending =====
+                next_pending_send: None,
+                is_pending_send: false,
+                is_pending_send_capacity: false,
+                next_pending_send_capacity: None,
+                is_queued_open: false,
+                next_open: None,
 
-            // ===== Fields related to receiving =====
-            next_pending_accept: None,
-            is_pending_accept: false,
-            recv_flow,
-            in_flight_recv_data: 0,
-            next_window_update: None,
-            is_pending_window_update: false,
-            reset_at: None,
-            next_reset_expire: None,
-            pending_recv: buffer::Deque::new(),
-            is_recv: true,
-            recv_task: None,
-            push_task: None,
-            pending_push_promises: store::Queue::new(),
-            content_length: ContentLength::Omitted,
+                // ===== Fields related to receiving =====
+                next_pending_accept: None,
+                is_pending_accept: false,
+                next_window_update: None,
+                is_pending_window_update: false,
+                reset_at: None,
+                next_reset_expire: None,
+                content_length: ContentLength::Omitted,
+            },
         }
     }
 
-    /// Increment the stream's ref count
-    pub fn ref_inc(&mut self) {
-        assert!(self.ref_count < usize::MAX);
-        self.ref_count += 1;
+    pub fn shared_ref(&self) -> &Shared {
+        self.shared_state.as_ref()
     }
 
-    /// Decrements the stream's ref count
-    pub fn ref_dec(&mut self) {
-        assert!(self.ref_count > 0);
-        self.ref_count -= 1;
+    pub fn clone_shared(&self) -> Arc<Shared> {
+        self.shared_state.clone()
+    }
+
+    pub fn shared(&self) -> MutexGuard<'_, SharedState> {
+        self.shared_state.state()
+    }
+
+    pub fn send(&self) -> MutexGuard<'_, Send> {
+        self.shared_state.send()
+    }
+
+    pub fn recv(&self) -> MutexGuard<'_, Recv> {
+        self.shared_state.recv()
+    }
+
+    pub fn inner(&self) -> &Inner {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut Inner {
+        &mut self.inner
     }
 
     /// Returns true if stream is currently being held for some time because of
     /// a local reset.
     pub fn is_pending_reset_expiration(&self) -> bool {
-        self.reset_at.is_some()
+        self.inner().is_pending_reset_expiration()
     }
 
     /// Returns true if frames for this stream are ready to be sent over the wire
     pub fn is_send_ready(&self) -> bool {
-        // Why do we check pending_open?
-        //
-        // We allow users to call send_request() which schedules a stream to be pending_open
-        // if there is no room according to the concurrency limit (max_send_streams), and we
-        // also allow data to be buffered for send with send_data() if there is no capacity for
-        // the stream to send the data, which attempts to place the stream in pending_send.
-        // If the stream is not open, we don't want the stream to be scheduled for
-        // execution (pending_send). Note that if the stream is in pending_open, it will be
-        // pushed to pending_send when there is room for an open stream.
-        //
-        // In pending_push we track whether a PushPromise still needs to be sent
-        // from a different stream before we can start sending frames on this one.
-        // This is different from the "open" check because reserved streams don't count
-        // toward the concurrency limit.
-        // See https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2
-        !self.is_pending_open && !self.is_pending_push
+        let is_pending_open = self.send().is_pending_open;
+        let is_pending_push = self.shared().is_pending_push;
+        !is_pending_open && !is_pending_push
     }
 
     /// Returns true if the stream is closed
     pub fn is_closed(&self) -> bool {
-        // The state has fully transitioned to closed.
-        self.state.is_closed() &&
-            // Because outbound frames transition the stream state before being
-            // buffered, we have to ensure that all frames have been flushed.
-            self.pending_send.is_empty() &&
-            // Sometimes large data frames are sent out in chunks. After a chunk
-            // of the frame is sent, the remainder is pushed back onto the send
-            // queue to be rescheduled.
-            //
-            // Checking for additional buffered data lets us catch this case.
-            self.buffered_send_data == 0
+        self.shared_state.is_closed()
     }
 
     /// Returns true if the stream is no longer in use
     pub fn is_released(&self) -> bool {
-        // The stream is closed and fully flushed
-        self.is_closed() &&
-            // There are no more outstanding references to the stream
-            self.ref_count == 0 &&
-            // The stream is not in any queue
-            !self.is_pending_send && !self.is_pending_send_capacity &&
-            !self.is_pending_accept && !self.is_pending_window_update &&
-            !self.is_pending_open && self.reset_at.is_none()
+        let (ref_count, pending_operation_count, state_is_closed) = {
+            let shared = self.shared();
+            (
+                shared.ref_count,
+                shared.pending_operation_count,
+                shared.state.is_closed(),
+            )
+        };
+        let send_is_empty = {
+            let send = self.send();
+            send.pending_send.is_empty()
+                && send.pending_op_data.is_empty()
+                && send.buffered_send_data == 0
+        };
+        let is_closed = state_is_closed && send_is_empty;
+
+        let inner = self.inner();
+        is_closed
+            && ref_count == 0
+            && pending_operation_count == 0
+            && !inner.is_pending_send
+            && !inner.is_pending_send_capacity
+            && !inner.is_pending_accept
+            && !inner.is_pending_window_update
+            && !inner.is_queued_open
+            && inner.reset_at.is_none()
     }
 
     /// Returns true when the consumer of the stream has dropped all handles
@@ -268,74 +395,533 @@ impl Stream {
     ///
     /// In this case, a reset should be sent.
     pub fn is_canceled_interest(&self) -> bool {
-        self.ref_count == 0 && !self.state.is_closed()
+        self.shared_state.is_canceled_interest()
     }
 
-    /// Current available stream send capacity
-    pub fn capacity(&self, max_buffer_size: usize) -> WindowSize {
-        let available = self.send_flow.available().as_size() as usize;
-        let buffered = self.buffered_send_data;
-
-        available.min(max_buffer_size).saturating_sub(buffered) as WindowSize
+    pub fn assign_capacity(&self, capacity: WindowSize, max_buffer_size: usize) {
+        self.shared_state.assign_capacity(capacity, max_buffer_size);
     }
 
-    pub fn assign_capacity(&mut self, capacity: WindowSize, max_buffer_size: usize) {
-        let prev_capacity = self.capacity(max_buffer_size);
-        debug_assert!(capacity > 0);
-        // TODO: proper error handling
-        let _res = self.send_flow.assign_capacity(capacity);
-        debug_assert!(_res.is_ok());
-
-        tracing::trace!(
-            "  assigned capacity to stream; available={}; buffered={}; id={:?}; max_buffer_size={} prev={}",
-            self.send_flow.available(),
-            self.buffered_send_data,
-            self.id,
-            max_buffer_size,
-            prev_capacity,
-        );
-
-        if prev_capacity < self.capacity(max_buffer_size) {
-            self.notify_capacity();
-        }
-    }
-
-    pub fn send_data(&mut self, len: WindowSize, max_buffer_size: usize) {
-        let prev_capacity = self.capacity(max_buffer_size);
-
-        // TODO: proper error handling
-        let _res = self.send_flow.send_data(len);
-        debug_assert!(_res.is_ok());
-
-        // Decrement the stream's buffered data counter
-        debug_assert!(self.buffered_send_data >= len as usize);
-        self.buffered_send_data -= len as usize;
-        self.requested_send_capacity -= len;
-
-        tracing::trace!(
-            "  sent stream data; available={}; buffered={}; id={:?}; max_buffer_size={} prev={}",
-            self.send_flow.available(),
-            self.buffered_send_data,
-            self.id,
-            max_buffer_size,
-            prev_capacity,
-        );
-
-        if prev_capacity < self.capacity(max_buffer_size) {
-            self.notify_capacity();
-        }
+    pub fn send_data(&self, len: WindowSize, max_buffer_size: usize) {
+        self.shared_state.send_data(len, max_buffer_size);
     }
 
     /// If the capacity was limited because of the max_send_buffer_size,
     /// then consider waking the send task again...
-    pub fn notify_capacity(&mut self) {
+    /// Returns `Err` when the decrement cannot be completed due to overflow.
+    pub fn dec_content_length(&mut self, len: usize) -> Result<(), ()> {
+        self.inner_mut().dec_content_length(len)
+    }
+
+    pub fn ensure_content_length_zero(&self) -> Result<(), ()> {
+        self.inner().ensure_content_length_zero()
+    }
+
+    pub fn notify_send(&self) {
+        self.shared_state.notify_send();
+    }
+
+    pub fn notify_recv(&self) {
+        self.shared_state.notify_recv();
+    }
+
+    pub(super) fn notify_push(&self) {
+        self.shared_state.notify_push();
+    }
+
+    /// Set the stream's state to `Closed` with the given reason and initiator.
+    /// Notify the send, receive, and push tasks, if they exist.
+    pub(super) fn set_reset(&self, reason: Reason, initiator: Initiator) {
+        self.shared_state.set_reset(reason, initiator);
+    }
+}
+
+impl fmt::Debug for Stream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner = self.inner();
+        let (state, ref_count, pending_operation_count, is_pending_push) = {
+            let state = self.shared();
+            (
+                state.state.clone(),
+                state.ref_count,
+                state.pending_operation_count,
+                state.is_pending_push,
+            )
+        };
+        let send = self.send();
+        let recv = self.recv();
+        f.debug_struct("Stream")
+            .field("id", &self.id)
+            .field("state", &state)
+            .field("is_counted", &inner.is_counted)
+            .field("ref_count", &ref_count)
+            .h2_field_some("next_pending_send", &inner.next_pending_send)
+            .h2_field_if("is_pending_send", &inner.is_pending_send)
+            .field("send_flow", &send.send_flow)
+            .field("requested_send_capacity", &send.requested_send_capacity)
+            .field("buffered_send_data", &send.buffered_send_data)
+            .h2_field_some("send_task", &send.send_task.as_ref().map(|_| ()))
+            .h2_field_if_then(
+                "pending_send",
+                !send.pending_send.is_empty(),
+                &send.pending_send,
+            )
+            .h2_field_if_then(
+                "pending_op_data",
+                !send.pending_op_data.is_empty(),
+                &send.pending_op_data,
+            )
+            .h2_field_if_then(
+                "pending_operation_count",
+                pending_operation_count > 0,
+                &pending_operation_count,
+            )
+            .h2_field_some(
+                "next_pending_send_capacity",
+                &inner.next_pending_send_capacity,
+            )
+            .h2_field_if("is_pending_send_capacity", &inner.is_pending_send_capacity)
+            .h2_field_if("send_capacity_inc", &send.send_capacity_inc)
+            .h2_field_some("next_open", &inner.next_open)
+            .h2_field_if("is_pending_open", &send.is_pending_open)
+            .h2_field_if("is_pending_push", &is_pending_push)
+            .h2_field_some("next_pending_accept", &inner.next_pending_accept)
+            .h2_field_if("is_pending_accept", &inner.is_pending_accept)
+            .field("recv_flow", &recv.recv_flow)
+            .field("in_flight_recv_data", &recv.in_flight_recv_data)
+            .h2_field_some("next_window_update", &inner.next_window_update)
+            .h2_field_if("is_pending_window_update", &inner.is_pending_window_update)
+            .h2_field_some("reset_at", &inner.reset_at)
+            .h2_field_some("next_reset_expire", &inner.next_reset_expire)
+            .h2_field_if_then(
+                "pending_recv",
+                !recv.pending_recv.is_empty(),
+                &recv.pending_recv,
+            )
+            .h2_field_if("is_recv", &recv.is_recv)
+            .h2_field_some("recv_task", &recv.recv_task.as_ref().map(|_| ()))
+            .h2_field_some("push_task", &recv.push_task.as_ref().map(|_| ()))
+            .h2_field_if_then(
+                "pending_push_promises",
+                !recv.pending_push_promises.is_empty(),
+                &recv.pending_push_promises,
+            )
+            .field("content_length", &inner.content_length)
+            .finish()
+    }
+}
+
+impl store::Next for NextAccept {
+    fn next(stream: &Inner) -> Option<store::Key> {
+        stream.next_pending_accept
+    }
+
+    fn set_next(stream: &mut Inner, key: Option<store::Key>) {
+        stream.next_pending_accept = key;
+    }
+
+    fn take_next(stream: &mut Inner) -> Option<store::Key> {
+        stream.next_pending_accept.take()
+    }
+
+    fn is_queued(stream: &Inner) -> bool {
+        stream.is_pending_accept
+    }
+
+    fn set_queued(stream: &mut Inner, val: bool) {
+        stream.is_pending_accept = val;
+    }
+}
+
+impl store::Next for NextSend {
+    fn next(stream: &Inner) -> Option<store::Key> {
+        stream.next_pending_send
+    }
+
+    fn set_next(stream: &mut Inner, key: Option<store::Key>) {
+        stream.next_pending_send = key;
+    }
+
+    fn take_next(stream: &mut Inner) -> Option<store::Key> {
+        stream.next_pending_send.take()
+    }
+
+    fn is_queued(stream: &Inner) -> bool {
+        stream.is_pending_send
+    }
+
+    fn set_queued(stream: &mut Inner, val: bool) {
+        stream.is_pending_send = val;
+    }
+}
+
+impl store::Next for NextSendCapacity {
+    fn next(stream: &Inner) -> Option<store::Key> {
+        stream.next_pending_send_capacity
+    }
+
+    fn set_next(stream: &mut Inner, key: Option<store::Key>) {
+        stream.next_pending_send_capacity = key;
+    }
+
+    fn take_next(stream: &mut Inner) -> Option<store::Key> {
+        stream.next_pending_send_capacity.take()
+    }
+
+    fn is_queued(stream: &Inner) -> bool {
+        stream.is_pending_send_capacity
+    }
+
+    fn set_queued(stream: &mut Inner, val: bool) {
+        stream.is_pending_send_capacity = val;
+    }
+}
+
+impl store::Next for NextWindowUpdate {
+    fn next(stream: &Inner) -> Option<store::Key> {
+        stream.next_window_update
+    }
+
+    fn set_next(stream: &mut Inner, key: Option<store::Key>) {
+        stream.next_window_update = key;
+    }
+
+    fn take_next(stream: &mut Inner) -> Option<store::Key> {
+        stream.next_window_update.take()
+    }
+
+    fn is_queued(stream: &Inner) -> bool {
+        stream.is_pending_window_update
+    }
+
+    fn set_queued(stream: &mut Inner, val: bool) {
+        stream.is_pending_window_update = val;
+    }
+}
+
+impl store::Next for NextOpen {
+    fn next(stream: &Inner) -> Option<store::Key> {
+        stream.next_open
+    }
+
+    fn set_next(stream: &mut Inner, key: Option<store::Key>) {
+        stream.next_open = key;
+    }
+
+    fn take_next(stream: &mut Inner) -> Option<store::Key> {
+        stream.next_open.take()
+    }
+
+    fn is_queued(stream: &Inner) -> bool {
+        stream.is_queued_open
+    }
+
+    fn set_queued(stream: &mut Inner, val: bool) {
+        stream.is_queued_open = val;
+    }
+}
+
+impl store::Next for NextResetExpire {
+    fn next(stream: &Inner) -> Option<store::Key> {
+        stream.next_reset_expire
+    }
+
+    fn set_next(stream: &mut Inner, key: Option<store::Key>) {
+        stream.next_reset_expire = key;
+    }
+
+    fn take_next(stream: &mut Inner) -> Option<store::Key> {
+        stream.next_reset_expire.take()
+    }
+
+    fn is_queued(stream: &Inner) -> bool {
+        stream.reset_at.is_some()
+    }
+
+    fn set_queued(stream: &mut Inner, val: bool) {
+        if val {
+            stream.reset_at = Some(Instant::now());
+        } else {
+            stream.reset_at = None;
+        }
+    }
+}
+
+// ===== impl ContentLength =====
+
+impl ContentLength {
+    pub fn is_head(&self) -> bool {
+        matches!(*self, Self::Head)
+    }
+}
+
+impl Shared {
+    pub fn new(
+        id: StreamId,
+        init_send_window: WindowSize,
+        init_recv_window: WindowSize,
+    ) -> Arc<Self> {
+        let mut send_flow = FlowControl::new();
+        let mut recv_flow = FlowControl::new();
+
+        recv_flow
+            .inc_window(init_recv_window)
+            .expect("invalid initial receive window");
+        let _res = recv_flow.assign_capacity(init_recv_window);
+        debug_assert!(_res.is_ok());
+
+        send_flow
+            .inc_window(init_send_window)
+            .expect("invalid initial send window size");
+
+        Arc::new(Shared {
+            id,
+            store: AtomicU32::new(u32::MAX),
+            state: Mutex::new(SharedState {
+                state: State::default(),
+                ref_count: 0,
+                pending_operation_count: 0,
+                is_pending_conn_ops: false,
+                is_pending_push: false,
+            }),
+            send: Mutex::new(Send {
+                // ===== Fields related to sending =====
+                send_flow,
+                requested_send_capacity: 0,
+                buffered_send_data: 0,
+                send_task: None,
+                pending_send: buffer::Deque::new(),
+                pending_op_data: buffer::Deque::new(),
+                send_capacity_inc: false,
+                is_pending_open: false,
+            }),
+            recv: Mutex::new(Recv {
+                // ===== Fields related to receiving =====
+                recv_flow,
+                in_flight_recv_data: 0,
+                pending_recv: buffer::Deque::new(),
+                is_recv: true,
+                recv_task: None,
+                push_task: None,
+                pending_push_promises: buffer::Deque::new(),
+            }),
+            pending_ops: Mutex::new(PendingOps::default()),
+        })
+    }
+
+    pub fn store(&self) -> Option<store::Key> {
+        let idx = self.store.load(Ordering::Relaxed);
+        store::Key::from_parts(self.id, idx)
+    }
+
+    pub fn stored(&self, idx: u32) {
+        self.store.store(idx, Ordering::Relaxed);
+    }
+
+    pub fn state(&self) -> MutexGuard<'_, SharedState> {
+        self.state.lock().unwrap()
+    }
+
+    pub fn send(&self) -> MutexGuard<'_, Send> {
+        self.send.lock().unwrap()
+    }
+
+    pub fn recv(&self) -> MutexGuard<'_, Recv> {
+        self.recv.lock().unwrap()
+    }
+
+    pub fn pending_ops(&self) -> MutexGuard<'_, PendingOps> {
+        self.pending_ops.lock().unwrap()
+    }
+
+    /// Increment the stream's ref count
+    pub fn ref_inc(&self) {
+        let mut shared = self.state();
+        assert!(shared.ref_count < usize::MAX);
+        shared.ref_count += 1;
+    }
+
+    /// Decrements the stream's ref count
+    pub fn ref_dec(&self) {
+        let mut shared = self.state();
+        assert!(shared.ref_count > 0);
+        shared.ref_count -= 1;
+    }
+
+    /// Increment the queued operation count for this stream.
+    pub fn ops_inc(&self) {
+        let mut shared = self.state();
+        assert!(shared.pending_operation_count < usize::MAX);
+        shared.pending_operation_count += 1;
+    }
+
+    /// Decrement the queued operation count for this stream.
+    pub fn ops_dec(&self) {
+        let mut shared = self.state();
+        assert!(shared.pending_operation_count > 0);
+        shared.pending_operation_count -= 1;
+    }
+
+    pub fn mark_pending_conn_ops(&self) -> bool {
+        let mut shared = self.state();
+        let was_pending = shared.is_pending_conn_ops;
+        shared.is_pending_conn_ops = true;
+        !was_pending
+    }
+
+    pub fn clear_pending_conn_ops(&self) {
+        self.state().is_pending_conn_ops = false;
+    }
+
+    pub fn notify_send(&self) {
+        self.send().notify_send();
+    }
+
+    pub fn wait_send(&self, cx: &Context) {
+        self.send().wait_send(cx);
+    }
+
+    pub fn notify_recv(&self) {
+        self.recv().notify_recv();
+    }
+
+    pub fn notify_push(&self) {
+        self.recv().notify_push();
+    }
+
+    pub fn set_reset(&self, reason: Reason, initiator: Initiator) {
+        self.state().state.set_reset(self.id, reason, initiator);
+        self.notify_send();
+        self.notify_push();
+        self.notify_recv();
+    }
+
+    pub fn handle_error(&self, err: &proto::Error) {
+        self.state().state.handle_error(err);
+        self.notify_send();
+        self.notify_push();
+        self.notify_recv();
+    }
+
+    pub fn is_pending_open(&self) -> bool {
+        self.send().is_pending_open
+    }
+
+    fn is_closed(&self) -> bool {
+        let state_is_closed = self.state().state.is_closed();
+        let send_is_empty = {
+            let send = self.send();
+            send.pending_send.is_empty()
+                && send.pending_op_data.is_empty()
+                && send.buffered_send_data == 0
+        };
+        state_is_closed && send_is_empty
+    }
+
+    fn is_canceled_interest(&self) -> bool {
+        let shared = self.state();
+        shared.ref_count == 0 && !shared.state.is_closed()
+    }
+
+    pub fn capacity(&self, max_buffer_size: usize) -> WindowSize {
+        let shared = self.send();
+        let available = shared.send_flow.available().as_size() as usize;
+        available
+            .min(max_buffer_size)
+            .saturating_sub(shared.buffered_send_data) as WindowSize
+    }
+
+    fn assign_capacity(&self, capacity: WindowSize, max_buffer_size: usize) {
+        let mut shared = self.send();
+        let prev_capacity = shared.capacity(max_buffer_size);
+        debug_assert!(capacity > 0);
+        let _res = shared.send_flow.assign_capacity(capacity);
+        debug_assert!(_res.is_ok());
+
+        tracing::trace!(
+            "  assigned capacity to stream; available={}; buffered={}; id={:?}; max_buffer_size={} prev={}",
+            shared.send_flow.available(),
+            shared.buffered_send_data,
+            self.id,
+            max_buffer_size,
+            prev_capacity,
+        );
+
+        if prev_capacity < shared.capacity(max_buffer_size) {
+            shared.notify_capacity();
+        }
+    }
+
+    fn send_data(&self, len: WindowSize, max_buffer_size: usize) {
+        let mut shared = self.send();
+        let prev_capacity = shared.capacity(max_buffer_size);
+        let _res = shared.send_flow.send_data(len);
+        debug_assert!(_res.is_ok());
+
+        debug_assert!(shared.buffered_send_data >= len as usize);
+        shared.buffered_send_data -= len as usize;
+        shared.requested_send_capacity -= len;
+
+        tracing::trace!(
+            "  sent stream data; available={}; buffered={}; id={:?}; max_buffer_size={} prev={}",
+            shared.send_flow.available(),
+            shared.buffered_send_data,
+            self.id,
+            max_buffer_size,
+            prev_capacity,
+        );
+
+        if prev_capacity < shared.capacity(max_buffer_size) {
+            shared.notify_capacity();
+        }
+    }
+}
+
+impl Send {
+    pub(super) fn capacity(&self, max_buffer_size: usize) -> WindowSize {
+        let available = self.send_flow.available().as_size() as usize;
+        available
+            .min(max_buffer_size)
+            .saturating_sub(self.buffered_send_data) as WindowSize
+    }
+
+    fn notify_capacity(&mut self) {
         self.send_capacity_inc = true;
         tracing::trace!("  notifying task");
         self.notify_send();
     }
 
-    /// Returns `Err` when the decrement cannot be completed due to overflow.
-    pub fn dec_content_length(&mut self, len: usize) -> Result<(), ()> {
+    fn notify_send(&mut self) {
+        if let Some(task) = self.send_task.take() {
+            task.wake();
+        }
+    }
+
+    pub fn wait_send(&mut self, cx: &Context) {
+        self.send_task = Some(cx.waker().clone());
+    }
+}
+
+impl Recv {
+    fn notify_recv(&mut self) {
+        if let Some(task) = self.recv_task.take() {
+            task.wake();
+        }
+    }
+
+    fn notify_push(&mut self) {
+        if let Some(task) = self.push_task.take() {
+            task.wake();
+        }
+    }
+}
+
+impl Inner {
+    fn is_pending_reset_expiration(&self) -> bool {
+        self.reset_at.is_some()
+    }
+
+    fn dec_content_length(&mut self, len: usize) -> Result<(), ()> {
         match self.content_length {
             ContentLength::Remaining(ref mut rem) => match rem.checked_sub(len as u64) {
                 Some(val) => *rem = val,
@@ -352,249 +938,11 @@ impl Stream {
         Ok(())
     }
 
-    pub fn ensure_content_length_zero(&self) -> Result<(), ()> {
+    fn ensure_content_length_zero(&self) -> Result<(), ()> {
         match self.content_length {
             ContentLength::Remaining(0) => Ok(()),
             ContentLength::Remaining(_) => Err(()),
             _ => Ok(()),
         }
-    }
-
-    pub fn notify_send(&mut self) {
-        if let Some(task) = self.send_task.take() {
-            task.wake();
-        }
-    }
-
-    pub fn wait_send(&mut self, cx: &Context) {
-        self.send_task = Some(cx.waker().clone());
-    }
-
-    pub fn notify_recv(&mut self) {
-        if let Some(task) = self.recv_task.take() {
-            task.wake();
-        }
-    }
-
-    pub(super) fn notify_push(&mut self) {
-        if let Some(task) = self.push_task.take() {
-            task.wake();
-        }
-    }
-
-    /// Set the stream's state to `Closed` with the given reason and initiator.
-    /// Notify the send, receive, and push tasks, if they exist.
-    pub(super) fn set_reset(&mut self, reason: Reason, initiator: Initiator) {
-        self.state.set_reset(self.id, reason, initiator);
-        self.notify_send();
-        self.notify_push();
-        self.notify_recv();
-    }
-}
-
-impl fmt::Debug for Stream {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Stream")
-            .field("id", &self.id)
-            .field("state", &self.state)
-            .field("is_counted", &self.is_counted)
-            .field("ref_count", &self.ref_count)
-            .h2_field_some("next_pending_send", &self.next_pending_send)
-            .h2_field_if("is_pending_send", &self.is_pending_send)
-            .field("send_flow", &self.send_flow)
-            .field("requested_send_capacity", &self.requested_send_capacity)
-            .field("buffered_send_data", &self.buffered_send_data)
-            .h2_field_some("send_task", &self.send_task.as_ref().map(|_| ()))
-            .h2_field_if_then(
-                "pending_send",
-                !self.pending_send.is_empty(),
-                &self.pending_send,
-            )
-            .h2_field_some(
-                "next_pending_send_capacity",
-                &self.next_pending_send_capacity,
-            )
-            .h2_field_if("is_pending_send_capacity", &self.is_pending_send_capacity)
-            .h2_field_if("send_capacity_inc", &self.send_capacity_inc)
-            .h2_field_some("next_open", &self.next_open)
-            .h2_field_if("is_pending_open", &self.is_pending_open)
-            .h2_field_if("is_pending_push", &self.is_pending_push)
-            .h2_field_some("next_pending_accept", &self.next_pending_accept)
-            .h2_field_if("is_pending_accept", &self.is_pending_accept)
-            .field("recv_flow", &self.recv_flow)
-            .field("in_flight_recv_data", &self.in_flight_recv_data)
-            .h2_field_some("next_window_update", &self.next_window_update)
-            .h2_field_if("is_pending_window_update", &self.is_pending_window_update)
-            .h2_field_some("reset_at", &self.reset_at)
-            .h2_field_some("next_reset_expire", &self.next_reset_expire)
-            .h2_field_if_then(
-                "pending_recv",
-                !self.pending_recv.is_empty(),
-                &self.pending_recv,
-            )
-            .h2_field_if("is_recv", &self.is_recv)
-            .h2_field_some("recv_task", &self.recv_task.as_ref().map(|_| ()))
-            .h2_field_some("push_task", &self.push_task.as_ref().map(|_| ()))
-            .h2_field_if_then(
-                "pending_push_promises",
-                !self.pending_push_promises.is_empty(),
-                &self.pending_push_promises,
-            )
-            .field("content_length", &self.content_length)
-            .finish()
-    }
-}
-
-impl store::Next for NextAccept {
-    fn next(stream: &Stream) -> Option<store::Key> {
-        stream.next_pending_accept
-    }
-
-    fn set_next(stream: &mut Stream, key: Option<store::Key>) {
-        stream.next_pending_accept = key;
-    }
-
-    fn take_next(stream: &mut Stream) -> Option<store::Key> {
-        stream.next_pending_accept.take()
-    }
-
-    fn is_queued(stream: &Stream) -> bool {
-        stream.is_pending_accept
-    }
-
-    fn set_queued(stream: &mut Stream, val: bool) {
-        stream.is_pending_accept = val;
-    }
-}
-
-impl store::Next for NextSend {
-    fn next(stream: &Stream) -> Option<store::Key> {
-        stream.next_pending_send
-    }
-
-    fn set_next(stream: &mut Stream, key: Option<store::Key>) {
-        stream.next_pending_send = key;
-    }
-
-    fn take_next(stream: &mut Stream) -> Option<store::Key> {
-        stream.next_pending_send.take()
-    }
-
-    fn is_queued(stream: &Stream) -> bool {
-        stream.is_pending_send
-    }
-
-    fn set_queued(stream: &mut Stream, val: bool) {
-        if val {
-            // ensure that stream is not queued for being opened
-            // if it's being put into queue for sending data
-            debug_assert!(!stream.is_pending_open);
-        }
-        stream.is_pending_send = val;
-    }
-}
-
-impl store::Next for NextSendCapacity {
-    fn next(stream: &Stream) -> Option<store::Key> {
-        stream.next_pending_send_capacity
-    }
-
-    fn set_next(stream: &mut Stream, key: Option<store::Key>) {
-        stream.next_pending_send_capacity = key;
-    }
-
-    fn take_next(stream: &mut Stream) -> Option<store::Key> {
-        stream.next_pending_send_capacity.take()
-    }
-
-    fn is_queued(stream: &Stream) -> bool {
-        stream.is_pending_send_capacity
-    }
-
-    fn set_queued(stream: &mut Stream, val: bool) {
-        stream.is_pending_send_capacity = val;
-    }
-}
-
-impl store::Next for NextWindowUpdate {
-    fn next(stream: &Stream) -> Option<store::Key> {
-        stream.next_window_update
-    }
-
-    fn set_next(stream: &mut Stream, key: Option<store::Key>) {
-        stream.next_window_update = key;
-    }
-
-    fn take_next(stream: &mut Stream) -> Option<store::Key> {
-        stream.next_window_update.take()
-    }
-
-    fn is_queued(stream: &Stream) -> bool {
-        stream.is_pending_window_update
-    }
-
-    fn set_queued(stream: &mut Stream, val: bool) {
-        stream.is_pending_window_update = val;
-    }
-}
-
-impl store::Next for NextOpen {
-    fn next(stream: &Stream) -> Option<store::Key> {
-        stream.next_open
-    }
-
-    fn set_next(stream: &mut Stream, key: Option<store::Key>) {
-        stream.next_open = key;
-    }
-
-    fn take_next(stream: &mut Stream) -> Option<store::Key> {
-        stream.next_open.take()
-    }
-
-    fn is_queued(stream: &Stream) -> bool {
-        stream.is_pending_open
-    }
-
-    fn set_queued(stream: &mut Stream, val: bool) {
-        if val {
-            // ensure that stream is not queued for being sent
-            // if it's being put into queue for opening the stream
-            debug_assert!(!stream.is_pending_send);
-        }
-        stream.is_pending_open = val;
-    }
-}
-
-impl store::Next for NextResetExpire {
-    fn next(stream: &Stream) -> Option<store::Key> {
-        stream.next_reset_expire
-    }
-
-    fn set_next(stream: &mut Stream, key: Option<store::Key>) {
-        stream.next_reset_expire = key;
-    }
-
-    fn take_next(stream: &mut Stream) -> Option<store::Key> {
-        stream.next_reset_expire.take()
-    }
-
-    fn is_queued(stream: &Stream) -> bool {
-        stream.reset_at.is_some()
-    }
-
-    fn set_queued(stream: &mut Stream, val: bool) {
-        if val {
-            stream.reset_at = Some(Instant::now());
-        } else {
-            stream.reset_at = None;
-        }
-    }
-}
-
-// ===== impl ContentLength =====
-
-impl ContentLength {
-    pub fn is_head(&self) -> bool {
-        matches!(*self, Self::Head)
     }
 }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1,18 +1,23 @@
-use super::recv::RecvHeaderBlockError;
+use super::buffer;
+use super::counts;
+use super::recv::{self, RecvHeaderBlockError};
+use super::send::{self, PreparedReserveCapacity, PreparedSendData, PreparedSendReset};
 use super::store::{self, Entry, Resolve, Store};
+use super::stream;
 use super::{Buffer, Config, Counts, Prioritized, Recv, Send, Stream, StreamId};
 use crate::codec::{Codec, SendError, UserError};
 use crate::ext::Protocol;
 use crate::frame::{self, Frame, Reason};
-use crate::proto::{peer, Error, Initiator, Open, Peer, WindowSize};
+use crate::proto::{Error, Initiator, Open, Peer, WindowSize, peer};
 use crate::{client, proto, server};
 
 use bytes::{Buf, Bytes};
 use http::{HeaderMap, Request, Response};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll, Waker};
 use tokio::io::AsyncWrite;
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::{fmt, io};
 
 #[derive(Debug)]
@@ -22,7 +27,7 @@ where
 {
     /// Holds most of the connection and stream related state for processing
     /// HTTP/2 frames associated with streams.
-    inner: Arc<Mutex<Inner>>,
+    inner: Inner,
 
     /// This is the queue of frames to be written to the wire. This is split out
     /// to avoid requiring a `B` generic on all public API types even if `B` is
@@ -34,6 +39,8 @@ where
     /// been shown to be necessary.
     send_buffer: Arc<SendBuffer<B>>,
 
+    shared: Arc<Shared>,
+
     _p: ::std::marker::PhantomData<P>,
 }
 
@@ -41,9 +48,10 @@ where
 // Ensures that the methods only get one instantiation, instead of two (client and server)
 #[derive(Debug)]
 pub(crate) struct DynStreams<'a, B> {
-    inner: &'a Mutex<Inner>,
+    inner: &'a mut Inner,
 
     send_buffer: &'a SendBuffer<B>,
+    shared: &'a Shared,
 
     peer: peer::Dyn,
 }
@@ -57,8 +65,16 @@ pub(crate) struct StreamRef<B> {
 
 /// Reference to the stream state that hides the send data chunk generic
 pub(crate) struct OpaqueStreamRef {
-    inner: Arc<Mutex<Inner>>,
-    key: store::Key,
+    shared: Arc<Shared>,
+    stream: Arc<stream::Shared>,
+}
+
+/// An injector of streams into the connection.
+///
+/// Used by the `client::SendRequest`.
+pub(crate) struct Injector<B> {
+    send_buffer: Arc<SendBuffer<B>>,
+    shared: Arc<Shared>,
 }
 
 /// Fields needed to manage state related to managing the set of streams. This
@@ -73,11 +89,8 @@ struct Inner {
     /// Connection level state and performs actions on streams
     actions: Actions,
 
-    /// Stores stream state
+    /// Stores stream state, uniquely owned by the connection task.
     store: Store,
-
-    /// The number of stream refs to this shared state.
-    refs: usize,
 }
 
 #[derive(Debug)]
@@ -87,12 +100,26 @@ struct Actions {
 
     /// Manages state transitions initiated by sending frames
     send: Send,
+}
 
-    /// Task that calls `poll_complete`.
-    task: Option<Waker>,
+/// The new place to store the synchronized state.
+///
+/// Only things shared are in here, the connection doesn't need to share
+/// everything.
+#[derive(Debug)]
+struct Shared {
+    counts: counts::Shared,
+    recv: recv::Shared,
+    send: send::Shared,
 
     /// If the connection errors, a copy is kept for any StreamRefs.
-    conn_error: Option<proto::Error>,
+    conn_error: RwLock<Option<Error>>,
+
+    queued_request_headers: AtomicUsize,
+    pending_ops: Mutex<PendingConnOps>,
+
+    /// Task that drives connection-level processing.
+    conn_task: ConnWaker,
 }
 
 /// Contains the buffer of frames to be written to the wire.
@@ -100,6 +127,58 @@ struct Actions {
 struct SendBuffer<B> {
     inner: Mutex<Buffer<Frame<B>>>,
 }
+
+#[derive(Debug)]
+struct PendingConnOps {
+    buffer: Buffer<QueuedStream>,
+    queue: buffer::Deque,
+}
+
+#[derive(Debug)]
+struct QueuedStream {
+    stream: Arc<stream::Shared>,
+}
+
+impl PendingConnOps {
+    fn new() -> Self {
+        Self {
+            buffer: Buffer::new(),
+            queue: buffer::Deque::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    fn push_back_stream(&mut self, stream: QueuedStream) {
+        self.queue.push_back(&mut self.buffer, stream);
+    }
+
+    fn pop_front_stream(&mut self) -> Option<QueuedStream> {
+        self.queue.pop_front(&mut self.buffer)
+    }
+
+    fn for_each_pending_stream<F>(&self, mut f: F)
+    where
+        F: FnMut(&Arc<stream::Shared>),
+    {
+        for queued_stream in self.queue.iter(&self.buffer) {
+            f(&queued_stream.stream);
+        }
+    }
+}
+
+/// Assert that there is no pending request for this StreamRef.
+#[derive(Debug)]
+struct AssertNoPendingRequest;
+
+/// A newtype around the connection waker.
+///
+/// As a separate type, function arguments can better indicate which waker
+/// is expected for any given action.
+#[derive(Debug)]
+pub(super) struct ConnWaker(atomic_waker::AtomicWaker);
 
 // ===== impl Streams =====
 
@@ -111,43 +190,54 @@ where
     pub fn new(config: Config) -> Self {
         let peer = P::r#dyn();
 
+        let (recv, recv_shared) = Recv::new(peer, &config);
+        let (send, send_shared) = Send::new(&config);
+        let counts_shared = counts::Shared::new(&config);
+
         Streams {
-            inner: Inner::new(peer, config),
+            inner: Inner::new(peer, recv, send, config),
             send_buffer: Arc::new(SendBuffer::new()),
+            shared: Arc::new(Shared {
+                counts: counts_shared,
+                recv: recv_shared,
+                send: send_shared,
+                conn_error: RwLock::new(None),
+                queued_request_headers: AtomicUsize::new(0),
+                pending_ops: Mutex::new(PendingConnOps::new()),
+                conn_task: ConnWaker::new(),
+            }),
             _p: ::std::marker::PhantomData,
         }
     }
 
     pub fn set_target_connection_window_size(&mut self, size: WindowSize) -> Result<(), Reason> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
+        let me = &mut self.inner;
 
         me.actions
             .recv
-            .set_target_connection_window(size, &mut me.actions.task)
+            .set_target_connection_window(size, &self.shared.conn_task)
     }
 
     pub fn next_incoming(&mut self) -> Option<StreamRef<B>> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-        me.actions.recv.next_incoming(&mut me.store).map(|key| {
-            let stream = &mut me.store.resolve(key);
+        let me = &mut self.inner;
+        let store = &mut me.store;
+
+        me.actions.recv.next_incoming(store).map(|key| {
+            let stream = &mut store.resolve(key);
+            let shared = stream.shared();
             tracing::trace!(
                 "next_incoming; id={:?}, state={:?}",
                 stream.id,
-                stream.state
+                shared.state
             );
-            // TODO: ideally, OpaqueStreamRefs::new would do this, but we're holding
-            // the lock, so it can't.
-            me.refs += 1;
-
             // Pending-accepted remotely-reset streams are counted.
-            if stream.state.is_remote_reset() {
+            if shared.state.is_remote_reset() {
                 me.counts.dec_num_remote_reset_streams();
             }
+            drop(shared);
 
             StreamRef {
-                opaque: OpaqueStreamRef::new(self.inner.clone(), stream),
+                opaque: OpaqueStreamRef::new(self.shared.clone(), stream),
                 send_buffer: self.send_buffer.clone(),
             }
         })
@@ -161,17 +251,16 @@ where
     where
         T: AsyncWrite + Unpin,
     {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-        me.actions.recv.send_pending_refusal(cx, dst)
+        self.inner.actions.recv.send_pending_refusal(cx, dst)
     }
 
     pub fn clear_expired_reset_streams(&mut self) {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-        me.actions
-            .recv
-            .clear_expired_reset_streams(&mut me.store, &mut me.counts);
+        let me = &mut self.inner;
+        me.actions.recv.clear_expired_reset_streams(
+            &self.shared.counts,
+            &mut me.store,
+            &mut me.counts,
+        );
     }
 
     pub fn poll_complete<T>(
@@ -182,8 +271,8 @@ where
     where
         T: AsyncWrite + Unpin,
     {
-        let mut me = self.inner.lock().unwrap();
-        me.poll_complete(&self.send_buffer, cx, dst)
+        self.inner
+            .poll_complete(&self.send_buffer, &self.shared, cx, dst)
     }
 
     pub fn apply_remote_settings(
@@ -191,150 +280,43 @@ where
         frame: &frame::Settings,
         is_initial: bool,
     ) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
+        let me = &mut self.inner;
 
         let mut send_buffer = self.send_buffer.inner.lock().unwrap();
         let send_buffer = &mut *send_buffer;
 
-        me.counts.apply_remote_settings(frame, is_initial);
+        me.counts
+            .apply_remote_settings(&self.shared.counts, frame, is_initial);
 
         me.actions.send.apply_remote_settings(
+            &self.shared.send,
             frame,
             send_buffer,
             &mut me.store,
+            &self.shared.counts,
             &mut me.counts,
-            &mut me.actions.task,
+            &self.shared.conn_task,
         )
     }
 
     pub fn apply_local_settings(&mut self, frame: &frame::Settings) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        me.actions.recv.apply_local_settings(frame, &mut me.store)
+        let me = &mut self.inner;
+        me.actions
+            .recv
+            .apply_local_settings(&self.shared.recv, frame, &mut me.store)
     }
 
-    pub fn send_request(
-        &mut self,
-        mut request: Request<()>,
-        end_of_stream: bool,
-        pending: Option<&OpaqueStreamRef>,
-    ) -> Result<(StreamRef<B>, bool), SendError> {
-        use super::stream::ContentLength;
-        use http::Method;
-
-        let protocol = request.extensions_mut().remove::<Protocol>();
-
-        // Clear before taking lock, incase extensions contain a StreamRef.
-        request.extensions_mut().clear();
-
-        // TODO: There is a hazard with assigning a stream ID before the
-        // prioritize layer. If prioritization reorders new streams, this
-        // implicitly closes the earlier stream IDs.
-        //
-        // See: hyperium/h2#11
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
-
-        me.actions.ensure_no_conn_error()?;
-        me.actions.send.ensure_next_stream_id()?;
-
-        // The `pending` argument is provided by the `Client`, and holds
-        // a store `Key` of a `Stream` that may have been not been opened
-        // yet.
-        //
-        // If that stream is still pending, the Client isn't allowed to
-        // queue up another pending stream. They should use `poll_ready`.
-        if let Some(stream) = pending {
-            if me.store.resolve(stream.key).is_pending_open {
-                return Err(UserError::Rejected.into());
-            }
+    pub fn injector(&self) -> Injector<B> {
+        Injector {
+            shared: self.shared.clone(),
+            send_buffer: self.send_buffer.clone(),
         }
-
-        if me.counts.peer().is_server() {
-            // Servers cannot open streams. PushPromise must first be reserved.
-            return Err(UserError::UnexpectedFrameType.into());
-        }
-
-        let stream_id = me.actions.send.open()?;
-
-        let mut stream = Stream::new(
-            stream_id,
-            me.actions.send.init_window_sz(),
-            me.actions.recv.init_window_sz(),
-        );
-
-        if *request.method() == Method::HEAD {
-            stream.content_length = ContentLength::Head;
-        }
-
-        // Convert the message
-        let headers =
-            client::Peer::convert_send_message(stream_id, request, protocol, end_of_stream)?;
-
-        let mut stream = me.store.insert(stream.id, stream);
-
-        let sent = me.actions.send.send_headers(
-            headers,
-            send_buffer,
-            &mut stream,
-            &mut me.counts,
-            &mut me.actions.task,
-        );
-
-        // send_headers can return a UserError, if it does,
-        // we should forget about this stream.
-        if let Err(err) = sent {
-            stream.unlink();
-            stream.remove();
-            return Err(err.into());
-        }
-
-        // Given that the stream has been initialized, it should not be in the
-        // closed state.
-        debug_assert!(!stream.state.is_closed());
-
-        // TODO: ideally, OpaqueStreamRefs::new would do this, but we're holding
-        // the lock, so it can't.
-        me.refs += 1;
-
-        let is_full = me.counts.next_send_stream_will_reach_capacity();
-        Ok((
-            StreamRef {
-                opaque: OpaqueStreamRef::new(self.inner.clone(), &mut stream),
-                send_buffer: self.send_buffer.clone(),
-            },
-            is_full,
-        ))
-    }
-
-    pub(crate) fn is_extended_connect_protocol_enabled(&self) -> bool {
-        self.inner
-            .lock()
-            .unwrap()
-            .actions
-            .send
-            .is_extended_connect_protocol_enabled()
-    }
-
-    pub fn current_max_send_streams(&self) -> usize {
-        let me = self.inner.lock().unwrap();
-        me.counts.max_send_streams()
-    }
-
-    pub fn current_max_recv_streams(&self) -> usize {
-        let me = self.inner.lock().unwrap();
-        me.counts.max_recv_streams()
     }
 }
 
 impl<B> DynStreams<'_, B> {
     pub fn is_buffer_empty(&self) -> bool {
-        self.send_buffer.is_empty()
+        self.send_buffer.is_empty() && self.shared.pending_ops.lock().unwrap().is_empty()
     }
 
     pub fn is_server(&self) -> bool {
@@ -342,50 +324,46 @@ impl<B> DynStreams<'_, B> {
     }
 
     pub fn recv_headers(&mut self, frame: frame::Headers) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-
-        me.recv_headers(self.peer, self.send_buffer, frame)
+        self.inner
+            .recv_headers(self.peer, self.send_buffer, self.shared, frame)
     }
 
     pub fn recv_data(&mut self, frame: frame::Data) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-        me.recv_data(self.peer, self.send_buffer, frame)
+        self.inner
+            .recv_data(self.peer, self.send_buffer, self.shared, frame)
     }
 
     pub fn recv_reset(&mut self, frame: frame::Reset) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-
-        me.recv_reset(self.send_buffer, frame)
+        self.inner.recv_reset(self.send_buffer, self.shared, frame)
     }
 
     /// Notify all streams that a connection-level error happened.
     pub fn handle_error(&mut self, err: proto::Error) -> StreamId {
-        let mut me = self.inner.lock().unwrap();
-        me.handle_error(self.send_buffer, err)
+        self.inner.handle_error(self.send_buffer, self.shared, err)
     }
 
     pub fn recv_go_away(&mut self, frame: &frame::GoAway) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-        me.recv_go_away(self.send_buffer, frame)
+        self.inner
+            .recv_go_away(self.send_buffer, self.shared, frame)
     }
 
     pub fn last_processed_id(&self) -> StreamId {
-        self.inner.lock().unwrap().actions.recv.last_processed_id()
+        self.inner.actions.recv.last_processed_id()
     }
 
     pub fn recv_window_update(&mut self, frame: frame::WindowUpdate) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-        me.recv_window_update(self.send_buffer, frame)
+        self.inner
+            .recv_window_update(self.send_buffer, self.shared, frame)
     }
 
     pub fn recv_push_promise(&mut self, frame: frame::PushPromise) -> Result<(), Error> {
-        let mut me = self.inner.lock().unwrap();
-        me.recv_push_promise(self.send_buffer, frame)
+        self.inner
+            .recv_push_promise(self.send_buffer, self.shared, frame)
     }
 
     pub fn recv_eof(&mut self, clear_pending_accept: bool) -> Result<(), ()> {
-        let mut me = self.inner.lock().map_err(|_| ())?;
-        me.recv_eof(self.send_buffer, clear_pending_accept)
+        self.inner
+            .recv_eof(self.send_buffer, self.shared, clear_pending_accept)
     }
 
     pub fn send_reset(
@@ -393,38 +371,88 @@ impl<B> DynStreams<'_, B> {
         id: StreamId,
         reason: Reason,
     ) -> Result<(), crate::proto::error::GoAway> {
-        let mut me = self.inner.lock().unwrap();
-        me.send_reset(self.send_buffer, id, reason)
+        self.inner
+            .send_reset(self.send_buffer, self.shared, id, reason)
     }
 
     pub fn send_go_away(&mut self, last_processed_id: StreamId) {
-        let mut me = self.inner.lock().unwrap();
-        me.actions.recv.go_away(last_processed_id);
+        self.inner.actions.recv.go_away(last_processed_id);
+    }
+}
+
+fn reconcile_deferred_recv_window(stream: &mut Stream, target: WindowSize) {
+    let mut recv = stream.recv();
+    let current = recv.recv_flow.window_size();
+
+    match target.cmp(&current) {
+        std::cmp::Ordering::Less => {
+            let dec = current - target;
+            let res = recv.recv_flow.dec_recv_window(dec);
+            debug_assert!(
+                res.is_ok(),
+                "deferred recv window decrement should be valid"
+            );
+        }
+        std::cmp::Ordering::Greater => {
+            let inc = target - current;
+            let res = recv.recv_flow.inc_window(inc);
+            debug_assert!(
+                res.is_ok(),
+                "deferred recv window increment should be valid"
+            );
+            let res = recv.recv_flow.assign_capacity(inc);
+            debug_assert!(
+                res.is_ok(),
+                "deferred recv capacity assignment should be valid"
+            );
+        }
+        std::cmp::Ordering::Equal => {}
+    }
+}
+
+fn reconcile_deferred_send_window(stream: &mut Stream, target: WindowSize) {
+    let mut send = stream.send();
+    let current = send.send_flow.window_size();
+
+    match target.cmp(&current) {
+        std::cmp::Ordering::Less => {
+            let dec = current - target;
+            let res = send.send_flow.dec_send_window(dec);
+            debug_assert!(
+                res.is_ok(),
+                "deferred send window decrement should be valid"
+            );
+        }
+        std::cmp::Ordering::Greater => {
+            let inc = target - current;
+            let res = send.send_flow.inc_window(inc);
+            debug_assert!(
+                res.is_ok(),
+                "deferred send window increment should be valid"
+            );
+        }
+        std::cmp::Ordering::Equal => {}
     }
 }
 
 impl Inner {
-    fn new(peer: peer::Dyn, config: Config) -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(Inner {
+    fn new(peer: peer::Dyn, recv: Recv, send: Send, config: Config) -> Self {
+        Inner {
             counts: Counts::new(peer, &config),
-            actions: Actions {
-                recv: Recv::new(peer, &config),
-                send: Send::new(&config),
-                task: None,
-                conn_error: None,
-            },
+            actions: Actions { recv, send },
             store: Store::new(),
-            refs: 1,
-        }))
+        }
     }
 
     fn recv_headers<B>(
         &mut self,
         peer: peer::Dyn,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         frame: frame::Headers,
     ) -> Result<(), Error> {
         let id = frame.stream_id();
+        let store = &mut self.store;
 
         // The GOAWAY process has begun. All streams with a greater ID than
         // specified as part of GOAWAY should be ignored.
@@ -437,7 +465,7 @@ impl Inner {
             return Ok(());
         }
 
-        let key = match self.store.find_entry(id) {
+        let key = match store.find_entry(id) {
             Entry::Occupied(e) => e.key(),
             Entry::Vacant(e) => {
                 // Client: it's possible to send a request, and then send
@@ -448,7 +476,7 @@ impl Inner {
                 if !peer.is_server() {
                     // This may be response headers for a stream we've already
                     // forgotten about...
-                    if self.actions.may_have_forgotten_stream(peer, id) {
+                    if self.actions.may_have_forgotten_stream(peer, shared, id) {
                         tracing::debug!(
                             "recv_headers for old stream={:?}, sending STREAM_CLOSED",
                             id,
@@ -460,30 +488,32 @@ impl Inner {
                 match self
                     .actions
                     .recv
-                    .open(id, Open::Headers, &mut self.counts)?
+                    .open(id, Open::Headers, &shared.counts, &mut self.counts)?
                 {
                     Some(stream_id) => {
                         let stream = Stream::new(
                             stream_id,
-                            self.actions.send.init_window_sz(),
-                            self.actions.recv.init_window_sz(),
+                            shared.send.init_window_sz(),
+                            shared.recv.init_window_sz(),
                         );
 
-                        e.insert(stream)
+                        let key = e.insert(stream);
+                        shared.counts.inc_num_wired_streams();
+                        key
                     }
                     None => return Ok(()),
                 }
             }
         };
 
-        let stream = self.store.resolve(key);
+        let stream = store.resolve(key);
 
-        if stream.is_pending_open {
+        if stream.send().is_pending_open {
             proto_err!(conn: "recv_headers: received frame on idle stream {:?}", id);
             return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
         }
 
-        if stream.state.is_local_error() {
+        if stream.shared().state.is_local_error() {
             // Locally reset streams must ignore frames "for some time".
             // This is because the remote may have sent trailers before
             // receiving the RST_STREAM frame.
@@ -495,27 +525,38 @@ impl Inner {
         let mut send_buffer = send_buffer.inner.lock().unwrap();
         let send_buffer = &mut *send_buffer;
 
-        self.counts.transition(stream, |counts, stream| {
+        self.counts.transition(&shared.counts, stream, |counts, stream| {
             tracing::trace!(
                 "recv_headers; stream={:?}; state={:?}",
                 stream.id,
-                stream.state
+                stream.shared().state
             );
 
-            let res = if stream.state.is_recv_headers() {
-                match actions.recv.recv_headers(frame, stream, counts) {
+            let res = if stream.shared().state.is_recv_headers() {
+                match actions
+                    .recv
+                    .recv_headers(&shared.recv, frame, stream, &shared.counts, counts)
+                {
                     Ok(()) => Ok(()),
                     Err(RecvHeaderBlockError::Oversize(resp)) => {
                         if let Some(resp) = resp {
                             let sent = actions.send.send_headers(
-                                resp, send_buffer, stream, counts, &mut actions.task);
+                                &shared.send,
+                                resp,
+                                send_buffer,
+                                stream,
+                                counts,
+                                &shared.conn_task,
+                            );
                             debug_assert!(sent.is_ok(), "oversize response should not fail");
 
                             actions.send.schedule_implicit_reset(
                                 stream,
                                 Reason::PROTOCOL_ERROR,
+                                &shared.counts,
                                 counts,
-                                &mut actions.task);
+                                &shared.conn_task,
+                            );
 
                             actions.recv.enqueue_reset_expiration(stream, counts);
 
@@ -534,10 +575,17 @@ impl Inner {
                     return Err(Error::library_reset(stream.id, Reason::PROTOCOL_ERROR));
                 }
 
-                actions.recv.recv_trailers(frame, stream)
+                actions.recv.recv_trailers(&shared.recv, frame, stream)
             };
 
-            actions.reset_on_recv_stream_err(send_buffer, stream, counts, res)
+            actions.reset_on_recv_stream_err(
+                send_buffer,
+                stream,
+                &shared.counts,
+                counts,
+                res,
+                &shared.conn_task,
+            )
         })
     }
 
@@ -545,11 +593,13 @@ impl Inner {
         &mut self,
         peer: peer::Dyn,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         frame: frame::Data,
     ) -> Result<(), Error> {
         let id = frame.stream_id();
+        let store = &mut self.store;
 
-        let stream = match self.store.find_mut(&id) {
+        let stream = match store.find_mut(&id) {
             Some(stream) => stream,
             None => {
                 // The GOAWAY process has begun. All streams with a greater ID
@@ -565,12 +615,12 @@ impl Inner {
                     let sz = frame.flow_controlled_len();
                     assert!(sz <= super::MAX_WINDOW_SIZE as usize);
                     let sz = sz as WindowSize;
-                    self.actions.recv.ignore_data(sz)?;
+                    self.actions.recv.ignore_data(sz, &shared.conn_task)?;
 
                     return Ok(());
                 }
 
-                if self.actions.may_have_forgotten_stream(peer, id) {
+                if self.actions.may_have_forgotten_stream(peer, shared, id) {
                     tracing::debug!("recv_data for old stream={:?}, sending STREAM_CLOSED", id,);
 
                     let sz = frame.flow_controlled_len();
@@ -578,8 +628,8 @@ impl Inner {
                     // this is just a sanity check.
                     assert!(sz <= super::MAX_WINDOW_SIZE as usize);
                     let sz = sz as WindowSize;
-                    self.actions.recv.ignore_data(sz)?;
 
+                    self.actions.recv.ignore_data(sz, &shared.conn_task)?;
                     return Err(Error::library_reset(id, Reason::STREAM_CLOSED));
                 }
 
@@ -592,28 +642,40 @@ impl Inner {
         let mut send_buffer = send_buffer.inner.lock().unwrap();
         let send_buffer = &mut *send_buffer;
 
-        self.counts.transition(stream, |counts, stream| {
-            let sz = frame.flow_controlled_len();
-            let res = actions.recv.recv_data(frame, stream);
-
-            // Any stream error after receiving a DATA frame means
-            // we won't give the data to the user, and so they can't
-            // release the capacity. We do it automatically.
-            if let Err(Error::Reset(..)) = res {
-                actions
+        self.counts
+            .transition(&shared.counts, stream, |counts, stream| {
+                let sz = frame.flow_controlled_len();
+                let res = actions
                     .recv
-                    .release_connection_capacity(sz as WindowSize, &mut None);
-            }
-            actions.reset_on_recv_stream_err(send_buffer, stream, counts, res)
-        })
+                    .recv_data(&shared.recv, &shared.conn_task, frame, stream);
+
+                // Any stream error after receiving a DATA frame means
+                // we won't give the data to the user, and so they can't
+                // release the capacity. We do it automatically.
+                if let Err(Error::Reset(..)) = res {
+                    actions
+                        .recv
+                        .release_connection_capacity(sz as WindowSize, &shared.conn_task);
+                }
+                actions.reset_on_recv_stream_err(
+                    send_buffer,
+                    stream,
+                    &shared.counts,
+                    counts,
+                    res,
+                    &shared.conn_task,
+                )
+            })
     }
 
     fn recv_reset<B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         frame: frame::Reset,
     ) -> Result<(), Error> {
         let id = frame.stream_id();
+        let store = &mut self.store;
 
         if id.is_zero() {
             proto_err!(conn: "recv_reset: invalid stream ID 0");
@@ -631,19 +693,19 @@ impl Inner {
             return Ok(());
         }
 
-        let stream = match self.store.find_mut(&id) {
+        let stream = match store.find_mut(&id) {
             Some(stream) => stream,
             None => {
                 // TODO: Are there other error cases?
                 self.actions
-                    .ensure_not_idle(self.counts.peer(), id)
+                    .ensure_not_idle(self.counts.peer(), shared, id)
                     .map_err(Error::library_go_away)?;
 
                 return Ok(());
             }
         };
 
-        if stream.is_pending_open {
+        if stream.send().is_pending_open {
             proto_err!(conn: "recv_reset: received frame on idle stream {:?}", id);
             return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
         }
@@ -653,20 +715,29 @@ impl Inner {
 
         let actions = &mut self.actions;
 
-        self.counts.transition(stream, |counts, stream| {
-            actions.recv.recv_reset(frame, stream, counts)?;
-            actions.send.handle_error(send_buffer, stream, counts);
-            assert!(stream.state.is_closed());
-            Ok(())
-        })
+        self.counts
+            .transition(&shared.counts, stream, |counts, stream| {
+                let has_queued_frame = stream.inner().is_pending_send
+                    || stream.shared_ref().pending_ops().has_queued_frame();
+                actions
+                    .recv
+                    .recv_reset(frame, stream, counts, has_queued_frame)?;
+                actions
+                    .send
+                    .handle_error(send_buffer, stream, &shared.counts, counts);
+                assert!(stream.shared().state.is_closed());
+                Ok(())
+            })
     }
 
     fn recv_window_update<B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         frame: frame::WindowUpdate,
     ) -> Result<(), Error> {
         let id = frame.stream_id();
+        let store = &mut self.store;
 
         let mut send_buffer = send_buffer.inner.lock().unwrap();
         let send_buffer = &mut *send_buffer;
@@ -674,13 +745,13 @@ impl Inner {
         if id.is_zero() {
             self.actions
                 .send
-                .recv_connection_window_update(frame, &mut self.store, &mut self.counts)
+                .recv_connection_window_update(frame, &mut *store, &shared.counts, &mut self.counts)
                 .map_err(Error::library_go_away)?;
         } else {
             // The remote may send window updates for streams that the local now
             // considers closed. It's ok...
-            if let Some(mut stream) = self.store.find_mut(&id) {
-                if stream.is_pending_open {
+            if let Some(mut stream) = store.find_mut(&id) {
+                if stream.send().is_pending_open {
                     proto_err!(conn: "recv_window_update: received frame on idle stream {:?}", id);
                     return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
                 }
@@ -692,20 +763,23 @@ impl Inner {
                         frame.size_increment(),
                         send_buffer,
                         &mut stream,
+                        &shared.counts,
                         &mut self.counts,
-                        &mut self.actions.task,
+                        &shared.conn_task,
                     )
                     .map_err(|reason| Error::library_reset(id, reason));
 
                 return self.actions.reset_on_recv_stream_err(
                     send_buffer,
                     &mut stream,
+                    &shared.counts,
                     &mut self.counts,
                     res,
+                    &shared.conn_task,
                 );
             } else {
                 self.actions
-                    .ensure_not_idle(self.counts.peer(), id)
+                    .ensure_not_idle(self.counts.peer(), shared, id)
                     .map_err(Error::library_go_away)?;
             }
         }
@@ -713,22 +787,37 @@ impl Inner {
         Ok(())
     }
 
-    fn handle_error<B>(&mut self, send_buffer: &SendBuffer<B>, err: proto::Error) -> StreamId {
+    fn handle_error<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        err: proto::Error,
+    ) -> StreamId {
         let actions = &mut self.actions;
         let counts = &mut self.counts;
         let mut send_buffer = send_buffer.inner.lock().unwrap();
         let send_buffer = &mut *send_buffer;
+        let store = &mut self.store;
 
         let last_processed_id = actions.recv.last_processed_id();
 
-        self.store.for_each(|stream| {
-            counts.transition(stream, |counts, stream| {
-                actions.recv.handle_error(&err, &mut *stream);
-                actions.send.handle_error(send_buffer, stream, counts);
+        store.for_each(|stream| {
+            counts.transition(&shared.counts, stream, |counts, stream| {
+                actions.recv.handle_error(&err, &*stream);
+                actions
+                    .send
+                    .handle_error(send_buffer, stream, &shared.counts, counts);
             })
         });
 
-        actions.conn_error = Some(err);
+        *shared.conn_error.write().unwrap() = Some(err);
+        if let Some(err) = shared.conn_error.read().unwrap().as_ref() {
+            shared
+                .pending_ops
+                .lock()
+                .unwrap()
+                .for_each_pending_stream(|stream| stream.handle_error(err));
+        }
 
         last_processed_id
     }
@@ -736,12 +825,14 @@ impl Inner {
     fn recv_go_away<B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         frame: &frame::GoAway,
     ) -> Result<(), Error> {
         let actions = &mut self.actions;
         let counts = &mut self.counts;
         let mut send_buffer = send_buffer.inner.lock().unwrap();
         let send_buffer = &mut *send_buffer;
+        let store = &mut self.store;
 
         let last_stream_id = frame.last_stream_id();
 
@@ -750,16 +841,29 @@ impl Inner {
         let err = Error::remote_go_away(frame.debug_data().clone(), frame.reason());
 
         let peer = counts.peer();
-        self.store.for_each(|stream| {
+        store.for_each(|stream| {
             if stream.id > last_stream_id && peer.is_local_init(stream.id) {
-                counts.transition(stream, |counts, stream| {
-                    actions.recv.handle_error(&err, &mut *stream);
-                    actions.send.handle_error(send_buffer, stream, counts);
+                counts.transition(&shared.counts, stream, |counts, stream| {
+                    actions.recv.handle_error(&err, &*stream);
+                    actions
+                        .send
+                        .handle_error(send_buffer, stream, &shared.counts, counts);
                 })
             }
         });
 
-        actions.conn_error = Some(err);
+        *shared.conn_error.write().unwrap() = Some(err);
+        if let Some(err) = shared.conn_error.read().unwrap().as_ref() {
+            shared
+                .pending_ops
+                .lock()
+                .unwrap()
+                .for_each_pending_stream(|stream| {
+                    if peer.is_local_init(stream.id) && stream.id > last_stream_id {
+                        stream.handle_error(err);
+                    }
+                });
+        }
 
         Ok(())
     }
@@ -767,13 +871,15 @@ impl Inner {
     fn recv_push_promise<B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         frame: frame::PushPromise,
     ) -> Result<(), Error> {
         let id = frame.stream_id();
         let promised_id = frame.promised_id();
+        let store = &mut self.store;
 
         // First, ensure that the initiating stream is still in a valid state.
-        let parent_key = match self.store.find_mut(&id) {
+        let parent_key = match store.find_mut(&id) {
             Some(stream) => {
                 // The GOAWAY process has begun. All streams with a greater ID
                 // than specified as part of GOAWAY should be ignored.
@@ -787,7 +893,7 @@ impl Inner {
                 }
 
                 // The stream must be receive open
-                if !stream.state.ensure_recv_open()? {
+                if !stream.shared().state.ensure_recv_open()? {
                     proto_err!(conn: "recv_push_promise: initiating stream is not opened");
                     return Err(Error::library_go_away(Reason::PROTOCOL_ERROR));
                 }
@@ -805,7 +911,7 @@ impl Inner {
         // could grow in memory indefinitely.
 
         // Ensure that we can reserve streams
-        self.actions.recv.ensure_can_reserve()?;
+        self.actions.recv.ensure_can_reserve(&shared.recv)?;
 
         // Next, open the stream.
         //
@@ -814,7 +920,12 @@ impl Inner {
         if self
             .actions
             .recv
-            .open(promised_id, Open::PushPromise, &mut self.counts)?
+            .open(
+                promised_id,
+                Open::PushPromise,
+                &shared.counts,
+                &mut self.counts,
+            )?
             .is_none()
         {
             return Ok(());
@@ -822,44 +933,45 @@ impl Inner {
 
         // Try to handle the frame and create a corresponding key for the pushed stream
         // this requires a bit of indirection to make the borrow checker happy.
-        let child_key: Option<store::Key> = {
+        let child_stream: Option<Arc<stream::Shared>> = {
             // Create state for the stream
-            let stream = self.store.insert(promised_id, {
+            let stream = store.insert(promised_id, {
                 Stream::new(
                     promised_id,
-                    self.actions.send.init_window_sz(),
-                    self.actions.recv.init_window_sz(),
+                    shared.send.init_window_sz(),
+                    shared.recv.init_window_sz(),
                 )
             });
+            shared.counts.inc_num_wired_streams();
 
             let actions = &mut self.actions;
 
-            self.counts.transition(stream, |counts, stream| {
-                let stream_valid = actions.recv.recv_push_promise(frame, stream);
+            self.counts
+                .transition(&shared.counts, stream, |counts, stream| {
+                    let stream_valid = actions.recv.recv_push_promise(&shared.recv, frame, stream);
 
-                match stream_valid {
-                    Ok(()) => Ok(Some(stream.key())),
-                    _ => {
-                        let mut send_buffer = send_buffer.inner.lock().unwrap();
-                        actions
-                            .reset_on_recv_stream_err(
-                                &mut *send_buffer,
-                                stream,
-                                counts,
-                                stream_valid,
-                            )
-                            .map(|()| None)
+                    match stream_valid {
+                        Ok(()) => Ok(Some(stream.clone_shared())),
+                        _ => {
+                            let mut send_buffer = send_buffer.inner.lock().unwrap();
+                            actions
+                                .reset_on_recv_stream_err(
+                                    &mut *send_buffer,
+                                    stream,
+                                    &shared.counts,
+                                    counts,
+                                    stream_valid,
+                                    &shared.conn_task,
+                                )
+                                .map(|()| None)
+                        }
                     }
-                }
-            })?
+                })?
         };
         // If we're successful, push the headers and stream...
-        if let Some(child) = child_key {
-            let mut ppp = self.store[parent_key].pending_push_promises.take();
-            ppp.push(&mut self.store.resolve(child));
-
-            let parent = &mut self.store.resolve(parent_key);
-            parent.pending_push_promises = ppp;
+        if let Some(child) = child_stream {
+            let parent = &mut store.resolve(parent_key);
+            shared.recv.push_pushed(parent.shared_ref(), child);
             parent.notify_push();
         };
 
@@ -869,15 +981,17 @@ impl Inner {
     fn recv_eof<B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         clear_pending_accept: bool,
     ) -> Result<(), ()> {
         let actions = &mut self.actions;
         let counts = &mut self.counts;
         let mut send_buffer = send_buffer.inner.lock().unwrap();
         let send_buffer = &mut *send_buffer;
+        let store = &mut self.store;
 
-        if actions.conn_error.is_none() {
-            actions.conn_error = Some(
+        if shared.conn_error.read().unwrap().is_none() {
+            *shared.conn_error.write().unwrap() = Some(
                 io::Error::new(
                     io::ErrorKind::BrokenPipe,
                     "connection closed because of a broken pipe",
@@ -888,23 +1002,34 @@ impl Inner {
 
         tracing::trace!("Streams::recv_eof");
 
-        self.store.for_each(|stream| {
-            counts.transition(stream, |counts, stream| {
+        store.for_each(|stream| {
+            counts.transition(&shared.counts, stream, |counts, stream| {
                 actions.recv.recv_eof(stream);
 
                 // This handles resetting send state associated with the
                 // stream
-                actions.send.handle_error(send_buffer, stream, counts);
+                actions
+                    .send
+                    .handle_error(send_buffer, stream, &shared.counts, counts);
             })
         });
 
-        actions.clear_queues(clear_pending_accept, &mut self.store, counts);
+        if let Some(err) = shared.conn_error.read().unwrap().as_ref() {
+            shared
+                .pending_ops
+                .lock()
+                .unwrap()
+                .for_each_pending_stream(|stream| stream.handle_error(err));
+        }
+
+        actions.clear_queues(clear_pending_accept, &shared.counts, store, counts);
         Ok(())
     }
 
     fn poll_complete<T, B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         cx: &mut Context,
         dst: &mut Codec<T, Prioritized<B>>,
     ) -> Poll<io::Result<()>>
@@ -912,36 +1037,479 @@ impl Inner {
         T: AsyncWrite + Unpin,
         B: Buf,
     {
-        let mut send_buffer = send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
+        // Register before processing deferred stream operations. If flushing
+        // those operations returns `Pending`, user handles may still queue more
+        // work before the transport wakes this task again.
+        shared.conn_task.register(cx.waker());
+
+        self.process_pending_conn_ops(send_buffer, shared);
 
         // Send WINDOW_UPDATE frames first
         //
         // TODO: It would probably be better to interleave updates w/ data
         // frames.
-        ready!(self
-            .actions
-            .recv
-            .poll_complete(cx, &mut self.store, &mut self.counts, dst))?;
+        {
+            ready!(self.actions.recv.poll_complete(
+                cx,
+                &mut self.store,
+                &shared.counts,
+                &mut self.counts,
+                dst
+            ))?;
+        }
 
         // Send any other pending frames
-        ready!(self.actions.send.poll_complete(
-            cx,
-            send_buffer,
-            &mut self.store,
-            &mut self.counts,
-            dst
-        ))?;
+        {
+            let mut send_buffer = send_buffer.inner.lock().unwrap();
+            let send_buffer = &mut *send_buffer;
+            ready!(self.actions.send.poll_complete(
+                cx,
+                send_buffer,
+                &mut self.store,
+                &shared.counts,
+                &mut self.counts,
+                dst
+            ))?;
+        }
 
-        // Nothing else to do, track the task
-        self.actions.task = Some(cx.waker().clone());
+        if !shared.pending_ops.lock().unwrap().is_empty() {
+            shared.conn_task.wake();
+        }
 
         Poll::Ready(Ok(()))
     }
 
+    fn process_pending_conn_ops<B>(&mut self, send_buffer: &SendBuffer<B>, shared: &Shared)
+    where
+        B: Buf,
+    {
+        loop {
+            let mut pending_ops = shared.pending_ops.lock().unwrap();
+            if let Some(queued_stream) = pending_ops.pop_front_stream() {
+                drop(pending_ops);
+                self.process_pending_stream_ops(send_buffer, shared, queued_stream);
+            } else {
+                return;
+            }
+        }
+    }
+
+    fn process_pending_stream_ops<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        queued_stream: QueuedStream,
+    ) where
+        B: Buf,
+    {
+        let QueuedStream { stream } = queued_stream;
+        stream.clear_pending_conn_ops();
+        let mut ops = stream.pending_ops().take();
+
+        if let Some(frame) = ops.request_headers.take() {
+            stream.ops_dec();
+            self.process_op_req_headers(send_buffer, shared, stream.clone(), frame);
+        }
+
+        for (frame, promised) in ops.push_promises {
+            stream.ops_dec();
+            self.process_op_push_promise(send_buffer, shared, stream.clone(), frame, promised);
+        }
+
+        for frame in ops.informational_headers {
+            stream.ops_dec();
+            self.process_op_informational_headers(send_buffer, shared, stream.clone(), frame);
+        }
+
+        if let Some(frame) = ops.response_headers {
+            stream.ops_dec();
+            self.process_op_response_headers(send_buffer, shared, stream.clone(), frame);
+        }
+
+        for prepared in ops.data {
+            stream.ops_dec();
+            self.process_op_data(send_buffer, shared, stream.clone(), prepared);
+        }
+
+        for prepared in ops.reserve_capacity {
+            stream.ops_dec();
+            self.process_op_reserve_cap(shared, stream.clone(), prepared);
+        }
+
+        if ops.release_capacity_count > 0 {
+            for _ in 0..ops.release_capacity_count {
+                stream.ops_dec();
+            }
+            self.process_op_release_cap(shared, stream.clone(), ops.release_capacity);
+        }
+
+        if let Some(frame) = ops.trailers {
+            stream.ops_dec();
+            self.process_op_trailers(send_buffer, shared, stream.clone(), frame);
+        }
+
+        if let Some(reset) = ops.reset {
+            stream.ops_dec();
+            self.process_op_reset(
+                send_buffer,
+                shared,
+                stream.clone(),
+                reset.reason,
+                reset.prepared,
+            );
+        }
+
+        for _ in 0..ops.drop_count {
+            stream.ops_dec();
+            release_queued_send_ref(
+                &mut self.actions,
+                &mut self.counts,
+                shared,
+                &shared.counts,
+                &mut self.store,
+                &stream,
+            );
+        }
+    }
+
+    fn process_op_req_headers<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        frame: frame::Headers,
+    ) where
+        B: Buf,
+    {
+        shared
+            .queued_request_headers
+            .fetch_sub(1, Ordering::Relaxed);
+        if self.store.find_mut_even_if_unlinked(&stream).is_none() {
+            let (is_unreferenced, is_closed_without_reset, is_ignored_by_go_away) = {
+                let shared_state = stream.state();
+                (
+                    shared_state.ref_count == 0,
+                    shared_state.state.is_closed() && !shared_state.state.is_local_reset(),
+                    self.counts.peer().is_local_init(stream.id)
+                        && self.actions.send.is_ignored_by_go_away(stream.id),
+                )
+            };
+
+            if is_ignored_by_go_away {
+                if let Some(err) = shared.conn_error.read().unwrap().as_ref() {
+                    stream.handle_error(err);
+                }
+            }
+
+            if is_unreferenced || is_closed_without_reset || is_ignored_by_go_away {
+                return;
+            }
+
+            let mut stream = Stream::new_with_shared(stream.clone());
+            reconcile_deferred_send_window(&mut stream, shared.send.init_window_sz());
+            reconcile_deferred_recv_window(&mut stream, shared.recv.init_window_sz());
+            if frame.pseudo().method == Some(http::Method::HEAD) {
+                stream.inner_mut().content_length = stream::ContentLength::Head;
+            }
+            self.store.insert(stream.id, stream);
+            shared.counts.inc_num_wired_streams();
+        }
+
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+
+        let is_pending_reset = stream_ptr.is_pending_reset_expiration();
+
+        let should_send = {
+            stream_ptr.notify_send();
+            let shared = stream_ptr.shared();
+            !shared.state.is_closed() || shared.state.is_local_reset()
+        };
+        if !should_send {
+            self.counts
+                .transition_after(&shared.counts, stream_ptr, is_pending_reset);
+            return;
+        }
+        let mut send_frames_guard = send_buffer.inner.lock().unwrap();
+        let send_frames = &mut *send_frames_guard;
+        self.actions.send.send_headers_after_prepare(
+            &shared.send,
+            frame,
+            send_frames,
+            &mut stream_ptr,
+            &mut self.counts,
+            &shared.conn_task,
+        );
+    }
+
+    fn process_op_data<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        prepared: PreparedSendData,
+    ) where
+        B: Buf,
+    {
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+
+        let is_pending_reset = stream_ptr.is_pending_reset_expiration();
+        let stream_is_reset = {
+            let shared_state = stream_ptr.shared();
+            shared_state.state.is_reset()
+        };
+        //if stream_ptr.shared().state.is_reset() {
+        if stream_is_reset {
+            let mut send_frames_guard = send_buffer.inner.lock().unwrap();
+            let send_frames = &mut *send_frames_guard;
+            let frame = stream_ptr.send().pending_op_data.pop_front(send_frames);
+            debug_assert!(
+                matches!(frame, None | Some(Frame::Data(_))),
+                "pending_op_data must only contain DATA frames"
+            );
+            self.counts
+                .transition_after(&shared.counts, stream_ptr, is_pending_reset);
+            return;
+        }
+
+        let mut send_frames_guard = send_buffer.inner.lock().unwrap();
+        let send_frames = &mut *send_frames_guard;
+        let frame = stream_ptr.send().pending_op_data.pop_front(send_frames);
+        match frame {
+            Some(Frame::Data(frame)) => {
+                self.actions.send.send_prepared_data(
+                    frame,
+                    prepared,
+                    send_frames,
+                    &mut stream_ptr,
+                    &shared.counts,
+                    &mut self.counts,
+                    &shared.conn_task,
+                );
+            }
+            Some(frame) => {
+                unreachable!("pending_op_data must only contain DATA frames: {frame:?}")
+            }
+            None => {}
+        }
+    }
+
+    fn process_op_reserve_cap(
+        &mut self,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        prepared: PreparedReserveCapacity,
+    ) {
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+
+        self.actions.send.apply_reserve_capacity(
+            prepared,
+            &mut stream_ptr,
+            &shared.counts,
+            &mut self.counts,
+        );
+    }
+
+    fn process_op_release_cap(
+        &mut self,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        capacity: WindowSize,
+    ) {
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+        self.actions
+            .recv
+            .release_connection_capacity(capacity, &shared.conn_task);
+        self.actions
+            .recv
+            .schedule_stream_window_update(&mut stream_ptr, &shared.conn_task);
+    }
+
+    fn process_op_push_promise<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        frame: frame::PushPromise,
+        promised: Arc<stream::Shared>,
+    ) where
+        B: Buf,
+    {
+        if self.store.find_mut_even_if_unlinked(&promised).is_none() {
+            let mut stream = Stream::new_with_shared(promised.clone());
+            reconcile_deferred_send_window(&mut stream, shared.send.init_window_sz());
+            reconcile_deferred_recv_window(&mut stream, shared.recv.init_window_sz());
+            self.store.insert(stream.id, stream);
+            shared.counts.inc_num_wired_streams();
+        }
+
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+
+        let mut send_frames_guard = send_buffer.inner.lock().unwrap();
+        let send_frames = &mut *send_frames_guard;
+        self.actions.send.send_push_promise_frame(
+            &shared.send,
+            frame,
+            send_frames,
+            &mut stream_ptr,
+            &shared.conn_task,
+        );
+    }
+
+    fn process_op_trailers<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        frame: frame::Headers,
+    ) where
+        B: Buf,
+    {
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+        let stream_is_reset = {
+            let shared_state = stream_ptr.shared();
+            shared_state.state.is_reset()
+        };
+        if stream_is_reset {
+            let is_pending_reset = stream_ptr.is_pending_reset_expiration();
+            self.counts
+                .transition_after(&shared.counts, stream_ptr, is_pending_reset);
+            return;
+        }
+
+        let mut send_frames_guard = send_buffer.inner.lock().unwrap();
+        let send_frames = &mut *send_frames_guard;
+        self.actions.send.send_trailers_frame(
+            frame,
+            send_frames,
+            &mut stream_ptr,
+            &shared.counts,
+            &mut self.counts,
+            &shared.conn_task,
+        );
+    }
+
+    fn process_op_informational_headers<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        frame: frame::Headers,
+    ) where
+        B: Buf,
+    {
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+        let stream_is_reset = {
+            let shared_state = stream_ptr.shared();
+            shared_state.state.is_reset()
+        };
+        if stream_is_reset {
+            let is_pending_reset = stream_ptr.is_pending_reset_expiration();
+            self.counts
+                .transition_after(&shared.counts, stream_ptr, is_pending_reset);
+            return;
+        }
+
+        let mut send_frames_guard = send_buffer.inner.lock().unwrap();
+        let send_frames = &mut *send_frames_guard;
+        self.actions.send.send_interim_informational_headers_frame(
+            frame,
+            send_frames,
+            &mut stream_ptr,
+            &shared.conn_task,
+        );
+    }
+
+    fn process_op_response_headers<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        frame: frame::Headers,
+    ) where
+        B: Buf,
+    {
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+        let stream_is_reset = {
+            let shared_state = stream_ptr.shared();
+            shared_state.state.is_reset()
+        };
+        if stream_is_reset {
+            let is_pending_reset = stream_ptr.is_pending_reset_expiration();
+            self.counts
+                .transition_after(&shared.counts, stream_ptr, is_pending_reset);
+            return;
+        }
+
+        let mut send_frames_guard = send_buffer.inner.lock().unwrap();
+        let send_frames = &mut *send_frames_guard;
+        self.actions.send.send_headers_frame(
+            &shared.send,
+            frame,
+            send_frames,
+            &mut stream_ptr,
+            &shared.conn_task,
+        );
+    }
+
+    fn process_op_reset<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        shared: &Shared,
+        stream: Arc<stream::Shared>,
+        reason: Reason,
+        prepared: PreparedSendReset,
+    ) where
+        B: Buf,
+    {
+        let Some(mut stream_ptr) = self.store.find_mut_even_if_unlinked(&stream) else {
+            return;
+        };
+
+        self.actions.send.send_prepared_reset(
+            reason,
+            prepared,
+            &mut *send_buffer.inner.lock().unwrap(),
+            &mut stream_ptr,
+            &shared.counts,
+            &mut self.counts,
+            &shared.conn_task,
+        );
+        drop(stream_ptr);
+        if prepared.send_explicit_reset {
+        } else {
+            release_queued_send_ref(
+                &mut self.actions,
+                &mut self.counts,
+                shared,
+                &shared.counts,
+                &mut self.store,
+                &stream,
+            );
+        }
+    }
+
+    // ===== send_* fns =====
+
     fn send_reset<B>(
         &mut self,
         send_buffer: &SendBuffer<B>,
+        shared: &Shared,
         id: StreamId,
         reason: Reason,
     ) -> Result<(), crate::proto::error::GoAway> {
@@ -963,7 +1531,7 @@ impl Inner {
                 if self.counts.peer().is_local_init(id) {
                     // We normally would open this stream, so update our
                     // next-send-id record.
-                    self.actions.send.maybe_reset_next_stream_id(id);
+                    shared.send.maybe_reset_next_stream_id(id);
                 } else {
                     // We normally would recv this stream, so update our
                     // next-recv-id record.
@@ -972,7 +1540,9 @@ impl Inner {
 
                 let stream = Stream::new(id, 0, 0);
 
-                e.insert(stream)
+                let key = e.insert(stream);
+                shared.counts.inc_num_wired_streams();
+                key
             }
         };
 
@@ -983,36 +1553,11 @@ impl Inner {
             stream,
             reason,
             Initiator::Library,
+            &shared.counts,
             &mut self.counts,
             send_buffer,
+            &shared.conn_task,
         )
-    }
-}
-
-impl<B> Streams<B, client::Peer>
-where
-    B: Buf,
-{
-    pub fn poll_pending_open(
-        &mut self,
-        cx: &Context,
-        pending: Option<&OpaqueStreamRef>,
-    ) -> Poll<Result<(), crate::Error>> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        me.actions.ensure_no_conn_error()?;
-        me.actions.send.ensure_next_stream_id()?;
-
-        if let Some(pending) = pending {
-            let mut stream = me.store.resolve(pending.key);
-            tracing::trace!("poll_pending_open; stream = {:?}", stream.is_pending_open);
-            if stream.is_pending_open {
-                stream.wait_send(cx);
-                return Poll::Pending;
-            }
-        }
-        Poll::Ready(Ok(()))
     }
 }
 
@@ -1020,69 +1565,45 @@ impl<B, P> Streams<B, P>
 where
     P: Peer,
 {
-    pub fn as_dyn(&self) -> DynStreams<'_, B> {
+    pub fn as_dyn(&mut self) -> DynStreams<'_, B> {
         let Self {
             inner,
             send_buffer,
+            shared,
             _p,
         } = self;
         DynStreams {
             inner,
             send_buffer,
+            shared,
             peer: P::r#dyn(),
         }
     }
 
     /// This function is safe to call multiple times.
-    ///
-    /// A `Result` is returned to avoid panicking if the mutex is poisoned.
     pub fn recv_eof(&mut self, clear_pending_accept: bool) -> Result<(), ()> {
         self.as_dyn().recv_eof(clear_pending_accept)
     }
 
     pub(crate) fn max_send_streams(&self) -> usize {
-        self.inner.lock().unwrap().counts.max_send_streams()
+        self.inner.counts.max_send_streams(&self.shared.counts)
     }
 
     pub(crate) fn max_recv_streams(&self) -> usize {
-        self.inner.lock().unwrap().counts.max_recv_streams()
-    }
-
-    #[cfg(feature = "unstable")]
-    pub fn num_active_streams(&self) -> usize {
-        let me = self.inner.lock().unwrap();
-        me.store.num_active_streams()
+        self.inner.counts.max_recv_streams(&self.shared.counts)
     }
 
     pub fn has_streams(&self) -> bool {
-        let me = self.inner.lock().unwrap();
-        me.counts.has_streams()
+        self.inner.counts.has_streams(&self.shared.counts)
     }
 
     pub fn has_streams_or_other_references(&self) -> bool {
-        let me = self.inner.lock().unwrap();
-        me.counts.has_streams() || me.refs > 1
+        self.inner.counts.has_streams(&self.shared.counts) || Arc::strong_count(&self.shared) > 1
     }
 
     #[cfg(feature = "unstable")]
     pub fn num_wired_streams(&self) -> usize {
-        let me = self.inner.lock().unwrap();
-        me.store.num_wired_streams()
-    }
-}
-
-// no derive because we don't need B and P to be Clone.
-impl<B, P> Clone for Streams<B, P>
-where
-    P: Peer,
-{
-    fn clone(&self) -> Self {
-        self.inner.lock().unwrap().refs += 1;
-        Streams {
-            inner: self.inner.clone(),
-            send_buffer: self.send_buffer.clone(),
-            _p: ::std::marker::PhantomData,
-        }
+        self.shared.counts.num_wired_streams()
     }
 }
 
@@ -1091,14 +1612,156 @@ where
     P: Peer,
 {
     fn drop(&mut self) {
-        if let Ok(mut inner) = self.inner.lock() {
-            inner.refs -= 1;
-            if inner.refs == 1 {
-                if let Some(task) = inner.actions.task.take() {
-                    task.wake();
+        if Arc::strong_count(&self.shared) == 2 {
+            self.shared.conn_task.wake();
+        }
+    }
+}
+
+// ===== impl Injector =====
+
+impl<B> Injector<B>
+where
+    B: Buf,
+{
+    pub fn poll_pending_open(
+        &mut self,
+        cx: &Context,
+        pending: Option<&OpaqueStreamRef>,
+    ) -> Poll<Result<(), crate::Error>> {
+        self.shared.ensure_no_conn_error()?;
+        self.shared.send.ensure_next_stream_id()?;
+
+        if let Some(pending) = pending {
+            let is_pending_open = pending.stream.is_pending_open();
+            tracing::trace!("poll_pending_open; stream = {:?}", is_pending_open);
+            if is_pending_open {
+                pending.stream.wait_send(cx);
+                if !pending.stream.is_pending_open() {
+                    pending.stream.notify_send();
                 }
+                return Poll::Pending;
             }
         }
+        Poll::Ready(Ok(()))
+    }
+
+    pub fn enqueue_request(
+        &mut self,
+        mut request: Request<()>,
+        end_of_stream: bool,
+        pending: Option<&OpaqueStreamRef>,
+    ) -> Result<StreamRef<B>, SendError> {
+        // The `pending` argument is provided by the `Client`, and holds
+        // a store `Key` of a `Stream` that may have been not been opened
+        // yet.
+        //
+        // If that stream is still pending, the Client isn't allowed to
+        // queue up another pending stream. They should use `poll_ready`.
+        if let Some(stream) = pending {
+            if stream.stream.is_pending_open() {
+                return Err(UserError::Rejected.into());
+            }
+        }
+        let pending = AssertNoPendingRequest;
+
+        let protocol = request.extensions_mut().remove::<Protocol>();
+
+        // Clear before taking lock, incase extensions contain a StreamRef.
+        request.extensions_mut().clear();
+
+        self.shared.ensure_no_conn_error()?;
+        self.shared.send.ensure_next_stream_id()?;
+
+        let stream = self.prepare_request(
+            request,
+            protocol,
+            end_of_stream,
+            pending,
+            self.shared.send.init_window_sz(),
+            self.shared.recv.init_window_sz(),
+        )?;
+
+        Ok(stream)
+    }
+
+    fn prepare_request(
+        &mut self,
+        request: Request<()>,
+        protocol: Option<Protocol>,
+        end_of_stream: bool,
+        _: AssertNoPendingRequest,
+        init_send_window: WindowSize,
+        init_recv_window: WindowSize,
+    ) -> Result<StreamRef<B>, SendError> {
+        // TODO: There is a hazard with assigning a stream ID before the
+        // prioritize layer. If prioritization reorders new streams, this
+        // implicitly closes the earlier stream IDs.
+        //
+        // See: hyperium/h2#11
+
+        let stream_id = self.shared.send.open()?;
+        let stream = stream::Shared::new(stream_id, init_send_window, init_recv_window);
+
+        // Convert the message
+        let headers =
+            client::Peer::convert_send_message(stream_id, request, protocol, end_of_stream)?;
+
+        Send::check_headers(headers.fields())?;
+        {
+            let queued_request_headers = self.shared.pending_request_headers_count();
+            let is_pending_open = self.shared.counts.num_send_streams() + queued_request_headers
+                >= self.shared.counts.max_send_streams();
+            stream.state().state.send_open(end_of_stream)?;
+            stream.send().is_pending_open = is_pending_open;
+        }
+
+        let stream_ref = StreamRef {
+            opaque: OpaqueStreamRef::from_shared(self.shared.clone(), stream.clone()),
+            send_buffer: self.send_buffer.clone(),
+        };
+
+        self.shared.push_request_headers(headers, stream);
+
+        Ok(stream_ref)
+    }
+
+    pub fn is_extended_connect_protocol_enabled(&self) -> bool {
+        self.shared.send.is_extended_connect_protocol_enabled()
+    }
+
+    pub fn current_max_send_streams(&self) -> usize {
+        self.shared.counts.max_send_streams()
+    }
+
+    pub fn current_max_recv_streams(&self) -> usize {
+        self.shared.counts.current_max_recv_streams()
+    }
+
+    #[cfg(feature = "unstable")]
+    pub fn num_active_streams(&self) -> usize {
+        self.shared.counts.num_active_streams()
+    }
+
+    #[cfg(feature = "unstable")]
+    pub fn num_wired_streams(&self) -> usize {
+        self.shared.counts.num_wired_streams()
+    }
+}
+
+// no derive because we don't need B and P to be Clone.
+impl<B> Clone for Injector<B> {
+    fn clone(&self) -> Self {
+        Injector {
+            send_buffer: self.send_buffer.clone(),
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl<B> Drop for Injector<B> {
+    fn drop(&mut self) {
+        self.shared.conn_task.wake();
     }
 }
 
@@ -1109,105 +1772,74 @@ impl<B> StreamRef<B> {
     where
         B: Buf,
     {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let stream = me.store.resolve(self.opaque.key);
-        let actions = &mut me.actions;
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
-
-        me.counts.transition(stream, |counts, stream| {
-            // Create the data frame
-            let mut frame = frame::Data::new(stream.id, data);
+        let (frame, prepared) = {
+            let mut frame = frame::Data::new(self.opaque.stream.id, data);
             frame.set_end_stream(end_stream);
+            let prepared = Send::prepare_data(&frame, &self.opaque.stream)?;
+            (frame, prepared)
+        };
 
-            // Send the data frame
-            actions
-                .send
-                .send_data(frame, send_buffer, stream, counts, &mut actions.task)
-        })
+        self.send_buffer
+            .push_pending_op_data(frame.into(), &self.opaque.stream);
+
+        self.opaque
+            .shared
+            .push_pending_op(self.opaque.stream.clone(), |ops| ops.push_data(prepared));
+
+        Ok(())
     }
 
     pub fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), UserError> {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
+        if !self.opaque.stream.state().state.is_send_streaming() {
+            return Err(UserError::UnexpectedFrameType);
+        }
+        self.opaque.stream.state().state.send_close();
+        let frame = frame::Headers::trailers(self.opaque.stream.id, trailers);
 
-        let stream = me.store.resolve(self.opaque.key);
-        let actions = &mut me.actions;
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
+        self.opaque
+            .shared
+            .push_pending_op(self.opaque.stream.clone(), |ops| ops.set_trailers(frame));
 
-        me.counts.transition(stream, |counts, stream| {
-            // Create the trailers frame
-            let frame = frame::Headers::trailers(stream.id, trailers);
-
-            // Send the trailers frame
-            actions
-                .send
-                .send_trailers(frame, send_buffer, stream, counts, &mut actions.task)
-        })
+        Ok(())
     }
 
     pub fn send_reset(&mut self, reason: Reason) {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
+        let has_queued_request_headers = self.opaque.stream.pending_ops().has_request_headers();
+        let prepared = Send::prepare_reset(
+            &self.opaque.stream,
+            self.is_pending_open() || has_queued_request_headers,
+            reason,
+            Initiator::User,
+        );
 
-        let stream = me.store.resolve(self.opaque.key);
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
-
-        match me
-            .actions
-            .send_reset(stream, reason, Initiator::User, &mut me.counts, send_buffer)
-        {
-            Ok(()) => (),
-            Err(crate::proto::error::GoAway { .. }) => {
-                // this should never happen, because Initiator::User resets do
-                // not count toward the local limit.
-                // we could perhaps make this state impossible, if we made the
-                // initiator argument a generic, and so this could return
-                // Infallible instead of an impossible GoAway, but oh well.
-                unreachable!("Initiator::User should not error sending reset");
-            }
+        if let Some(prepared) = prepared {
+            self.opaque
+                .shared
+                .push_pending_op(self.opaque.stream.clone(), |ops| {
+                    ops.set_reset(reason, prepared)
+                });
         }
     }
 
     pub fn send_informational_headers(&mut self, frame: frame::Headers) -> Result<(), UserError> {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
+        debug_assert!(
+            frame.is_informational(),
+            "Frame must be informational after conversion from informational response"
+        );
 
-        let stream = me.store.resolve(self.opaque.key);
-        let actions = &mut me.actions;
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
+        if frame.is_end_stream() {
+            return Err(UserError::UnexpectedFrameType);
+        }
 
-        me.counts.transition(stream, |counts, stream| {
-            // For informational responses (1xx), we need to send headers without
-            // changing the stream state. This allows multiple informational responses
-            // to be sent before the final response.
+        Send::check_headers(frame.fields())?;
 
-            // Validate that this is actually an informational response
-            debug_assert!(
-                frame.is_informational(),
-                "Frame must be informational after conversion from informational response"
-            );
+        self.opaque
+            .shared
+            .push_pending_op(self.opaque.stream.clone(), |ops| {
+                ops.push_informational_headers(frame)
+            });
 
-            // Ensure the frame is not marked as end_stream for informational responses
-            if frame.is_end_stream() {
-                return Err(UserError::UnexpectedFrameType);
-            }
-
-            // Send the interim informational headers directly to the buffer without state changes
-            // This bypasses the normal send_headers flow that would transition the stream state
-            actions.send.send_interim_informational_headers(
-                frame,
-                send_buffer,
-                stream,
-                counts,
-                &mut actions.task,
-            )
-        })
+        Ok(())
     }
 
     pub fn send_response(
@@ -1217,21 +1849,18 @@ impl<B> StreamRef<B> {
     ) -> Result<(), UserError> {
         // Clear before taking lock, incase extensions contain a StreamRef.
         response.extensions_mut().clear();
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
+        let frame =
+            server::Peer::convert_send_message(self.opaque.stream.id, response, end_of_stream);
+        Send::check_headers(frame.fields())?;
+        self.opaque.stream.state().state.send_open(end_of_stream)?;
 
-        let stream = me.store.resolve(self.opaque.key);
-        let actions = &mut me.actions;
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
+        self.opaque
+            .shared
+            .push_pending_op(self.opaque.stream.clone(), |ops| {
+                ops.set_response_headers(frame)
+            });
 
-        me.counts.transition(stream, |counts, stream| {
-            let frame = server::Peer::convert_send_message(stream.id, response, end_of_stream);
-
-            actions
-                .send
-                .send_headers(frame, send_buffer, stream, counts, &mut actions.task)
-        })
+        Ok(())
     }
 
     pub fn send_push_promise(
@@ -1240,49 +1869,33 @@ impl<B> StreamRef<B> {
     ) -> Result<StreamRef<B>, UserError> {
         // Clear before taking lock, incase extensions contain a StreamRef.
         request.extensions_mut().clear();
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
+        let promised_id = self.opaque.shared.send.reserve_local()?;
 
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
-
-        let actions = &mut me.actions;
-        let promised_id = actions.send.reserve_local()?;
-
-        let child_key = {
-            let mut child_stream = me.store.insert(
-                promised_id,
-                Stream::new(
-                    promised_id,
-                    actions.send.init_window_sz(),
-                    actions.recv.init_window_sz(),
-                ),
-            );
-            child_stream.state.reserve_local()?;
-            child_stream.is_pending_push = true;
-            child_stream.key()
-        };
-
-        let pushed = {
-            let mut stream = me.store.resolve(self.opaque.key);
-
-            let frame = crate::server::Peer::convert_push_message(stream.id, promised_id, request)?;
-
-            actions
-                .send
-                .send_push_promise(frame, send_buffer, &mut stream, &mut actions.task)
-        };
-
-        if let Err(err) = pushed {
-            let mut child_stream = me.store.resolve(child_key);
-            child_stream.unlink();
-            child_stream.remove();
-            return Err(err);
+        if !self.opaque.shared.send.is_push_enabled() {
+            return Err(UserError::PeerDisabledServerPush);
         }
 
-        me.refs += 1;
-        let opaque =
-            OpaqueStreamRef::new(self.opaque.inner.clone(), &mut me.store.resolve(child_key));
+        let frame =
+            crate::server::Peer::convert_push_message(self.opaque.stream.id, promised_id, request)?;
+        Send::check_headers(frame.fields())?;
+
+        let child_stream = stream::Shared::new(
+            promised_id,
+            self.opaque.shared.send.init_window_sz(),
+            self.opaque.shared.recv.init_window_sz(),
+        );
+        {
+            child_stream.state().state.reserve_local()?;
+            child_stream.state().is_pending_push = true;
+        }
+
+        self.opaque
+            .shared
+            .push_pending_op(self.opaque.stream.clone(), |ops| {
+                ops.push_push_promise(frame, child_stream.clone())
+            });
+
+        let opaque = OpaqueStreamRef::from_shared(self.opaque.shared.clone(), child_stream);
 
         Ok(StreamRef {
             opaque,
@@ -1298,49 +1911,38 @@ impl<B> StreamRef<B> {
     ///
     /// This function panics if the request isn't present.
     pub fn take_request(&self) -> Request<()> {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.opaque.key);
-        me.actions.recv.take_request(&mut stream)
+        super::recv::take_request(&self.opaque.stream, &self.opaque.shared.recv)
     }
 
     /// Called by a client to see if the current stream is pending open
     pub fn is_pending_open(&self) -> bool {
-        let mut me = self.opaque.inner.lock().unwrap();
-        me.store.resolve(self.opaque.key).is_pending_open
+        self.opaque.stream.is_pending_open()
     }
 
     /// Request capacity to send data
     pub fn reserve_capacity(&mut self, capacity: WindowSize) {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
+        let prepared = send::prepare_reserve_capacity(capacity, &self.opaque.stream);
 
-        let mut stream = me.store.resolve(self.opaque.key);
-
-        me.actions
-            .send
-            .reserve_capacity(capacity, &mut stream, &mut me.counts)
+        if let Some(prepared) = prepared {
+            self.opaque
+                .shared
+                .push_pending_op(self.opaque.stream.clone(), |ops| {
+                    ops.push_reserve_capacity(prepared)
+                });
+        }
     }
 
     /// Returns the stream's current send capacity.
     pub fn capacity(&self) -> WindowSize {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.opaque.key);
-
-        me.actions.send.capacity(&mut stream)
+        self.opaque.shared.send.capacity(&self.opaque.stream)
     }
 
     /// Request to be notified when the stream's capacity increases
     pub fn poll_capacity(&mut self, cx: &Context) -> Poll<Option<Result<WindowSize, UserError>>> {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.opaque.key);
-
-        me.actions.send.poll_capacity(cx, &mut stream)
+        self.opaque
+            .shared
+            .send
+            .poll_capacity(cx, &self.opaque.stream)
     }
 
     /// Request to be notified for if a `RST_STREAM` is received for this stream.
@@ -1349,12 +1951,7 @@ impl<B> StreamRef<B> {
         cx: &Context,
         mode: proto::PollReset,
     ) -> Poll<Result<Reason, crate::Error>> {
-        let mut me = self.opaque.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.opaque.key);
-
-        me.actions.send.poll_reset(cx, &mut stream, mode)
+        super::send::poll_reset(cx, &self.opaque.stream, mode)
     }
 
     pub fn clone_to_opaque(&self) -> OpaqueStreamRef {
@@ -1378,21 +1975,17 @@ impl<B> Clone for StreamRef<B> {
 // ===== impl OpaqueStreamRef =====
 
 impl OpaqueStreamRef {
-    fn new(inner: Arc<Mutex<Inner>>, stream: &mut store::Ptr) -> OpaqueStreamRef {
+    fn new(shared: Arc<Shared>, stream: &mut store::Ptr) -> OpaqueStreamRef {
+        OpaqueStreamRef::from_shared(shared, stream.clone_shared())
+    }
+
+    fn from_shared(shared: Arc<Shared>, stream: Arc<stream::Shared>) -> OpaqueStreamRef {
         stream.ref_inc();
-        OpaqueStreamRef {
-            inner,
-            key: stream.key(),
-        }
+        OpaqueStreamRef { shared, stream }
     }
     /// Called by a client to check for a received response.
     pub fn poll_response(&mut self, cx: &Context) -> Poll<Result<Response<()>, proto::Error>> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.key);
-
-        me.actions.recv.poll_response(cx, &mut stream)
+        super::recv::poll_response(cx, &self.stream, &self.shared.recv)
     }
 
     /// Called by a client to check for informational responses (1xx status codes)
@@ -1400,213 +1993,161 @@ impl OpaqueStreamRef {
         &mut self,
         cx: &Context,
     ) -> Poll<Option<Result<Response<()>, proto::Error>>> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.key);
-
-        me.actions.recv.poll_informational(cx, &mut stream)
+        super::recv::poll_informational(cx, &self.stream, &self.shared.recv)
     }
     /// Called by a client to check for a pushed request.
     pub fn poll_pushed(
         &mut self,
         cx: &Context,
     ) -> Poll<Option<Result<(Request<()>, OpaqueStreamRef), proto::Error>>> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.key);
-        me.actions
-            .recv
-            .poll_pushed(cx, &mut stream)
-            .map_ok(|(h, key)| {
-                me.refs += 1;
-                let opaque_ref =
-                    OpaqueStreamRef::new(self.inner.clone(), &mut me.store.resolve(key));
-                (h, opaque_ref)
-            })
+        super::recv::poll_pushed(cx, &self.stream, &self.shared.recv).map_ok(|(h, stream)| {
+            let opaque_ref = OpaqueStreamRef::from_shared(self.shared.clone(), stream);
+            (h, opaque_ref)
+        })
     }
 
     pub fn is_end_stream(&self) -> bool {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let stream = me.store.resolve(self.key);
-
-        me.actions.recv.is_end_stream(&stream)
+        super::recv::is_end_stream(&self.stream)
     }
 
     pub fn poll_data(&mut self, cx: &Context) -> Poll<Option<Result<Bytes, proto::Error>>> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.key);
-
-        me.actions.recv.poll_data(cx, &mut stream)
+        super::recv::poll_data(cx, &self.stream, &self.shared.recv)
     }
 
     pub fn poll_trailers(&mut self, cx: &Context) -> Poll<Option<Result<HeaderMap, proto::Error>>> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.key);
-
-        me.actions.recv.poll_trailers(cx, &mut stream)
+        super::recv::poll_trailers(cx, &self.stream, &self.shared.recv)
     }
 
     pub(crate) fn available_recv_capacity(&self) -> isize {
-        let me = self.inner.lock().unwrap();
-        let me = &*me;
-
-        let stream = &me.store[self.key];
-        stream.recv_flow.available().into()
+        self.stream.recv().recv_flow.available().into()
     }
 
     pub(crate) fn used_recv_capacity(&self) -> WindowSize {
-        let me = self.inner.lock().unwrap();
-        let me = &*me;
-
-        let stream = &me.store[self.key];
-        stream.in_flight_recv_data
+        self.stream.recv().in_flight_recv_data
     }
 
     /// Releases recv capacity back to the peer. This may result in sending
     /// WINDOW_UPDATE frames on both the stream and connection.
     pub fn release_capacity(&mut self, capacity: WindowSize) -> Result<(), UserError> {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
+        super::recv::release_capacity_local(capacity, &self.stream)?;
 
-        let mut stream = me.store.resolve(self.key);
+        self.shared
+            .push_pending_op(self.stream.clone(), |ops| ops.release_capacity(capacity));
 
-        me.actions
-            .recv
-            .release_capacity(capacity, &mut stream, &mut me.actions.task)
+        Ok(())
     }
 
     /// Clear the receive queue and set the status to no longer receive data frames.
     pub(crate) fn clear_recv_buffer(&mut self) {
-        let mut me = self.inner.lock().unwrap();
-        let me = &mut *me;
-
-        let mut stream = me.store.resolve(self.key);
-        stream.is_recv = false;
-        me.actions.recv.clear_recv_buffer(&mut stream);
+        self.stream.recv().is_recv = false;
+        self.shared.recv.clear(&self.stream);
     }
 
     pub fn stream_id(&self) -> StreamId {
-        self.inner.lock().unwrap().store[self.key].id
+        self.stream.id
     }
 }
 
 impl fmt::Debug for OpaqueStreamRef {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        use std::sync::TryLockError::*;
-
-        match self.inner.try_lock() {
-            Ok(me) => {
-                let stream = &me.store[self.key];
-                fmt.debug_struct("OpaqueStreamRef")
-                    .field("stream_id", &stream.id)
-                    .field("ref_count", &stream.ref_count)
-                    .finish()
-            }
-            Err(Poisoned(_)) => fmt
-                .debug_struct("OpaqueStreamRef")
-                .field("inner", &"<Poisoned>")
-                .finish(),
-            Err(WouldBlock) => fmt
-                .debug_struct("OpaqueStreamRef")
-                .field("inner", &"<Locked>")
-                .finish(),
-        }
+        let state = self.stream.state();
+        fmt.debug_struct("OpaqueStreamRef")
+            .field("stream_id", &self.stream.id)
+            .field("ref_count", &state.ref_count)
+            .finish()
     }
 }
 
 impl Clone for OpaqueStreamRef {
     fn clone(&self) -> Self {
-        // Increment the ref count
-        let mut inner = self.inner.lock().unwrap();
-        inner.store.resolve(self.key).ref_inc();
-        inner.refs += 1;
+        self.stream.ref_inc();
 
         OpaqueStreamRef {
-            inner: self.inner.clone(),
-            key: self.key,
+            shared: self.shared.clone(),
+            stream: self.stream.clone(),
         }
     }
 }
 
 impl Drop for OpaqueStreamRef {
     fn drop(&mut self) {
-        drop_stream_ref(&self.inner, self.key);
+        drop_stream_ref(&self.shared, &self.stream);
     }
 }
 
 // TODO: Move back in fn above
-fn drop_stream_ref(inner: &Mutex<Inner>, key: store::Key) {
-    let mut me = match inner.lock() {
-        Ok(inner) => inner,
-        Err(_) => {
-            if ::std::thread::panicking() {
-                tracing::trace!("StreamRef::drop; mutex poisoned");
-                return;
-            } else {
-                panic!("StreamRef::drop; mutex poisoned");
-            }
-        }
-    };
-
-    let me = &mut *me;
-    me.refs -= 1;
-    let mut stream = me.store.resolve(key);
-
+fn drop_stream_ref(shared: &Shared, stream: &Arc<stream::Shared>) {
     tracing::trace!("drop_stream_ref; stream={:?}", stream);
+
+    // Keep the stream alive until the deferred cleanup op runs.
+    stream.ops_inc();
 
     // decrement the stream's ref count by 1.
     stream.ref_dec();
 
-    let actions = &mut me.actions;
+    stream.pending_ops().inc_drop_count();
+    shared.push_stream_pending_ops(stream.clone());
+}
 
-    // If the stream is not referenced and it is already
-    // closed (does not have to go through logic below
-    // of canceling the stream), we should notify the task
-    // (connection) so that it can close properly
-    if stream.ref_count == 0 && stream.is_closed() {
-        if let Some(task) = actions.task.take() {
-            task.wake();
-        }
+fn release_queued_send_ref(
+    actions: &mut Actions,
+    counts: &mut Counts,
+    shared: &Shared,
+    counts_shared: &counts::Shared,
+    store: &mut Store,
+    stream: &Arc<stream::Shared>,
+) {
+    let Some(stream) = store.find_mut_even_if_unlinked(&stream) else {
+        return;
+    };
+
+    tracing::trace!("release_queued_send_ref; stream={:?}", stream);
+
+    let is_closed = stream.is_closed();
+    let is_unreferenced_and_closed = {
+        let shared = stream.shared();
+        shared.ref_count == 0 && is_closed
+    };
+    if is_unreferenced_and_closed {
+        shared.conn_task.wake();
     }
 
-    me.counts.transition(stream, |counts, stream| {
-        maybe_cancel(stream, actions, counts);
+    counts.transition(counts_shared, stream, |counts, stream| {
+        maybe_cancel(stream, actions, &shared.counts, counts, &shared.conn_task);
 
-        if stream.ref_count == 0 {
-            // Release any recv window back to connection, no one can access
-            // it anymore.
+        if stream.shared().ref_count == 0 {
             actions
                 .recv
-                .release_closed_capacity(stream, &mut actions.task);
+                .release_closed_capacity(stream, &shared.conn_task, &shared.recv);
 
-            // We won't be able to reach our push promises anymore
-            let mut ppp = stream.pending_push_promises.take();
-            while let Some(promise) = ppp.pop(stream.store_mut()) {
-                counts.transition(promise, |counts, stream| {
-                    maybe_cancel(stream, actions, counts);
-                });
+            while let Some(promise) = shared.recv.pop_pushed(stream.shared_ref()) {
+                if let Some(promise) = stream.store_mut().find_mut(&promise.id) {
+                    counts.transition(counts_shared, promise, |counts, stream| {
+                        maybe_cancel(stream, actions, counts_shared, counts, &shared.conn_task);
+                    });
+                }
             }
         }
     });
 }
 
-fn maybe_cancel(stream: &mut store::Ptr, actions: &mut Actions, counts: &mut Counts) {
+fn maybe_cancel(
+    stream: &mut store::Ptr,
+    actions: &mut Actions,
+    counts_shared: &counts::Shared,
+    counts: &mut Counts,
+    conn_task: &ConnWaker,
+) {
     if stream.is_canceled_interest() {
         // Server is allowed to early respond without fully consuming the client input stream
         // But per the RFC, must send a RST_STREAM(NO_ERROR) in such cases. https://www.rfc-editor.org/rfc/rfc7540#section-8.1
         // Some other http2 implementation may interpret other error code as fatal if not respected (i.e: nginx https://trac.nginx.org/nginx/ticket/2376)
-        let reason = if counts.peer().is_server()
-            && stream.state.is_send_closed()
-            && stream.state.is_recv_streaming()
-        {
+        let reason = if {
+            let shared = stream.shared();
+            counts.peer().is_server()
+                && shared.state.is_send_closed()
+                && shared.state.is_recv_streaming()
+        } {
             Reason::NO_ERROR
         } else {
             Reason::CANCEL
@@ -1614,7 +2155,7 @@ fn maybe_cancel(stream: &mut store::Ptr, actions: &mut Actions, counts: &mut Cou
 
         actions
             .send
-            .schedule_implicit_reset(stream, reason, counts, &mut actions.task);
+            .schedule_implicit_reset(stream, reason, counts_shared, counts, conn_task);
         actions.recv.enqueue_reset_expiration(stream, counts);
     }
 }
@@ -1631,6 +2172,53 @@ impl<B> SendBuffer<B> {
         let buf = self.inner.lock().unwrap();
         buf.is_empty()
     }
+
+    fn push_pending_op_data(&self, frame: Frame<B>, stream: &stream::Shared) {
+        let mut send_frames = self.inner.lock().unwrap();
+        stream
+            .send()
+            .pending_op_data
+            .push_back(&mut send_frames, frame);
+    }
+}
+
+impl Shared {
+    fn push_request_headers(&self, frame: frame::Headers, stream: Arc<stream::Shared>) {
+        self.queued_request_headers.fetch_add(1, Ordering::Relaxed);
+        self.push_pending_op(stream, |ops| ops.set_request_headers(frame));
+    }
+
+    fn push_pending_op<F>(&self, stream: Arc<stream::Shared>, f: F)
+    where
+        F: FnOnce(&mut stream::PendingOps),
+    {
+        stream.ops_inc();
+        f(&mut stream.pending_ops());
+        self.push_stream_pending_ops(stream);
+    }
+
+    fn push_stream_pending_ops(&self, stream: Arc<stream::Shared>) {
+        if !stream.mark_pending_conn_ops() {
+            return;
+        }
+
+        let mut pending_ops = self.pending_ops.lock().unwrap();
+        pending_ops.push_back_stream(QueuedStream { stream });
+
+        self.conn_task.wake();
+    }
+
+    fn pending_request_headers_count(&self) -> usize {
+        self.queued_request_headers.load(Ordering::Relaxed)
+    }
+
+    fn ensure_no_conn_error(&self) -> Result<(), proto::Error> {
+        if let Some(ref err) = *self.conn_error.read().unwrap() {
+            Err(err.clone())
+        } else {
+            Ok(())
+        }
+    }
 }
 
 // ===== impl Actions =====
@@ -1641,10 +2229,12 @@ impl Actions {
         stream: store::Ptr,
         reason: Reason,
         initiator: Initiator,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
         send_buffer: &mut Buffer<Frame<B>>,
+        conn_task: &ConnWaker,
     ) -> Result<(), crate::proto::error::GoAway> {
-        counts.transition(stream, |counts, stream| {
+        counts.transition(counts_shared, stream, |counts, stream| {
             if initiator.is_library() {
                 if counts.can_inc_num_local_error_resets() {
                     counts.inc_num_local_error_resets();
@@ -1665,8 +2255,9 @@ impl Actions {
                 initiator,
                 send_buffer,
                 stream,
+                counts_shared,
                 counts,
-                &mut self.task,
+                conn_task,
             );
             self.recv.enqueue_reset_expiration(stream, counts);
             // if a RecvStream is parked, ensure it's notified
@@ -1680,8 +2271,10 @@ impl Actions {
         &mut self,
         buffer: &mut Buffer<Frame<B>>,
         stream: &mut store::Ptr,
+        counts_shared: &counts::Shared,
         counts: &mut Counts,
         res: Result<(), Error>,
+        conn_task: &ConnWaker,
     ) -> Result<(), Error> {
         if let Err(Error::Reset(stream_id, reason, initiator)) = res {
             debug_assert_eq!(stream_id, stream.id);
@@ -1690,8 +2283,15 @@ impl Actions {
                 counts.inc_num_local_error_resets();
 
                 // Reset the stream.
-                self.send
-                    .send_reset(reason, initiator, buffer, stream, counts, &mut self.task);
+                self.send.send_reset(
+                    reason,
+                    initiator,
+                    buffer,
+                    stream,
+                    counts_shared,
+                    counts,
+                    conn_task,
+                );
                 self.recv.enqueue_reset_expiration(stream, counts);
                 // if a RecvStream is parked, ensure it's notified
                 stream.notify_recv();
@@ -1711,19 +2311,16 @@ impl Actions {
         }
     }
 
-    fn ensure_not_idle(&mut self, peer: peer::Dyn, id: StreamId) -> Result<(), Reason> {
+    fn ensure_not_idle(
+        &self,
+        peer: peer::Dyn,
+        shared: &Shared,
+        id: StreamId,
+    ) -> Result<(), Reason> {
         if peer.is_local_init(id) {
-            self.send.ensure_not_idle(id)
+            shared.send.ensure_not_idle(id)
         } else {
             self.recv.ensure_not_idle(id)
-        }
-    }
-
-    fn ensure_no_conn_error(&self) -> Result<(), proto::Error> {
-        if let Some(ref err) = self.conn_error {
-            Err(err.clone())
-        } else {
-            Ok(())
         }
     }
 
@@ -1736,19 +2333,42 @@ impl Actions {
     /// is more likely to be latency/memory constraints that caused this,
     /// and not a bad actor. So be less catastrophic, the spec allows
     /// us to send another RST_STREAM of STREAM_CLOSED.
-    fn may_have_forgotten_stream(&self, peer: peer::Dyn, id: StreamId) -> bool {
+    fn may_have_forgotten_stream(&self, peer: peer::Dyn, shared: &Shared, id: StreamId) -> bool {
         if id.is_zero() {
             return false;
         }
         if peer.is_local_init(id) {
-            self.send.may_have_created_stream(id)
+            shared.send.may_have_created_stream(id)
         } else {
             self.recv.may_have_created_stream(id)
         }
     }
 
-    fn clear_queues(&mut self, clear_pending_accept: bool, store: &mut Store, counts: &mut Counts) {
-        self.recv.clear_queues(clear_pending_accept, store, counts);
-        self.send.clear_queues(store, counts);
+    fn clear_queues(
+        &mut self,
+        clear_pending_accept: bool,
+        counts_shared: &counts::Shared,
+        store: &mut Store,
+        counts: &mut Counts,
+    ) {
+        self.recv
+            .clear_queues(clear_pending_accept, store, counts_shared, counts);
+        self.send.clear_queues(counts_shared, store, counts);
+    }
+}
+
+// ===== impl ConnWaker =====
+
+impl ConnWaker {
+    fn new() -> Self {
+        ConnWaker(atomic_waker::AtomicWaker::new())
+    }
+
+    pub(super) fn register(&self, waker: &Waker) {
+        self.0.register(waker);
+    }
+
+    pub(super) fn wake(&self) {
+        self.0.wake();
     }
 }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -1037,11 +1037,6 @@ impl Inner {
         T: AsyncWrite + Unpin,
         B: Buf,
     {
-        // Register before processing deferred stream operations. If flushing
-        // those operations returns `Pending`, user handles may still queue more
-        // work before the transport wakes this task again.
-        shared.conn_task.register(cx.waker());
-
         self.process_pending_conn_ops(send_buffer, shared);
 
         // Send WINDOW_UPDATE frames first
@@ -1049,28 +1044,49 @@ impl Inner {
         // TODO: It would probably be better to interleave updates w/ data
         // frames.
         {
-            ready!(self.actions.recv.poll_complete(
+            match self.actions.recv.poll_complete(
                 cx,
                 &mut self.store,
                 &shared.counts,
                 &mut self.counts,
-                dst
-            ))?;
+                dst,
+            ) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                Poll::Pending => {
+                    shared.conn_task.register(cx.waker());
+                    return Poll::Pending;
+                }
+            }
         }
 
         // Send any other pending frames
         {
             let mut send_buffer = send_buffer.inner.lock().unwrap();
             let send_buffer = &mut *send_buffer;
-            ready!(self.actions.send.poll_complete(
+            match self.actions.send.poll_complete(
                 cx,
                 send_buffer,
                 &mut self.store,
                 &shared.counts,
                 &mut self.counts,
-                dst
-            ))?;
+                dst,
+            ) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                Poll::Pending => {
+                    shared.conn_task.register(cx.waker());
+                    return Poll::Pending;
+                }
+            }
         }
+
+        // Arm the connection task after this poll has drained the currently
+        // pending work. Stream handles that enqueue more work before we return
+        // will either be observed by the check below or wake this registered
+        // task. This also preserves the old single-waker batching boundary for
+        // receive capacity releases.
+        shared.conn_task.register(cx.waker());
 
         if !shared.pending_ops.lock().unwrap().is_empty() {
             shared.conn_task.wake();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1630,7 +1630,7 @@ impl proto::Peer for Peer {
         fields: HeaderMap,
         stream_id: StreamId,
     ) -> Result<Self::Poll, Error> {
-        use http::{uri, Version};
+        use http::{Version, uri};
 
         let mut b = Request::builder();
 

--- a/tests/h2-support/src/mock.rs
+++ b/tests/h2-support/src/mock.rs
@@ -276,6 +276,11 @@ impl Handle {
         .await;
     }
 
+    pub fn set_write_capacity(&mut self, num: usize) {
+        let mut i = self.codec.get_mut().inner.lock().unwrap();
+        i.tx_rem = num;
+    }
+
     pub async fn unbounded_bytes(&mut self) {
         let mut i = self.codec.get_mut().inner.lock().unwrap();
         i.tx_rem = usize::MAX;

--- a/tests/h2-support/src/prelude.rs
+++ b/tests/h2-support/src/prelude.rs
@@ -29,6 +29,7 @@ pub use super::assert::assert_frame_eq;
 
 // Re-export useful crates
 pub use tokio_test::io as mock_io;
+pub use tokio_test::task;
 pub use {bytes, futures, http, tokio::io as tokio_io, tracing, tracing_subscriber};
 
 // Re-export primary future types

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -2,6 +2,7 @@ use futures::future::{ready, Either};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use h2_support::prelude::*;
+use h2_support::util::yield_once;
 use std::pin::Pin;
 use std::task::Context;
 use std::{io, panic};
@@ -348,6 +349,7 @@ async fn recv_decrement_max_concurrent_streams_when_requests_queued() {
 
         // first request is allowed
         let (resp1, _) = client.send_request(request, true).unwrap();
+        client = h2.drive(client.ready()).await.unwrap();
 
         let request = Request::builder()
             .method(Method::POST)
@@ -759,6 +761,34 @@ async fn connection_close_notifies_client_poll_ready() {
 }
 
 #[tokio::test]
+async fn drop_last_send_request_wakes_idle_connection() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(frames::go_away(0).no_error()).await;
+    };
+
+    let h2 = async move {
+        let (client, conn) = client::handshake(io).await.unwrap();
+        let conn = tokio::spawn(async move {
+            tokio::time::timeout(Duration::from_secs(1), conn)
+                .await
+                .expect("connection was not woken after SendRequest drop")
+                .expect("connection")
+        });
+
+        yield_once().await;
+        drop(client);
+        conn.await.unwrap();
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
 async fn sending_request_on_closed_connection() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
@@ -861,6 +891,7 @@ async fn recv_too_big_headers() {
             .unwrap();
 
         let req1 = client.send_request(request, true);
+        client = conn.drive(client.ready()).await.unwrap();
         // Spawn tasks to ensure that the error wakes up tasks that are blocked
         // waiting for a response.
         let req1 = async move {
@@ -955,6 +986,65 @@ async fn pending_send_request_gets_reset_by_peer_properly() {
     };
 
     join(srv, client).await;
+}
+
+#[tokio::test]
+async fn peer_reset_with_queued_send_data_frees_max_concurrent_slot() {
+    h2_support::trace_init!();
+
+    let (io, mut srv) = mock::new_with_write_capacity(73);
+
+    let srv = async move {
+        let settings = srv
+            .assert_client_handshake_with_settings(frames::settings().max_concurrent_streams(1))
+            .await;
+        assert_default_settings!(settings);
+
+        srv.recv_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+        srv.send_frame(frames::reset(1).cancel()).await;
+
+        srv.unbounded_bytes().await;
+        loop {
+            match srv.next().await.unwrap().unwrap() {
+                frame::Frame::Data(data) if data.stream_id() == StreamId::from(1) => {}
+                frame::Frame::Headers(headers) if headers.stream_id() == StreamId::from(3) => {
+                    break;
+                }
+                frame => panic!("unexpected frame: {:?}", frame),
+            }
+        }
+        srv.send_frame(frames::headers(3).response(200).eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut conn) = client::handshake(io).await.unwrap();
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+        let (response, mut stream) = client.send_request(request, false).unwrap();
+
+        let body = Bytes::from(vec![0; 2 * frame::DEFAULT_INITIAL_WINDOW_SIZE as usize]);
+        stream.send_data(body, true).unwrap();
+
+        let err = conn.drive(response).await.expect_err("response reset");
+        assert_eq!(err.reason(), Some(Reason::CANCEL));
+
+        poll_fn(|cx| client.poll_ready(cx)).await.unwrap();
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+        let (response, _) = client.send_request(request, true).unwrap();
+        let response = conn.drive(response).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    };
+
+    join(srv, h2).await;
 }
 
 #[tokio::test]
@@ -1253,10 +1343,26 @@ async fn malformed_response_headers_dont_unlink_stream() {
 
         srv.recv_frame(frames::headers(1).request("GET", "http://example.com/"))
             .await;
-        srv.recv_frame(frames::headers(3).request("GET", "http://example.com/"))
-            .await;
-        srv.recv_frame(frames::headers(5).request("GET", "http://example.com/"))
-            .await;
+        loop {
+            match srv.next().await.unwrap().unwrap() {
+                frame::Frame::Data(d) if d.stream_id() == StreamId::from(1) => {}
+                frame::Frame::Headers(h) => {
+                    assert_frame_eq(h, frames::headers(3).request("GET", "http://example.com/"));
+                    break;
+                }
+                other => panic!("unexpected frame before stream 3 headers: {:?}", other),
+            }
+        }
+        loop {
+            match srv.next().await.unwrap().unwrap() {
+                frame::Frame::Data(d) if d.stream_id() == StreamId::from(1) => {}
+                frame::Frame::Headers(h) => {
+                    assert_frame_eq(h, frames::headers(5).request("GET", "http://example.com/"));
+                    break;
+                }
+                other => panic!("unexpected frame before stream 5 headers: {:?}", other),
+            }
+        }
         drop_tx.send(()).unwrap();
         queued_rx.await.unwrap();
         srv.send_bytes(&[
@@ -1280,7 +1386,7 @@ async fn malformed_response_headers_dont_unlink_stream() {
     }
 
     let client = async move {
-        let (mut client, conn) = client::Builder::new()
+        let (mut client, mut conn) = client::Builder::new()
             .handshake::<_, Bytes>(io)
             .await
             .expect("handshake");
@@ -1288,7 +1394,9 @@ async fn malformed_response_headers_dont_unlink_stream() {
         let (_req1, mut send1) = client.send_request(request(), false).unwrap();
         // Use up most of the connection window.
         send1.send_data(vec![0; 65534].into(), true).unwrap();
+        client = conn.drive(client.ready()).await.unwrap();
         let (req2, mut send2) = client.send_request(request(), false).unwrap();
+        client = conn.drive(client.ready()).await.unwrap();
         let (req3, mut send3) = client.send_request(request(), false).unwrap();
 
         let f = async move {

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -1058,6 +1058,162 @@ async fn recv_settings_removes_available_capacity() {
 }
 
 #[tokio::test]
+async fn spawned_multi_stream_flow_control_wakes_tasks() {
+    use std::collections::BTreeSet;
+    use tokio::time::timeout;
+
+    h2_support::trace_init!();
+
+    const CHUNK: usize = 16_384;
+    const TOTAL_CHUNKS: usize = 3;
+    const STREAM_IDS: [u32; 3] = [1, 3, 5];
+
+    fn request(uri: &'static str) -> Request<()> {
+        Request::builder().uri(uri).body(()).unwrap()
+    }
+
+    let (io, mut srv) = mock::new();
+
+    let srv_task = tokio::spawn(async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+
+        srv.recv_frame(
+            frames::headers(1)
+                .request("GET", "https://example.com/a")
+                .eos(),
+        )
+        .await;
+        srv.recv_frame(
+            frames::headers(3)
+                .request("GET", "https://example.com/b")
+                .eos(),
+        )
+        .await;
+        srv.recv_frame(
+            frames::headers(5)
+                .request("GET", "https://example.com/c")
+                .eos(),
+        )
+        .await;
+
+        for stream_id in STREAM_IDS {
+            srv.send_frame(frames::headers(stream_id).response(200))
+                .await;
+        }
+
+        for stream_id in STREAM_IDS {
+            srv.send_frame(frames::data(stream_id, vec![0; CHUNK]))
+                .await;
+        }
+
+        let mut saw_stream_updates = BTreeSet::new();
+        let mut conn_increment_total = 0;
+
+        while conn_increment_total < (CHUNK * STREAM_IDS.len()) as u32 {
+            let frame = srv.next().await.unwrap().unwrap();
+            match frame {
+                h2::frame::Frame::WindowUpdate(frame) => {
+                    if frame.stream_id().is_zero() {
+                        conn_increment_total += frame.size_increment();
+                    } else {
+                        panic!(
+                            "unexpected stream window update before second round: {:?}",
+                            frame
+                        );
+                    }
+                }
+                frame => panic!(
+                    "unexpected frame while waiting for window updates: {:?}",
+                    frame
+                ),
+            }
+        }
+
+        for stream_id in STREAM_IDS {
+            srv.send_frame(frames::data(stream_id, vec![0; CHUNK]))
+                .await;
+        }
+
+        while saw_stream_updates.len() < STREAM_IDS.len()
+            || conn_increment_total < (CHUNK * STREAM_IDS.len() * 2) as u32
+        {
+            let frame = srv.next().await.unwrap().unwrap();
+            match frame {
+                h2::frame::Frame::WindowUpdate(frame) => {
+                    if frame.stream_id().is_zero() {
+                        conn_increment_total += frame.size_increment();
+                    } else {
+                        assert_eq!(frame.size_increment(), (CHUNK * 2) as u32);
+                        saw_stream_updates.insert(frame.stream_id());
+                    }
+                }
+                frame => panic!(
+                    "unexpected frame while waiting for stream updates: {:?}",
+                    frame
+                ),
+            }
+        }
+
+        for stream_id in STREAM_IDS {
+            srv.send_frame(frames::data(stream_id, vec![0; CHUNK]).eos())
+                .await;
+        }
+    });
+
+    let (mut client, conn) = client::handshake(io).await.unwrap();
+
+    let conn_task = tokio::spawn(async move {
+        conn.await.unwrap();
+    });
+
+    let response1 = client
+        .send_request(request("https://example.com/a"), true)
+        .unwrap()
+        .0;
+    client = client.ready().await.unwrap();
+    let response2 = client
+        .send_request(request("https://example.com/b"), true)
+        .unwrap()
+        .0;
+    client = client.ready().await.unwrap();
+    let response3 = client
+        .send_request(request("https://example.com/c"), true)
+        .unwrap()
+        .0;
+
+    let body_tasks = [response1, response2, response3].map(|response| {
+        tokio::spawn(async move {
+            let response = response.await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let (_, mut body) = response.into_parts();
+            let mut total = 0usize;
+
+            while let Some(chunk) = body.data().await {
+                let chunk = chunk.unwrap();
+                total += chunk.len();
+                body.flow_control().release_capacity(chunk.len()).unwrap();
+            }
+
+            assert_eq!(total, CHUNK * TOTAL_CHUNKS);
+        })
+    });
+
+    timeout(Duration::from_secs(5), async move {
+        for task in body_tasks {
+            task.await.unwrap();
+        }
+
+        drop(client);
+        conn_task.await.unwrap();
+        srv_task.await.unwrap();
+    })
+    .await
+    .expect("spawned flow-control tasks stalled");
+}
+
+#[tokio::test]
 async fn recv_settings_keeps_assigned_capacity() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();
@@ -1738,27 +1894,29 @@ async fn reserve_capacity_then_cancel_does_not_leak() {
 
         let srv = async move {
             let _ = srv.assert_client_handshake().await;
-            srv.recv_frame(frames::headers(1).request("POST", "https://example.com/"))
-                .await;
             if !explicit_reset {
+                srv.recv_frame(frames::headers(1).request("POST", "https://example.com/"))
+                    .await;
                 srv.send_frame(frames::headers(1).response(200)).await;
             }
             let mut data_bytes = 0;
-            loop {
+            let data_stream_id = loop {
                 let frame = srv.next().await.unwrap().unwrap();
                 match frame {
                     h2::frame::Frame::Reset(_) | h2::frame::Frame::Headers(_) => {}
                     h2::frame::Frame::Data(d) => {
+                        let stream_id = d.stream_id();
                         data_bytes += d.payload().len();
                         if d.is_end_stream() {
-                            break;
+                            break stream_id;
                         }
                     }
                     other => panic!("unexpected: {:?}", other),
                 }
-            }
+            };
             assert_eq!(data_bytes, 65535);
-            srv.send_frame(frames::headers(3).response(200).eos()).await;
+            srv.send_frame(frames::headers(data_stream_id).response(200).eos())
+                .await;
         };
 
         let client = async move {
@@ -2082,6 +2240,7 @@ async fn max_send_buffer_size_overflow() {
 
         assert_eq!(stream.capacity(), 0);
         stream.reserve_capacity(10);
+        let mut stream = conn.drive(util::wait_for_capacity(stream, 5)).await;
         assert_eq!(
             stream.capacity(),
             5,
@@ -2144,11 +2303,6 @@ async fn max_send_buffer_size_poll_capacity_wakes_task() {
         assert_eq!(stream.capacity(), 0);
         const TO_SEND: usize = 20;
         stream.reserve_capacity(TO_SEND);
-        assert_eq!(
-            stream.capacity(),
-            5,
-            "polled capacity not over max buffer size"
-        );
 
         let t1 = tokio::spawn(async move {
             let mut sent = 0;
@@ -2234,6 +2388,59 @@ async fn poll_capacity_wakeup_after_window_update() {
         stream.send_data("".into(), true).unwrap();
 
         // Wait for the connection to close
+        h2.await.unwrap();
+    };
+
+    join(srv, h2).await;
+}
+
+#[tokio::test]
+async fn poll_capacity_after_partial_send_uses_existing_capacity() {
+    h2_support::trace_init!();
+    let (io, mut srv) = mock::new();
+
+    let srv = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(frames::headers(1).request("POST", "https://example.com/"))
+            .await;
+        srv.send_frame(frames::headers(1).response(200).eos()).await;
+        srv.recv_frame(frames::data(1, "hello")).await;
+        srv.recv_frame(frames::data(1, " world").eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+
+        let (response, mut stream) = client.send_request(request, false).unwrap();
+        let response = h2.drive(response).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        stream.reserve_capacity(11);
+        let cap = h2
+            .drive(poll_fn(|cx| stream.poll_capacity(cx)))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(cap, 11);
+
+        stream.send_data("hello".into(), false).unwrap();
+        assert_eq!(stream.capacity(), 6);
+        stream.reserve_capacity(6);
+
+        let cap = h2
+            .drive(poll_fn(|cx| stream.poll_capacity(cx)))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(cap, 6);
+
+        stream.send_data(" world".into(), true).unwrap();
         h2.await.unwrap();
     };
 

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -7,6 +7,43 @@ use tokio::io::AsyncWriteExt;
 const SETTINGS: &[u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
 const SETTINGS_ACK: &[u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 
+async fn recv_frames(client: &mut mock::Handle, count: usize) -> Vec<h2::frame::Frame> {
+    let mut frames = Vec::with_capacity(count);
+    for _ in 0..count {
+        frames.push(client.next().await.unwrap().unwrap());
+    }
+    frames
+}
+
+fn frame_position<F: Into<h2::frame::Frame>>(frames: &[h2::frame::Frame], expected: F) -> usize {
+    let expected = expected.into();
+    frames
+        .iter()
+        .position(|actual| *actual == expected)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected frame not received; expected={:?}; actual={:?}",
+                expected, frames
+            )
+        })
+}
+
+fn assert_frame_before<F1, F2>(frames: &[h2::frame::Frame], first: F1, second: F2)
+where
+    F1: Into<h2::frame::Frame>,
+    F2: Into<h2::frame::Frame>,
+{
+    let first = frame_position(frames, first);
+    let second = frame_position(frames, second);
+    assert!(
+        first < second,
+        "expected frame {} before {}; frames={:?}",
+        first,
+        second,
+        frames
+    );
+}
+
 #[tokio::test]
 async fn read_preface_in_multiple_frames() {
     h2_support::trace_init!();
@@ -23,6 +60,75 @@ async fn read_preface_in_multiple_frames() {
     let mut h2 = server::handshake(mock).await.unwrap();
 
     assert!(h2.next().await.is_none());
+}
+
+#[tokio::test]
+async fn send_response_wakes_connection_parked_in_poll_complete() {
+    h2_support::trace_init!();
+    let (io, mut client) = mock::new();
+
+    let client_setup = async move {
+        let settings = client.assert_server_handshake().await;
+        assert_default_settings!(settings);
+        client
+            .send_frame(
+                frames::headers(1)
+                    .request("GET", "https://example.com/")
+                    .eos(),
+            )
+            .await;
+        client
+            .send_frame(
+                frames::headers(3)
+                    .request("GET", "https://example.com/")
+                    .eos(),
+            )
+            .await;
+        client
+    };
+
+    let server_setup = async move {
+        let mut srv = server::handshake(io).await.expect("handshake");
+        let (_req1, stream1) = srv.next().await.unwrap().unwrap();
+        let (_req2, stream2) = srv.next().await.unwrap().unwrap();
+        (srv, stream1, stream2)
+    };
+
+    let (mut client, (mut srv, mut stream1, mut stream2)) =
+        join(client_setup, server_setup).await;
+
+    // While poll_complete is blocked on write backpressure, user handles can
+    // still enqueue more deferred stream operations. Those operations must not
+    // lose their connection wake before transport readiness arrives.
+    client.set_write_capacity(0);
+    stream1
+        .send_response(Response::new(()), true)
+        .expect("send first response");
+
+    let mut conn = task::spawn(poll_fn(move |cx| srv.poll_closed(cx)));
+    assert!(
+        conn.poll().is_pending(),
+        "connection should park on write backpressure"
+    );
+    if conn.is_woken() {
+        assert!(
+            conn.poll().is_pending(),
+            "connection should still park on write backpressure"
+        );
+    }
+    assert!(
+        !conn.is_woken(),
+        "connection should remain parked until write capacity or app work wakes it"
+    );
+
+    stream2
+        .send_response(Response::new(()), true)
+        .expect("send second response");
+
+    assert!(
+        conn.is_woken(),
+        "send_response must wake connection parked on write backpressure"
+    );
 }
 
 #[tokio::test]
@@ -411,15 +517,32 @@ async fn push_request_with_data() {
                     .eos(),
             )
             .await;
-        client.recv_frame(frames::headers(1).response(200)).await;
-        client
-            .recv_frame(
-                frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
-            )
-            .await;
-        client.recv_frame(frames::headers(2).response(200)).await;
-        client.recv_frame(frames::data(1, &b""[..]).eos()).await;
-        client.recv_frame(frames::data(2, &b"\x00"[..]).eos()).await;
+        let frames = recv_frames(&mut client, 5).await;
+
+        frame_position(&frames, frames::headers(1).response(200));
+        frame_position(
+            &frames,
+            frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
+        );
+        frame_position(&frames, frames::headers(2).response(200));
+        frame_position(&frames, frames::data(1, &b""[..]).eos());
+        frame_position(&frames, frames::data(2, &b"\x00"[..]).eos());
+
+        assert_frame_before(
+            &frames,
+            frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
+            frames::headers(2).response(200),
+        );
+        assert_frame_before(
+            &frames,
+            frames::headers(1).response(200),
+            frames::data(1, &b""[..]).eos(),
+        );
+        assert_frame_before(
+            &frames,
+            frames::headers(2).response(200),
+            frames::data(2, &b"\x00"[..]).eos(),
+        );
     };
 
     let srv = async move {
@@ -477,17 +600,32 @@ async fn push_request_between_data() {
                     .eos(),
             )
             .await;
-        client.recv_frame(frames::headers(1).response(200)).await;
-        client.recv_frame(frames::data(1, &b""[..])).await;
-        client
-            .recv_frame(
-                frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
-            )
-            .await;
-        client
-            .recv_frame(frames::headers(2).response(200).eos())
-            .await;
-        client.recv_frame(frames::data(1, &b""[..]).eos()).await;
+        let frames = recv_frames(&mut client, 5).await;
+
+        frame_position(&frames, frames::headers(1).response(200));
+        frame_position(&frames, frames::data(1, &b""[..]));
+        frame_position(
+            &frames,
+            frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
+        );
+        frame_position(&frames, frames::headers(2).response(200).eos());
+        frame_position(&frames, frames::data(1, &b""[..]).eos());
+
+        assert_frame_before(
+            &frames,
+            frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
+            frames::headers(2).response(200).eos(),
+        );
+        assert_frame_before(
+            &frames,
+            frames::headers(1).response(200),
+            frames::data(1, &b""[..]),
+        );
+        assert_frame_before(
+            &frames,
+            frames::data(1, &b""[..]),
+            frames::data(1, &b""[..]).eos(),
+        );
     };
 
     let srv = async move {

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -94,8 +94,7 @@ async fn send_response_wakes_connection_parked_in_poll_complete() {
         (srv, stream1, stream2)
     };
 
-    let (mut client, (mut srv, mut stream1, mut stream2)) =
-        join(client_setup, server_setup).await;
+    let (mut client, (mut srv, mut stream1, mut stream2)) = join(client_setup, server_setup).await;
 
     // While poll_complete is blocked on write backpressure, user handles can
     // still enqueue more deferred stream operations. Those operations must not

--- a/tests/h2-tests/tests/stream_states.rs
+++ b/tests/h2-tests/tests/stream_states.rs
@@ -175,8 +175,7 @@ async fn closed_streams_are_released() {
         let (_, body) = response.into_parts();
         assert!(body.is_end_stream());
         drop(body);
-
-        // The stream state is now free
+        h2.drive(yield_once()).await;
         assert_eq!(0, client.num_wired_streams());
     };
 
@@ -190,6 +189,7 @@ async fn closed_streams_are_released() {
         )
         .await;
         srv.send_frame(frames::headers(1).response(204).eos()).await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     };
     join(srv, h2).await;
 }


### PR DESCRIPTION
This is stacked on top of #917.

## Problem

In #917, `Inner::poll_complete` registers the connection task waker before draining pending stream operations. That lets stream handles wake the connection task while it is still actively polling the current batch of work. For receive-side capacity releases, this changes the old batching boundary from main: instead of accumulating releases until the current poll has drained, the connection can be woken repeatedly and emit smaller, more frequent `WINDOW_UPDATE` frames.

In the reproducer this showed up most clearly with one TCP connection, default flow-control windows, and multiple concurrent streams. Base #917 sent roughly twice as many connection-level `WINDOW_UPDATE` frames as main/fixed, with about half the average update size.

## Solution

Delay `shared.conn_task.register(cx.waker())` until after recv/send pending work has been drained, matching the old single-waker coalescing boundary. The pending paths still register the waker before returning `Poll::Pending`, so transport wakeups are not missed.

## Validation

Focused test suite:

```text
cargo test --offline -p h2-tests --test flow_control
47 passed; 4 ignored
```

Benchmark configuration:

```text
requests=300
response_size=1048576
stream_window_size=65535
connection_window_size=65535
worker_threads=8
TCP_NODELAY=false
connections=1,2,4,8
streams_per_connection=1,2,4,8
```

Single-run Windows loopback results:

| Conns | Streams | Total conc. | Main req/s | Base #917 req/s | Fixed req/s | Fixed vs base | Fixed vs main |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 1 | 1,090.3 | 48.2 | 1,030.4 | 21.37x | 95% |
| 1 | 2 | 2 | 1,010.0 | 69.3 | 1,100.3 | 15.89x | 109% |
| 1 | 4 | 4 | 1,041.1 | 71.7 | 1,050.7 | 14.65x | 101% |
| 1 | 8 | 8 | 736.2 | 81.5 | 753.3 | 9.25x | 102% |
| 2 | 1 | 2 | 682.2 | 145.9 | 742.3 | 5.09x | 109% |
| 2 | 2 | 4 | 593.9 | 282.5 | 566.4 | 2.01x | 95% |
| 2 | 4 | 8 | 542.6 | 337.1 | 510.5 | 1.51x | 94% |
| 2 | 8 | 16 | 532.7 | 297.3 | 642.1 | 2.16x | 121% |
| 4 | 1 | 4 | 1,744.8 | 1,532.3 | 1,728.7 | 1.13x | 99% |
| 4 | 2 | 8 | 1,922.9 | 1,485.0 | 2,190.4 | 1.48x | 114% |
| 4 | 4 | 16 | 1,862.6 | 1,356.7 | 1,962.3 | 1.45x | 105% |
| 4 | 8 | 32 | 1,402.9 | 1,760.3 | 1,689.1 | 0.96x | 120% |
| 8 | 1 | 8 | 3,152.6 | 1,960.6 | 3,144.0 | 1.60x | 100% |
| 8 | 2 | 16 | 3,157.2 | 3,413.5 | 2,839.2 | 0.83x | 90% |
| 8 | 4 | 32 | 2,802.2 | 2,622.1 | 2,554.9 | 0.97x | 91% |
| 8 | 8 | 64 | 3,296.0 | 3,151.1 | 3,334.9 | 1.06x | 101% |

The fix removes the severe one-connection cliff and returns the slowest #917 cases to roughly main-level throughput.