### PR TITLE
Revert "perf(header): optimize `HeaderValue` creation via zero-copy sharing"

### DIFF
--- a/src/hpack/header.rs
+++ b/src/hpack/header.rs
@@ -96,7 +96,7 @@ impl Header {
         } else {
             // HTTP/2 requires lower case header names
             let name = HeaderName::from_lowercase(&name)?;
-            let value = HeaderValue::from_maybe_shared(value)?;
+            let value = HeaderValue::from_bytes(&value)?;
 
             Ok(Header::Field { name, value })
         }
@@ -231,7 +231,7 @@ impl<'a> Name<'a> {
         match self {
             Name::Field(name) => Ok(Header::Field {
                 name: name.clone(),
-                value: HeaderValue::from_maybe_shared(value)?,
+                value: HeaderValue::from_bytes(&value)?,
             }),
             Name::Authority => Ok(Header::Authority(BytesStr::try_from(value)?)),
             Name::Method => Ok(Header::Method(Method::from_bytes(&value)?)),


### PR DESCRIPTION
close: https://github.com/hyperium/h2/issues/923