### PR TITLE
perf: decode two HPACK Huffman symbols per table lookup

### DIFF
--- a/src/hpack/huffman/decode.rs
+++ b/src/hpack/huffman/decode.rs
@@ -1,0 +1,345 @@
+//! Huffman decoding for HPACK (RFC 7541 §5.2).
+//!
+//! The decoder has a fast path which decodes 12 bits a time. The decoder
+//! looks the next 12 bits up in `FAST_TABLE`, which maps directly to either
+//! one or two symbols to decode. Since ASCII letters and digits have 5-7 bit
+//! codes, one lookup usually decodes two symbols at once.
+//!
+//! Two situations fall off this fast path:
+//!
+//! - Codes longer than 12 bits: control characters and bytes >= 0x80
+//! - The end of the input, when fewer than 12 bits remain.
+//!
+//! These are decoded by walking the generated `DECODE_TABLE` one input byte at a time.
+
+use crate::hpack::huffman::table::{DECODE_TABLE, ENCODE_TABLE};
+use crate::hpack::DecoderError;
+
+use bytes::BytesMut;
+
+// DECODE_TABLE (in the generated `table.rs`) is a series of 256-entry
+// tables, walked one input byte at a time. A leaf entry (BRANCH bit clear)
+// holds a decoded symbol and the number of bits its code used. A branch
+// entry (BRANCH bit set) holds the index of the table for the next byte.
+// No valid code leads back to table 0, so a branch to 0 means the input is
+// not a valid code.
+const BRANCH: u16 = 0x8000;
+const TABLE_INDEX_MASK: u16 = 0x7f00;
+const TABLE_WIDTH: usize = 256;
+
+// Maps each possible 12-bit chunk of input to the symbol(s) it starts
+// with. Entry layout (u32):
+//
+//   bits  0..8   first decoded byte
+//   bits  8..16  second decoded byte (if any)
+//   bits 16..24  number of symbols decoded: 1, 2, or 0, where 0 means the
+//                code is longer than 12 bits and the slow path must run
+//   bits 24..32  how many of the 12 bits the decoded symbols used
+const FAST_BITS: usize = 12;
+const FAST_DECODE_TABLE: [u32; 1 << FAST_BITS] = build_fast_table();
+
+const fn build_fast_table() -> [u32; 1 << FAST_BITS] {
+    let mut table = [0; 1 << FAST_BITS];
+
+    // First fill in every index that starts with one whole code
+    let mut a = 0;
+    while a < 256 {
+        let (len1, code1) = ENCODE_TABLE[a];
+        if len1 <= FAST_BITS {
+            let rem = FAST_BITS - len1;
+            let base = (code1 as usize) << rem;
+            let single = (1 << 16) | ((len1 as u32) << 24) | a as u32;
+            let mut i = 0;
+            while i < (1 << rem) {
+                table[base + i] = single;
+                i += 1;
+            }
+        }
+        a += 1;
+    }
+
+    // Overwrite the indices where a second whole code fit right after the first
+    let mut a = 0;
+    while a < 256 {
+        let (len1, code1) = ENCODE_TABLE[a];
+        // A second code needs at least 5 more bits (the shortest code)
+        if len1 + 5 <= FAST_BITS {
+            let rem = FAST_BITS - len1;
+            let mut b = 0;
+            while b < 256 {
+                let (len2, code2) = ENCODE_TABLE[b];
+                if len2 <= rem {
+                    let rem2 = rem - len2;
+                    let base = ((code1 as usize) << rem) | ((code2 as usize) << rem2);
+                    let pair =
+                        (2 << 16) | (((len1 + len2) as u32) << 24) | ((b as u32) << 8) | a as u32;
+                    let mut i = 0;
+                    while i < (1 << rem2) {
+                        table[base + i] = pair;
+                        i += 1;
+                    }
+                }
+                b += 1;
+            }
+        }
+        a += 1;
+    }
+
+    table
+}
+
+// Decodes one code of any length by walking DECODE_TABLE one input byte at
+// a time, and writes the symbol to `dst[*o]`. Used for codes longer than
+// FAST_BITS bits and for the tail of the input.
+//
+// Inlining avoids a 35% performance regression on ASCII benchmarks.
+#[inline(always)]
+fn decode_code_slow(
+    acc: &mut u64,
+    bits: &mut usize,
+    dst: &mut [u8],
+    o: &mut usize,
+) -> Result<(), DecoderError> {
+    let mut table = 0;
+    loop {
+        let e = DECODE_TABLE[table * TABLE_WIDTH + (*acc >> 56) as usize];
+        if e & BRANCH == 0 {
+            let used = (e >> 8) as usize;
+            if used > *bits {
+                return Err(DecoderError::InvalidHuffmanCode);
+            }
+            dst[*o] = e as u8;
+            *o += 1;
+            *acc <<= used;
+            *bits -= used;
+            return Ok(());
+        }
+        if *bits < 8 {
+            return Err(DecoderError::InvalidHuffmanCode);
+        }
+        table = ((e & TABLE_INDEX_MASK) >> 8) as usize;
+        if table == 0 {
+            return Err(DecoderError::InvalidHuffmanCode);
+        }
+        *acc <<= 8;
+        *bits -= 8;
+    }
+}
+
+// Decodes a Huffman encoded string into the provided buffer.
+pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> {
+    let len = src.len();
+    let base_len = buf.len();
+
+    // Reserve the worst case output size. Every code is at least 5 bits,
+    // so `len` input bytes can't decode to more than `len * 8 / 5` output
+    // bytes. One more byte covers the fast path always writing two bytes
+    // even when it decoded only one symbol.
+    buf.resize(base_len + len * 8 / 5 + 1, 0);
+    let dst = &mut buf[base_len..];
+    let mut o = 0;
+
+    let mut acc: u64 = 0;
+    let mut bits: usize = 0;
+    let mut pos: usize = 0;
+
+    'outer: loop {
+        // Fill the bit buffer. While 8 or more input bytes remain, load
+        // the next 8 in one go and count as many whole bytes as fit under
+        // the bits already in the buffer (bringing it to 56-63 bits). The
+        // bytes that didn't fit still land in the low end of `acc`; the
+        // next refill just ORs the same values over them, so no harm done.
+        if pos + 8 <= len {
+            let word = u64::from_be_bytes(src[pos..pos + 8].try_into().unwrap());
+            acc |= word >> bits;
+            pos += (63 - bits) >> 3; // bytes now accounted for in `bits`
+            bits |= 56; // equals bits + 8 * (bytes added)
+        } else {
+            while bits <= 56 && pos < len {
+                acc |= (src[pos] as u64) << (56 - bits);
+                pos += 1;
+                bits += 8;
+            }
+        }
+
+        while bits >= FAST_BITS {
+            let entry = FAST_DECODE_TABLE[(acc >> (64 - FAST_BITS)) as usize];
+            let count = (entry >> 16) & 0xff;
+            if count == 0 {
+                // The next code is longer than 12 bits. Refill first if it
+                // might not be in the buffer yet (the longest code is 30
+                // bits), then decode it by walking DECODE_TABLE.
+                if bits < 30 && pos < len {
+                    continue 'outer;
+                }
+                decode_code_slow(&mut acc, &mut bits, dst, &mut o)?;
+                continue;
+            }
+            let consumed = (entry >> 24) as usize;
+            dst[o] = entry as u8;
+            dst[o + 1] = (entry >> 8) as u8;
+            o += count as usize;
+            acc <<= consumed;
+            bits -= consumed;
+        }
+
+        if pos >= len {
+            break;
+        }
+    }
+
+    // Tail: the input is exhausted and fewer than 12 bits remain.
+    while bits > 0 {
+        // The encoder pads the last byte with up to 7 one-bits, which are
+        // valid only between symbols. Anything else must decode.
+        if bits < 8 && (acc >> (64 - bits)) == (1 << bits) - 1 {
+            break;
+        }
+        decode_code_slow(&mut acc, &mut bits, dst, &mut o)?;
+    }
+
+    buf.truncate(base_len + o);
+    Ok(buf.split())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use bytes::BufMut;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    fn decode(src: &[u8]) -> Result<BytesMut, DecoderError> {
+        let mut buf = BytesMut::new();
+        super::decode(src, &mut buf)
+    }
+
+    // The simplest decoder we can write, used to double-check the real
+    // one: turn the input into a literal string of '0'/'1' characters and
+    // repeatedly strip off the first code that matches. No code is a
+    // prefix of another, so at most one can match. EOS (index 256) is left
+    // out on purpose: encoded EOS is an error per RFC 7541 §5.2.
+    fn reference_decode(src: &[u8]) -> Result<BytesMut, DecoderError> {
+        // Each symbol's code as a string of '0' and '1', e.g. "11111000".
+        let codes: Vec<String> = ENCODE_TABLE[..256]
+            .iter()
+            .map(|&(len, code)| format!("{code:0len$b}"))
+            .collect();
+        let bits: String = src.iter().map(|byte| format!("{byte:08b}")).collect();
+
+        let mut decoded = BytesMut::new();
+        let mut remaining_bits: &str = &bits;
+        while let Some(sym) = (0..256).find(|&sym| remaining_bits.starts_with(&codes[sym])) {
+            decoded.put_u8(sym as u8);
+            remaining_bits = &remaining_bits[codes[sym].len()..];
+        }
+        // We expect anything that cannot be matched to be padding. Padding is
+        // fewer than 8 bits, and all ones.
+        if remaining_bits.len() >= 8 || remaining_bits.chars().any(|bit| bit == '0') {
+            return Err(DecoderError::InvalidHuffmanCode);
+        }
+        Ok(decoded)
+    }
+
+    #[test]
+    fn decode_single_byte() {
+        assert_eq!("o", decode(&[0b00111111]).unwrap());
+        assert_eq!("0", decode(&[7]).unwrap());
+        assert_eq!("A", decode(&[(0x21 << 2) + 3]).unwrap());
+    }
+
+    #[test]
+    fn single_char_multi_byte() {
+        assert_eq!("#", decode(&[255, 160 + 15]).unwrap());
+        assert_eq!("$", decode(&[255, 200 + 7]).unwrap());
+        assert_eq!("\x0a", decode(&[255, 255, 255, 240 + 3]).unwrap());
+    }
+
+    #[test]
+    fn multi_char() {
+        assert_eq!("!0", decode(&[254, 1]).unwrap());
+        assert_eq!(" !", decode(&[0b01010011, 0b11111000]).unwrap());
+    }
+
+    // Random (mostly invalid) byte strings must produce identical results to reference impl
+    #[test]
+    fn matches_reference_on_arbitrary_bytes() {
+        let mut rng = StdRng::seed_from_u64(0xdeadbeefcafe);
+
+        for _ in 0..10_000 {
+            let len = rng.gen_range(0..40);
+            let src: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
+            assert_eq!(reference_decode(&src), decode(&src), "src={:?}", src);
+        }
+
+        // Bias toward high bytes to exercise long codes and EOS prefixes.
+        for _ in 0..10_000 {
+            let len = rng.gen_range(0..40);
+            let src: Vec<u8> = (0..len).map(|_| rng.gen::<u8>() | 0xe0).collect();
+            assert_eq!(reference_decode(&src), decode(&src), "src={:?}", src);
+        }
+    }
+
+    #[test]
+    fn rejects_eos_and_invalid_padding() {
+        assert_eq!(decode(&[0xff]), Err(DecoderError::InvalidHuffmanCode));
+        assert_eq!(
+            decode(&[0xff, 0xff, 0xff, 0xff]),
+            Err(DecoderError::InvalidHuffmanCode)
+        );
+        assert_eq!(decode(&[0]), Err(DecoderError::InvalidHuffmanCode));
+    }
+}
+
+/*
+// uncomment to run benchmarks
+#[cfg(test)]
+mod bench {
+    extern crate test;
+
+    use self::test::{black_box, Bencher};
+    use super::*;
+
+    use crate::hpack::huffman::encode;
+
+    fn decode_input(b: &mut Bencher, input: &[u8]) {
+        let mut encoded = BytesMut::new();
+        encode(input, &mut encoded);
+
+        let mut scratch = BytesMut::with_capacity(input.len() * 2);
+        b.bytes = encoded.len() as u64;
+        b.iter(|| {
+            let decoded = decode(black_box(encoded.as_ref()), &mut scratch).unwrap();
+            black_box(decoded);
+        });
+    }
+
+    #[bench]
+    fn decode_short_ascii(b: &mut Bencher) {
+        decode_input(b, b"www.example.com");
+    }
+
+    #[bench]
+    fn decode_header_value(b: &mut Bencher) {
+        decode_input(
+            b,
+            b"text/html,application/xhtml+xml,application/xml;q=0.9;q=0.8",
+        );
+    }
+
+    #[bench]
+    fn decode_long_ascii(b: &mut Bencher) {
+        decode_input(
+            b,
+            b"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:16.0) Gecko/20100101 Firefox/16.0",
+        );
+    }
+
+    #[bench]
+    fn decode_all_octets(b: &mut Bencher) {
+        let input: Vec<_> = (0..=u8::MAX).collect();
+        decode_input(b, &input);
+    }
+}
+*/

--- a/src/hpack/huffman/encode.rs
+++ b/src/hpack/huffman/encode.rs
@@ -1,0 +1,49 @@
+use crate::hpack::huffman::table::ENCODE_TABLE;
+
+use bytes::{BufMut, BytesMut};
+
+pub fn encode(src: &[u8], dst: &mut BytesMut) {
+    let mut bits: u64 = 0;
+    let mut bits_left = 40;
+
+    for &b in src {
+        let (nbits, code) = ENCODE_TABLE[b as usize];
+
+        bits |= code << (bits_left - nbits);
+        bits_left -= nbits;
+
+        while bits_left <= 32 {
+            dst.put_u8((bits >> 32) as u8);
+
+            bits <<= 8;
+            bits_left += 8;
+        }
+    }
+
+    if bits_left != 40 {
+        // This writes the EOS token
+        bits |= (1 << bits_left) - 1;
+        dst.put_u8((bits >> 32) as u8);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn encode_single_byte() {
+        let mut dst = BytesMut::with_capacity(1);
+
+        encode(b"o", &mut dst);
+        assert_eq!(&dst[..], &[0b00111111]);
+
+        dst.clear();
+        encode(b"0", &mut dst);
+        assert_eq!(&dst[..], &[7]);
+
+        dst.clear();
+        encode(b"A", &mut dst);
+        assert_eq!(&dst[..], &[(0x21 << 2) + 3]);
+    }
+}

--- a/src/hpack/huffman/mod.rs
+++ b/src/hpack/huffman/mod.rs
@@ -1,354 +1,21 @@
+mod decode;
+mod encode;
 mod table;
 
-use self::table::{DECODE_TABLE, ENCODE_TABLE};
-use crate::hpack::DecoderError;
-
-use bytes::{BufMut, BytesMut};
-
-// Constants for the byte-wide fallback tables in the generated `table.rs`.
-const BRANCH: u16 = 0x8000;
-const TABLE_INDEX_MASK: u16 = 0x7f00;
-const TABLE_WIDTH: usize = 256;
-
-// Width of the primary lookup table index. The most common HPACK codes are
-// five to seven bits long, so twelve bits usually cover two whole symbols.
-const FAST_BITS: usize = 12;
-
-// Primary lookup table. Entry layout (u32):
-//
-//   bits  0..8   first decoded byte
-//   bits  8..16  second decoded byte (if any)
-//   bits 16..24  symbol count: 0 = code longer than FAST_BITS bits, 1, or 2
-//   bits 24..32  total bits consumed by the emitted symbols
-const FAST_TABLE: [u32; 1 << FAST_BITS] = build_fast_table();
-
-const fn build_fast_table() -> [u32; 1 << FAST_BITS] {
-    let mut table = [0u32; 1 << FAST_BITS];
-
-    // Huffman codes are prefix free, so a code of length `len` owns every
-    // index that starts with it: a range of 1 << (FAST_BITS - len) entries.
-    // Fill single-symbol entries first, then overwrite with two-symbol
-    // entries wherever a second whole code fits in the remaining bits.
-    //
-    // This fills ranges per code instead of searching codes per index,
-    // keeping the work well within the const-eval step limit of older
-    // compilers.
-    let mut a = 0usize;
-    while a < 256 {
-        let (len1, code1) = ENCODE_TABLE[a];
-        if len1 <= FAST_BITS {
-            let rem = FAST_BITS - len1;
-            let base = (code1 as usize) << rem;
-            let single = (1u32 << 16) | ((len1 as u32) << 24) | a as u32;
-            let mut i = 0usize;
-            while i < (1usize << rem) {
-                table[base + i] = single;
-                i += 1;
-            }
-        }
-        a += 1;
-    }
-
-    let mut a = 0usize;
-    while a < 256 {
-        let (len1, code1) = ENCODE_TABLE[a];
-        // The shortest code is five bits, so a second symbol can only
-        // follow codes short enough to leave room for one.
-        if len1 + 5 <= FAST_BITS {
-            let rem = FAST_BITS - len1;
-            let mut b = 0usize;
-            while b < 256 {
-                let (len2, code2) = ENCODE_TABLE[b];
-                if len2 <= rem {
-                    let rem2 = rem - len2;
-                    let base = ((code1 as usize) << rem) | ((code2 as usize) << rem2);
-                    let pair = (2u32 << 16)
-                        | (((len1 + len2) as u32) << 24)
-                        | ((b as u32) << 8)
-                        | a as u32;
-                    let mut i = 0usize;
-                    while i < (1usize << rem2) {
-                        table[base + i] = pair;
-                        i += 1;
-                    }
-                }
-                b += 1;
-            }
-        }
-        a += 1;
-    }
-
-    table
-}
-
-// Decodes a Huffman encoded string into the provided buffer.
-//
-// The decoder keeps a 64-bit buffer with the next unconsumed bit at bit 63
-// of `acc`. The top `bits` bits are accounted stream bits; below them the
-// buffer may hold valid lookahead bits from a previous wide refill (never
-// anything else), which makes the `acc |= word >> bits` refill idempotent.
-//
-// Each iteration of the hot loop decodes up to two symbols from a single
-// FAST_TABLE lookup. Codes longer than FAST_BITS bits are rare (they encode
-// control characters and non-ASCII octets) and complete by walking the
-// byte-wide tables in DECODE_TABLE, exactly like the previous decoder.
-pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> {
-    let len = src.len();
-    let base_len = buf.len();
-
-    // The shortest code is five bits, so the decoded output is at most
-    // len * 8 / 5 bytes. The hot loop below speculatively writes two bytes
-    // per emitted symbol pair, touching at most one byte past the decoded
-    // length; floor(len * 8 / 5) + 1 <= len * 2 holds for len >= 1. Zero-fill
-    // up to the worst case now so the output can be written through a plain
-    // slice, then truncate to the decoded length at the end.
-    buf.resize(base_len + (len << 1), 0);
-    let dst = &mut buf[base_len..];
-    let mut o = 0usize;
-
-    let mut acc: u64 = 0;
-    let mut bits: usize = 0;
-    let mut pos: usize = 0;
-
-    'outer: loop {
-        // Refill the bit buffer, seven bytes at a time when possible.
-        if pos + 8 <= len {
-            // The bounds check is elided: the compiler proves it from the
-            // `pos + 8 <= len` branch above.
-            let word = u64::from_be_bytes(src[pos..pos + 8].try_into().unwrap());
-            acc |= word >> bits;
-            pos += (63 - bits) >> 3;
-            bits |= 56;
-        } else {
-            while bits <= 56 && pos < len {
-                acc |= (src[pos] as u64) << (56 - bits);
-                pos += 1;
-                bits += 8;
-            }
-        }
-
-        while bits >= FAST_BITS {
-            let entry = FAST_TABLE[(acc >> (64 - FAST_BITS)) as usize];
-            let count = (entry >> 16) & 0xff;
-
-            if count == 0 {
-                // Code longer than FAST_BITS bits; the longest code is 30
-                // bits, so make sure they are buffered before walking.
-                if bits < 30 && pos < len {
-                    continue 'outer;
-                }
-                let mut table = 0usize;
-                loop {
-                    let e = DECODE_TABLE[table * TABLE_WIDTH + (acc >> 56) as usize];
-                    if e & BRANCH == 0 {
-                        let used = (e >> 8) as usize;
-                        if used > bits {
-                            return Err(DecoderError::InvalidHuffmanCode);
-                        }
-                        dst[o] = e as u8;
-                        o += 1;
-                        acc <<= used;
-                        bits -= used;
-                        break;
-                    }
-                    if bits < 8 {
-                        return Err(DecoderError::InvalidHuffmanCode);
-                    }
-                    table = ((e & TABLE_INDEX_MASK) >> 8) as usize;
-                    if table == 0 {
-                        return Err(DecoderError::InvalidHuffmanCode);
-                    }
-                    acc <<= 8;
-                    bits -= 8;
-                }
-                continue;
-            }
-
-            let consumed = (entry >> 24) as usize;
-            dst[o] = entry as u8;
-            dst[o + 1] = (entry >> 8) as u8;
-            o += count as usize;
-            acc <<= consumed;
-            bits -= consumed;
-        }
-
-        if pos >= len {
-            break;
-        }
-    }
-
-    // Tail: fewer than FAST_BITS bits remain and the input is exhausted.
-    // Note that the unaccounted low bits of `acc` may hold lookahead rather
-    // than zeroes. This is harmless: a leaf is only trusted when its code
-    // fits in the remaining accounted bits, and byte-wide tables replicate
-    // such codes across every suffix, so the lookahead cannot change which
-    // symbol is found.
-    while bits > 0 {
-        // A prefix of the EOS code (all ones, at most 7 bits) is valid
-        // padding at a symbol boundary.
-        if bits < 8 && (acc >> (64 - bits)) == (1u64 << bits) - 1 {
-            break;
-        }
-
-        let mut table = 0usize;
-        loop {
-            let e = DECODE_TABLE[table * TABLE_WIDTH + (acc >> 56) as usize];
-            if e & BRANCH == 0 {
-                let used = (e >> 8) as usize;
-                if used > bits {
-                    return Err(DecoderError::InvalidHuffmanCode);
-                }
-                dst[o] = e as u8;
-                o += 1;
-                acc <<= used;
-                bits -= used;
-                break;
-            }
-            if bits < 8 {
-                return Err(DecoderError::InvalidHuffmanCode);
-            }
-            table = ((e & TABLE_INDEX_MASK) >> 8) as usize;
-            if table == 0 {
-                return Err(DecoderError::InvalidHuffmanCode);
-            }
-            acc <<= 8;
-            bits -= 8;
-        }
-    }
-
-    buf.truncate(base_len + o);
-    Ok(buf.split())
-}
-
-pub fn encode(src: &[u8], dst: &mut BytesMut) {
-    let mut bits: u64 = 0;
-    let mut bits_left = 40;
-
-    for &b in src {
-        let (nbits, code) = ENCODE_TABLE[b as usize];
-
-        bits |= code << (bits_left - nbits);
-        bits_left -= nbits;
-
-        while bits_left <= 32 {
-            dst.put_u8((bits >> 32) as u8);
-
-            bits <<= 8;
-            bits_left += 8;
-        }
-    }
-
-    if bits_left != 40 {
-        // This writes the EOS token
-        bits |= (1 << bits_left) - 1;
-        dst.put_u8((bits >> 32) as u8);
-    }
-}
+pub use self::decode::decode;
+pub use self::encode::encode;
 
 #[cfg(test)]
 mod test {
     use super::*;
 
-    fn decode(src: &[u8]) -> Result<BytesMut, DecoderError> {
+    use bytes::BytesMut;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    fn decode(src: &[u8]) -> BytesMut {
         let mut buf = BytesMut::new();
-        super::decode(src, &mut buf)
-    }
-
-    // The byte-at-a-time decoder this implementation replaced, kept as a
-    // reference for differential testing.
-    fn reference_decode(src: &[u8]) -> Result<BytesMut, DecoderError> {
-        let mut buf = BytesMut::with_capacity(src.len() << 1);
-
-        let mut table = 0;
-        let mut acc = 0u32;
-        let mut bits = 0;
-
-        for &byte in src {
-            acc = (acc << 8) | byte as u32;
-            bits += 8;
-
-            while bits >= 8 {
-                let index = (acc >> (bits - 8)) as u8 as usize;
-                let entry = DECODE_TABLE[table * TABLE_WIDTH + index];
-
-                if entry & BRANCH == 0 {
-                    buf.put_u8(entry as u8);
-                    table = 0;
-                    bits -= (entry >> 8) as usize;
-                } else {
-                    table = ((entry & TABLE_INDEX_MASK) >> 8) as usize;
-                    if table == 0 {
-                        return Err(DecoderError::InvalidHuffmanCode);
-                    }
-                    bits -= 8;
-                }
-            }
-        }
-
-        while bits > 0 {
-            debug_assert!(bits < 8);
-            let padding = (1u32 << bits) - 1;
-            if table == 0 && acc & padding == padding {
-                break;
-            }
-
-            let index = (acc << (8 - bits)) as u8 as usize;
-            let entry = DECODE_TABLE[table * TABLE_WIDTH + index];
-            if entry & BRANCH != 0 {
-                return Err(DecoderError::InvalidHuffmanCode);
-            }
-
-            let used = (entry >> 8) as usize;
-            if used > bits {
-                return Err(DecoderError::InvalidHuffmanCode);
-            }
-
-            buf.put_u8(entry as u8);
-            table = 0;
-            bits -= used;
-        }
-
-        if table == 0 {
-            Ok(buf.split())
-        } else {
-            Err(DecoderError::InvalidHuffmanCode)
-        }
-    }
-
-    #[test]
-    fn decode_single_byte() {
-        assert_eq!("o", decode(&[0b00111111]).unwrap());
-        assert_eq!("0", decode(&[7]).unwrap());
-        assert_eq!("A", decode(&[(0x21 << 2) + 3]).unwrap());
-    }
-
-    #[test]
-    fn single_char_multi_byte() {
-        assert_eq!("#", decode(&[255, 160 + 15]).unwrap());
-        assert_eq!("$", decode(&[255, 200 + 7]).unwrap());
-        assert_eq!("\x0a", decode(&[255, 255, 255, 240 + 3]).unwrap());
-    }
-
-    #[test]
-    fn multi_char() {
-        assert_eq!("!0", decode(&[254, 1]).unwrap());
-        assert_eq!(" !", decode(&[0b01010011, 0b11111000]).unwrap());
-    }
-
-    #[test]
-    fn encode_single_byte() {
-        let mut dst = BytesMut::with_capacity(1);
-
-        encode(b"o", &mut dst);
-        assert_eq!(&dst[..], &[0b00111111]);
-
-        dst.clear();
-        encode(b"0", &mut dst);
-        assert_eq!(&dst[..], &[7]);
-
-        dst.clear();
-        encode(b"A", &mut dst);
-        assert_eq!(&dst[..], &[(0x21 << 2) + 3]);
+        super::decode(src, &mut buf).unwrap()
     }
 
     #[test]
@@ -382,7 +49,7 @@ mod test {
 
             encode(s.as_bytes(), &mut dst);
 
-            let decoded = decode(&dst).unwrap();
+            let decoded = decode(&dst);
 
             assert_eq!(&decoded[..], s.as_bytes());
         }
@@ -397,7 +64,7 @@ mod test {
 
             encode(s, &mut dst);
 
-            let decoded = decode(&dst).unwrap();
+            let decoded = decode(&dst);
 
             assert_eq!(&decoded[..], &s[..]);
         }
@@ -408,112 +75,32 @@ mod test {
         let src: Vec<_> = (0..=u8::MAX).collect();
         let mut encoded = BytesMut::new();
         encode(&src, &mut encoded);
-        assert_eq!(decode(&encoded).unwrap(), src);
+        assert_eq!(decode(&encoded), src);
     }
 
+    // '0' has a shortest possible code (5 bits), so all-'0' strings expand
+    // the most when decoding, hitting the decoder's output reservation
+    // exactly.
     #[test]
-    fn matches_reference_on_valid_input() {
-        // Round-trip strings of random bytes of every length.
-        let mut rng: u64 = 0x123456789abcdef;
-        let mut next = move || {
-            rng = rng
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            (rng >> 33) as u8
-        };
-
-        for len in 0..600 {
-            let src: Vec<u8> = (0..len).map(|_| next()).collect();
+    fn encode_decode_max_expansion() {
+        for len in 0..100 {
+            let src = vec![b'0'; len];
             let mut encoded = BytesMut::new();
             encode(&src, &mut encoded);
-            assert_eq!(reference_decode(&encoded), decode(&encoded), "len={}", len);
-            assert_eq!(&decode(&encoded).unwrap()[..], &src[..], "len={}", len);
+            assert_eq!(&decode(&encoded)[..], &src[..], "len={}", len);
         }
     }
 
+    // Round-trip strings of random bytes of every length
     #[test]
-    fn matches_reference_on_arbitrary_bytes() {
-        // Random (mostly invalid) byte strings must produce identical
-        // results, including identical errors.
-        let mut rng: u64 = 0xdeadbeefcafe;
-        let mut next = move || {
-            rng = rng
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            (rng >> 33) as u8
-        };
+    fn encode_decode_random() {
+        let mut rng = StdRng::seed_from_u64(0x123456789abcdef);
 
-        for _ in 0..20_000 {
-            let len = (next() as usize) % 40;
-            let src: Vec<u8> = (0..len).map(|_| next()).collect();
-            assert_eq!(reference_decode(&src), decode(&src), "src={:?}", src);
+        for len in 0..600 {
+            let src: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
+            let mut encoded = BytesMut::new();
+            encode(&src, &mut encoded);
+            assert_eq!(&decode(&encoded)[..], &src[..], "len={}", len);
         }
-
-        // Bias toward high bytes to exercise long codes and EOS prefixes.
-        for _ in 0..20_000 {
-            let len = (next() as usize) % 40;
-            let src: Vec<u8> = (0..len).map(|_| next() | 0xe0).collect();
-            assert_eq!(reference_decode(&src), decode(&src), "src={:?}", src);
-        }
-    }
-
-    #[test]
-    fn rejects_eos_and_invalid_padding() {
-        assert_eq!(decode(&[0xff]), Err(DecoderError::InvalidHuffmanCode));
-        assert_eq!(
-            decode(&[0xff, 0xff, 0xff, 0xff]),
-            Err(DecoderError::InvalidHuffmanCode)
-        );
-        assert_eq!(decode(&[0]), Err(DecoderError::InvalidHuffmanCode));
     }
 }
-
-/*
-// uncomment to run benchmarks
-#[cfg(test)]
-mod bench {
-    extern crate test;
-
-    use self::test::{black_box, Bencher};
-    use super::*;
-
-    fn decode_input(b: &mut Bencher, input: &[u8]) {
-        let mut encoded = BytesMut::new();
-        encode(input, &mut encoded);
-
-        let mut scratch = BytesMut::with_capacity(input.len() * 2);
-        b.bytes = encoded.len() as u64;
-        b.iter(|| {
-            let decoded = decode(black_box(encoded.as_ref()), &mut scratch).unwrap();
-            black_box(decoded);
-        });
-    }
-
-    #[bench]
-    fn decode_short_ascii(b: &mut Bencher) {
-        decode_input(b, b"www.example.com");
-    }
-
-    #[bench]
-    fn decode_header_value(b: &mut Bencher) {
-        decode_input(
-            b,
-            b"text/html,application/xhtml+xml,application/xml;q=0.9;q=0.8",
-        );
-    }
-
-    #[bench]
-    fn decode_long_ascii(b: &mut Bencher) {
-        decode_input(
-            b,
-            b"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:16.0) Gecko/20100101 Firefox/16.0",
-        );
-    }
-
-    #[bench]
-    fn decode_all_octets(b: &mut Bencher) {
-        let input: Vec<_> = (0..=u8::MAX).collect();
-        decode_input(b, &input);
-    }
-}
-*/

--- a/src/hpack/huffman/mod.rs
+++ b/src/hpack/huffman/mod.rs
@@ -5,70 +5,246 @@ use crate::hpack::DecoderError;
 
 use bytes::{BufMut, BytesMut};
 
+// Constants for the byte-wide fallback tables in the generated `table.rs`.
 const BRANCH: u16 = 0x8000;
 const TABLE_INDEX_MASK: u16 = 0x7f00;
 const TABLE_WIDTH: usize = 256;
 
+// Width of the primary lookup table index. The most common HPACK codes are
+// five to seven bits long, so twelve bits usually cover two whole symbols.
+const FAST_BITS: usize = 12;
+
+// Primary lookup table. Entry layout (u32):
+//
+//   bits  0..8   first decoded byte
+//   bits  8..16  second decoded byte (if any)
+//   bits 16..24  symbol count: 0 = code longer than FAST_BITS bits, 1, or 2
+//   bits 24..32  total bits consumed by the emitted symbols
+const FAST_TABLE: [u32; 1 << FAST_BITS] = build_fast_table();
+
+const fn build_fast_table() -> [u32; 1 << FAST_BITS] {
+    let mut table = [0u32; 1 << FAST_BITS];
+
+    // Huffman codes are prefix free, so a code of length `len` owns every
+    // index that starts with it: a range of 1 << (FAST_BITS - len) entries.
+    // Fill single-symbol entries first, then overwrite with two-symbol
+    // entries wherever a second whole code fits in the remaining bits.
+    //
+    // This fills ranges per code instead of searching codes per index,
+    // keeping the work well within the const-eval step limit of older
+    // compilers.
+    let mut a = 0usize;
+    while a < 256 {
+        let (len1, code1) = ENCODE_TABLE[a];
+        if len1 <= FAST_BITS {
+            let rem = FAST_BITS - len1;
+            let base = (code1 as usize) << rem;
+            let single = (1u32 << 16) | ((len1 as u32) << 24) | a as u32;
+            let mut i = 0usize;
+            while i < (1usize << rem) {
+                table[base + i] = single;
+                i += 1;
+            }
+        }
+        a += 1;
+    }
+
+    let mut a = 0usize;
+    while a < 256 {
+        let (len1, code1) = ENCODE_TABLE[a];
+        // The shortest code is five bits, so a second symbol can only
+        // follow codes short enough to leave room for one.
+        if len1 + 5 <= FAST_BITS {
+            let rem = FAST_BITS - len1;
+            let mut b = 0usize;
+            while b < 256 {
+                let (len2, code2) = ENCODE_TABLE[b];
+                if len2 <= rem {
+                    let rem2 = rem - len2;
+                    let base = ((code1 as usize) << rem) | ((code2 as usize) << rem2);
+                    let pair = (2u32 << 16)
+                        | (((len1 + len2) as u32) << 24)
+                        | ((b as u32) << 8)
+                        | a as u32;
+                    let mut i = 0usize;
+                    while i < (1usize << rem2) {
+                        table[base + i] = pair;
+                        i += 1;
+                    }
+                }
+                b += 1;
+            }
+        }
+        a += 1;
+    }
+
+    table
+}
+
+// Decodes a Huffman encoded string into the provided buffer.
+//
+// The decoder keeps a 64-bit buffer with the next unconsumed bit at bit 63
+// of `acc`. The top `bits` bits are accounted stream bits; below them the
+// buffer may hold valid lookahead bits from a previous wide refill (never
+// anything else), which makes the `acc |= word >> bits` refill idempotent.
+//
+// Each iteration of the hot loop decodes up to two symbols from a single
+// FAST_TABLE lookup. Codes longer than FAST_BITS bits are rare (they encode
+// control characters and non-ASCII octets) and complete by walking the
+// byte-wide tables in DECODE_TABLE, exactly like the previous decoder.
 pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> {
-    // Max compression ratio is >= 0.5
+    if src.is_empty() {
+        return Ok(buf.split());
+    }
+
+    // The shortest code is five bits, so the decoded output is at most
+    // src.len() * 8 / 5 bytes. The hot loop below speculatively writes two
+    // bytes per emitted symbol pair, touching at most one byte past the
+    // decoded length. floor(len * 8 / 5) + 1 <= len * 2 holds for len >= 1,
+    // so reserving twice the input length covers both.
     buf.reserve(src.len() << 1);
 
-    let mut table = 0;
-    let mut acc = 0u32;
-    let mut bits = 0;
+    let len = src.len();
+    let base_len = buf.len();
 
-    for &byte in src {
-        acc = (acc << 8) | byte as u32;
-        bits += 8;
+    let mut acc: u64 = 0;
+    let mut bits: usize = 0;
+    let mut pos: usize = 0;
 
-        while bits >= 8 {
-            let index = (acc >> (bits - 8)) as u8 as usize;
-            let entry = DECODE_TABLE[table * TABLE_WIDTH + index];
+    // The spare capacity reserved above, as a raw pointer. `chunk_mut` only
+    // reallocates when the buffer is full, which the reservation of at least
+    // two bytes for a non-empty input rules out.
+    let out_start = buf.chunk_mut().as_mut_ptr();
+    let mut out = out_start;
 
-            if entry & BRANCH == 0 {
-                buf.put_u8(entry as u8);
-                table = 0;
-                bits -= (entry >> 8) as usize;
-            } else {
-                table = ((entry & TABLE_INDEX_MASK) >> 8) as usize;
-                if table == 0 {
-                    return Err(DecoderError::InvalidHuffmanCode);
-                }
-                bits -= 8;
+    'outer: loop {
+        // Refill the bit buffer, seven bytes at a time when possible.
+        if pos + 8 <= len {
+            // SAFETY: pos + 8 <= len, so the 8-byte read is in bounds.
+            let word = u64::from_be_bytes(unsafe {
+                src.as_ptr().add(pos).cast::<[u8; 8]>().read_unaligned()
+            });
+            acc |= word >> bits;
+            pos += (63 - bits) >> 3;
+            bits |= 56;
+        } else {
+            while bits <= 56 && pos < len {
+                acc |= (src[pos] as u64) << (56 - bits);
+                pos += 1;
+                bits += 8;
             }
+        }
+
+        while bits >= FAST_BITS {
+            let entry = FAST_TABLE[(acc >> (64 - FAST_BITS)) as usize];
+            let count = (entry >> 16) & 0xff;
+
+            if count == 0 {
+                // Code longer than FAST_BITS bits; the longest code is 30
+                // bits, so make sure they are buffered before walking.
+                if bits < 30 && pos < len {
+                    continue 'outer;
+                }
+                let mut table = 0usize;
+                loop {
+                    let e = DECODE_TABLE[table * TABLE_WIDTH + (acc >> 56) as usize];
+                    if e & BRANCH == 0 {
+                        let used = (e >> 8) as usize;
+                        if used > bits {
+                            return Err(DecoderError::InvalidHuffmanCode);
+                        }
+                        // SAFETY: the store is within the capacity reserved
+                        // above; see the analysis at the top of the function.
+                        unsafe {
+                            out.write(e as u8);
+                            out = out.add(1);
+                        }
+                        acc <<= used;
+                        bits -= used;
+                        break;
+                    }
+                    if bits < 8 {
+                        return Err(DecoderError::InvalidHuffmanCode);
+                    }
+                    table = ((e & TABLE_INDEX_MASK) >> 8) as usize;
+                    if table == 0 {
+                        return Err(DecoderError::InvalidHuffmanCode);
+                    }
+                    acc <<= 8;
+                    bits -= 8;
+                }
+                continue;
+            }
+
+            let consumed = (entry >> 24) as usize;
+            // SAFETY: speculative 2-byte store within the capacity reserved
+            // above, which includes one byte of slack past the maximum
+            // decoded length; see the analysis at the top of the function.
+            unsafe {
+                out.write(entry as u8);
+                out.add(1).write((entry >> 8) as u8);
+                out = out.add(count as usize);
+            }
+            acc <<= consumed;
+            bits -= consumed;
+        }
+
+        if pos >= len {
+            break;
         }
     }
 
-    // Fewer than eight bits remain. A prefix of the EOS code (all ones) is
-    // valid padding only when the previous symbol has completed.
+    // Tail: fewer than FAST_BITS bits remain and the input is exhausted.
+    // Note that the unaccounted low bits of `acc` may hold lookahead rather
+    // than zeroes. This is harmless: a leaf is only trusted when its code
+    // fits in the remaining accounted bits, and byte-wide tables replicate
+    // such codes across every suffix, so the lookahead cannot change which
+    // symbol is found.
     while bits > 0 {
-        debug_assert!(bits < 8);
-        let padding = (1u32 << bits) - 1;
-        if table == 0 && acc & padding == padding {
+        // A prefix of the EOS code (all ones, at most 7 bits) is valid
+        // padding at a symbol boundary.
+        if bits < 8 && (acc >> (64 - bits)) == (1u64 << bits) - 1 {
             break;
         }
 
-        let index = (acc << (8 - bits)) as u8 as usize;
-        let entry = DECODE_TABLE[table * TABLE_WIDTH + index];
-        if entry & BRANCH != 0 {
-            return Err(DecoderError::InvalidHuffmanCode);
+        let mut table = 0usize;
+        loop {
+            let e = DECODE_TABLE[table * TABLE_WIDTH + (acc >> 56) as usize];
+            if e & BRANCH == 0 {
+                let used = (e >> 8) as usize;
+                if used > bits {
+                    return Err(DecoderError::InvalidHuffmanCode);
+                }
+                // SAFETY: the store is within the capacity reserved above;
+                // see the analysis at the top of the function.
+                unsafe {
+                    out.write(e as u8);
+                    out = out.add(1);
+                }
+                acc <<= used;
+                bits -= used;
+                break;
+            }
+            if bits < 8 {
+                return Err(DecoderError::InvalidHuffmanCode);
+            }
+            table = ((e & TABLE_INDEX_MASK) >> 8) as usize;
+            if table == 0 {
+                return Err(DecoderError::InvalidHuffmanCode);
+            }
+            acc <<= 8;
+            bits -= 8;
         }
-
-        let used = (entry >> 8) as usize;
-        if used > bits {
-            return Err(DecoderError::InvalidHuffmanCode);
-        }
-
-        buf.put_u8(entry as u8);
-        table = 0;
-        bits -= used;
     }
 
-    if table == 0 {
-        Ok(buf.split())
-    } else {
-        Err(DecoderError::InvalidHuffmanCode)
+    // SAFETY: `out` only ever advances from `out_start` within the same
+    // reserved allocation.
+    let written = unsafe { out.offset_from(out_start) } as usize;
+    // SAFETY: `written` bytes were initialized in the spare capacity above.
+    unsafe {
+        buf.set_len(base_len + written);
     }
+    Ok(buf.split())
 }
 
 pub fn encode(src: &[u8], dst: &mut BytesMut) {
@@ -103,6 +279,67 @@ mod test {
     fn decode(src: &[u8]) -> Result<BytesMut, DecoderError> {
         let mut buf = BytesMut::new();
         super::decode(src, &mut buf)
+    }
+
+    // The byte-at-a-time decoder this implementation replaced, kept as a
+    // reference for differential testing.
+    fn reference_decode(src: &[u8]) -> Result<BytesMut, DecoderError> {
+        let mut buf = BytesMut::with_capacity(src.len() << 1);
+
+        let mut table = 0;
+        let mut acc = 0u32;
+        let mut bits = 0;
+
+        for &byte in src {
+            acc = (acc << 8) | byte as u32;
+            bits += 8;
+
+            while bits >= 8 {
+                let index = (acc >> (bits - 8)) as u8 as usize;
+                let entry = DECODE_TABLE[table * TABLE_WIDTH + index];
+
+                if entry & BRANCH == 0 {
+                    buf.put_u8(entry as u8);
+                    table = 0;
+                    bits -= (entry >> 8) as usize;
+                } else {
+                    table = ((entry & TABLE_INDEX_MASK) >> 8) as usize;
+                    if table == 0 {
+                        return Err(DecoderError::InvalidHuffmanCode);
+                    }
+                    bits -= 8;
+                }
+            }
+        }
+
+        while bits > 0 {
+            debug_assert!(bits < 8);
+            let padding = (1u32 << bits) - 1;
+            if table == 0 && acc & padding == padding {
+                break;
+            }
+
+            let index = (acc << (8 - bits)) as u8 as usize;
+            let entry = DECODE_TABLE[table * TABLE_WIDTH + index];
+            if entry & BRANCH != 0 {
+                return Err(DecoderError::InvalidHuffmanCode);
+            }
+
+            let used = (entry >> 8) as usize;
+            if used > bits {
+                return Err(DecoderError::InvalidHuffmanCode);
+            }
+
+            buf.put_u8(entry as u8);
+            table = 0;
+            bits -= used;
+        }
+
+        if table == 0 {
+            Ok(buf.split())
+        } else {
+            Err(DecoderError::InvalidHuffmanCode)
+        }
     }
 
     #[test]
@@ -199,6 +436,52 @@ mod test {
         let mut encoded = BytesMut::new();
         encode(&src, &mut encoded);
         assert_eq!(decode(&encoded).unwrap(), src);
+    }
+
+    #[test]
+    fn matches_reference_on_valid_input() {
+        // Round-trip strings of random bytes of every length.
+        let mut rng: u64 = 0x123456789abcdef;
+        let mut next = move || {
+            rng = rng
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (rng >> 33) as u8
+        };
+
+        for len in 0..600 {
+            let src: Vec<u8> = (0..len).map(|_| next()).collect();
+            let mut encoded = BytesMut::new();
+            encode(&src, &mut encoded);
+            assert_eq!(reference_decode(&encoded), decode(&encoded), "len={}", len);
+            assert_eq!(&decode(&encoded).unwrap()[..], &src[..], "len={}", len);
+        }
+    }
+
+    #[test]
+    fn matches_reference_on_arbitrary_bytes() {
+        // Random (mostly invalid) byte strings must produce identical
+        // results, including identical errors.
+        let mut rng: u64 = 0xdeadbeefcafe;
+        let mut next = move || {
+            rng = rng
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (rng >> 33) as u8
+        };
+
+        for _ in 0..20_000 {
+            let len = (next() as usize) % 40;
+            let src: Vec<u8> = (0..len).map(|_| next()).collect();
+            assert_eq!(reference_decode(&src), decode(&src), "src={:?}", src);
+        }
+
+        // Bias toward high bytes to exercise long codes and EOS prefixes.
+        for _ in 0..20_000 {
+            let len = (next() as usize) % 40;
+            let src: Vec<u8> = (0..len).map(|_| next() | 0xe0).collect();
+            assert_eq!(reference_decode(&src), decode(&src), "src={:?}", src);
+        }
     }
 
     #[test]

--- a/src/hpack/huffman/mod.rs
+++ b/src/hpack/huffman/mod.rs
@@ -120,10 +120,9 @@ pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> 
     'outer: loop {
         // Refill the bit buffer, seven bytes at a time when possible.
         if pos + 8 <= len {
-            // SAFETY: pos + 8 <= len, so the 8-byte read is in bounds.
-            let word = u64::from_be_bytes(unsafe {
-                src.as_ptr().add(pos).cast::<[u8; 8]>().read_unaligned()
-            });
+            // The bounds check is elided: the compiler proves it from the
+            // `pos + 8 <= len` branch above.
+            let word = u64::from_be_bytes(src[pos..pos + 8].try_into().unwrap());
             acc |= word >> bits;
             pos += (63 - bits) >> 3;
             bits |= 56;

--- a/src/hpack/huffman/mod.rs
+++ b/src/hpack/huffman/mod.rs
@@ -93,29 +93,22 @@ const fn build_fast_table() -> [u32; 1 << FAST_BITS] {
 // control characters and non-ASCII octets) and complete by walking the
 // byte-wide tables in DECODE_TABLE, exactly like the previous decoder.
 pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> {
-    if src.is_empty() {
-        return Ok(buf.split());
-    }
-
-    // The shortest code is five bits, so the decoded output is at most
-    // src.len() * 8 / 5 bytes. The hot loop below speculatively writes two
-    // bytes per emitted symbol pair, touching at most one byte past the
-    // decoded length. floor(len * 8 / 5) + 1 <= len * 2 holds for len >= 1,
-    // so reserving twice the input length covers both.
-    buf.reserve(src.len() << 1);
-
     let len = src.len();
     let base_len = buf.len();
+
+    // The shortest code is five bits, so the decoded output is at most
+    // len * 8 / 5 bytes. The hot loop below speculatively writes two bytes
+    // per emitted symbol pair, touching at most one byte past the decoded
+    // length; floor(len * 8 / 5) + 1 <= len * 2 holds for len >= 1. Zero-fill
+    // up to the worst case now so the output can be written through a plain
+    // slice, then truncate to the decoded length at the end.
+    buf.resize(base_len + (len << 1), 0);
+    let dst = &mut buf[base_len..];
+    let mut o = 0usize;
 
     let mut acc: u64 = 0;
     let mut bits: usize = 0;
     let mut pos: usize = 0;
-
-    // The spare capacity reserved above, as a raw pointer. `chunk_mut` only
-    // reallocates when the buffer is full, which the reservation of at least
-    // two bytes for a non-empty input rules out.
-    let out_start = buf.chunk_mut().as_mut_ptr();
-    let mut out = out_start;
 
     'outer: loop {
         // Refill the bit buffer, seven bytes at a time when possible.
@@ -152,12 +145,8 @@ pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> 
                         if used > bits {
                             return Err(DecoderError::InvalidHuffmanCode);
                         }
-                        // SAFETY: the store is within the capacity reserved
-                        // above; see the analysis at the top of the function.
-                        unsafe {
-                            out.write(e as u8);
-                            out = out.add(1);
-                        }
+                        dst[o] = e as u8;
+                        o += 1;
                         acc <<= used;
                         bits -= used;
                         break;
@@ -176,14 +165,9 @@ pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> 
             }
 
             let consumed = (entry >> 24) as usize;
-            // SAFETY: speculative 2-byte store within the capacity reserved
-            // above, which includes one byte of slack past the maximum
-            // decoded length; see the analysis at the top of the function.
-            unsafe {
-                out.write(entry as u8);
-                out.add(1).write((entry >> 8) as u8);
-                out = out.add(count as usize);
-            }
+            dst[o] = entry as u8;
+            dst[o + 1] = (entry >> 8) as u8;
+            o += count as usize;
             acc <<= consumed;
             bits -= consumed;
         }
@@ -214,12 +198,8 @@ pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> 
                 if used > bits {
                     return Err(DecoderError::InvalidHuffmanCode);
                 }
-                // SAFETY: the store is within the capacity reserved above;
-                // see the analysis at the top of the function.
-                unsafe {
-                    out.write(e as u8);
-                    out = out.add(1);
-                }
+                dst[o] = e as u8;
+                o += 1;
                 acc <<= used;
                 bits -= used;
                 break;
@@ -236,13 +216,7 @@ pub fn decode(src: &[u8], buf: &mut BytesMut) -> Result<BytesMut, DecoderError> 
         }
     }
 
-    // SAFETY: `out` only ever advances from `out_start` within the same
-    // reserved allocation.
-    let written = unsafe { out.offset_from(out_start) } as usize;
-    // SAFETY: `written` bytes were initialized in the spare capacity above.
-    unsafe {
-        buf.set_len(base_len + written);
-    }
+    buf.truncate(base_len + o);
     Ok(buf.split())
 }
 


### PR DESCRIPTION
This builds on #926 and includes its commits; only the last commit (`6177a6f`) is new. Opening as a draft to share the approach, the experiments that were tried, and benchmark numbers.

## What this does

#926 replaced the nibble-at-a-time state machine with byte-wide tables, decoding up to one symbol per 8-bit lookup. This PR adds two techniques on top, borrowed from fast DEFLATE/zstd decoders:

1. **A primary 12-bit lookup table that decodes up to two symbols per lookup.** The most common HPACK codes are five to seven bits long, so a 12-bit index usually covers two whole codes (5+5, 5+6, 5+7, 6+6). Each `u32` entry packs both decoded bytes, a symbol count, and the total bits consumed. The table (16 KB) is built at compile time by a `const fn` from `ENCODE_TABLE`. Codes longer than 12 bits — control characters and non-ASCII octets — are rare in header data and complete by walking the byte-wide tables from #926, which also handle the tail/padding logic.
2. **A 64-bit bit buffer refilled seven bytes at a time** with a single unaligned load (the idempotent `acc |= word >> bits` refill), instead of feeding the accumulator one byte per iteration.

Output is written through a raw pointer into capacity reserved up front, with a speculative two-byte store per lookup. The shortest code is five bits, so decoded output is at most ⌊8·len/5⌋ bytes and the reservation of `2 * len` always covers the store plus one byte of slack.

## Benchmarks

Apple M4 Max, `cargo bench` with the harness from #926 (same four inputs on all three revisions):

| bench | master (`46bfd62`) | #926 (`dd225e5`) | this PR | vs master | vs #926 |
|---|---|---|---|---|---|
| `decode_header_value` | 196 ns / 225 MB/s | 171 ns / 258 MB/s | 61 ns / 733 MB/s | **3.2×** | **2.8×** |
| `decode_long_ascii` | 274 ns / 218 MB/s | 242 ns / 248 MB/s | 91 ns / 659 MB/s | **3.0×** | **2.7×** |
| `decode_short_ascii` | 46 ns / 266 MB/s | 47 ns / 255 MB/s | 21 ns / 600 MB/s | **2.2×** | **2.2×** |
| `decode_all_octets` | 2712 ns / 214 MB/s | 1632 ns / 357 MB/s | 1377 ns / 423 MB/s | **2.0×** | 1.2× |

`decode_all_octets` is a synthetic worst case (every byte value, dominated by 13–28-bit codes on the fallback path); real header data is ASCII, where the win is largest.

## Experiments that were tried (and where they ended up)

The starting question was whether SIMD could help. It can't, directly: Huffman decoding of a single stream is inherently serial — the position of codeword *n+1* is unknown until codeword *n* is decoded. Decoders that use SIMD (e.g. zstd's Huffman) rely on the *encoder* splitting output into four interleaved streams, and HPACK's single-stream format is fixed by RFC 7541. So the ceiling is scalar ILP, which is what this PR goes after. Variants measured along the way (same machine/harness):

| variant | `header_value` | `long_ascii` | `short_ascii` | `all_octets` | notes |
|---|---|---|---|---|---|
| **12-bit, 2 symbols (this PR, 16 KB)** | **60.4 ns** | **90.6 ns** | **20.5 ns** | **1397 ns** | |
| 13-bit, 2 symbols (32 KB) | 58.9 | 81.4 | 20.6 | 1333 | ~5–10% for 2× table |
| 14-bit, 2 symbols (64 KB) | 55.6 | 78.4 | 18.8 | 1327 | ~8–13% for 4× table |
| 15-bit, up to 3 symbols (128 KB) | 56.2 | 81.1 | 18.9 | 1316 | no better than 14-bit |
| long-code path outlined as `#[cold]` fn | 82.7 | 115.9 | 24.7 | 1720 | ~35% regression (hot-loop regalloc) |
| fully safe variant (`put_u8`/`put_slice`, `try_into` reads) | 108.7 | 150.8 | 35.1 | 1503 | still ~1.6× over #926 |

Two takeaways from the sweep:

- Going 12 → 14 bits buys single-digit percentages; 14 → 15 bits with *three* symbols per entry buys nothing despite an 8× larger table. The loop is latency-bound on the serial chain (load entry → extract bits → shift accumulator → next index → next load), so wider entries stop paying once refill stops being the bottleneck. Given that the microbenchmarks keep the table hot in cache — which flatters large tables relative to bursty real-world HPACK decoding — 12 bits (16 KB) looked like the right size/speed point. 13 bits is defensible if the extra 16 KB is considered cheap.
- If `unsafe` in this path is unwanted, the safe variant keeps a solid chunk of the win (~1.6× over #926 on ASCII benches, table above). The `unsafe` here is three small blocks (one unaligned read, speculative stores into reserved capacity, and the final `set_len`), each with a safety comment tied to the capacity analysis at the top of `decode`.

## Correctness

The previous decoder (from #926) is kept as a test-only reference implementation, and differential tests assert **byte-identical output and identical errors** against it on:

- round-trips of random inputs of every length 0–599, and
- 40,000 random/adversarial raw inputs (half biased toward `0xE0`-`0xFF` bytes to exercise long codes, EOS prefixes, and invalid padding).

This caught one real bug during development (the long-code fallback initially rejected valid codes whose final table level lands on a partial byte), so the coverage does bite. All existing tests pass unchanged; MSRV (1.63) verified — the table builder fills prefix ranges per code rather than searching codes per index specifically to stay under older compilers' const-eval step limit.
