### PR TITLE
perf: reuse HPACK encode buffer across frames

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -6,7 +6,7 @@ use crate::hpack::{self, BytesStr};
 use http::header::{self, HeaderName, HeaderValue};
 use http::{uri, HeaderMap, Method, Request, StatusCode, Uri};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 
 use std::fmt;
 use std::io::Cursor;
@@ -104,7 +104,7 @@ struct HeaderBlock {
 
 #[derive(Debug)]
 struct EncodingHeaderBlock {
-    hpack: Bytes,
+    hpack: BytesMut,
 }
 
 const END_STREAM: u8 = 0x1;
@@ -287,7 +287,7 @@ impl Headers {
 
         self.header_block
             .into_encoding(encoder)
-            .encode(&head, dst, |_| {})
+            .encode(&head, dst, Some(encoder), |_| {})
     }
 
     fn head(&self) -> Head {
@@ -508,7 +508,7 @@ impl PushPromise {
 
         self.header_block
             .into_encoding(encoder)
-            .encode(&head, dst, |dst| {
+            .encode(&head, dst, Some(encoder), |dst| {
                 dst.put_u32(promised_id.into());
             })
     }
@@ -551,7 +551,7 @@ impl Continuation {
         // Get the CONTINUATION frame head
         let head = self.head();
 
-        self.header_block.encode(&head, dst, |_| {})
+        self.header_block.encode(&head, dst, None, |_| {})
     }
 }
 
@@ -647,7 +647,13 @@ impl Pseudo {
 // ===== impl EncodingHeaderBlock =====
 
 impl EncodingHeaderBlock {
-    fn encode<F>(mut self, head: &Head, dst: &mut EncodeBuf<'_>, f: F) -> Option<Continuation>
+    fn encode<F>(
+        mut self,
+        head: &Head,
+        dst: &mut EncodeBuf<'_>,
+        encoder: Option<&mut hpack::Encoder>,
+        f: F,
+    ) -> Option<Continuation>
     where
         F: FnOnce(&mut EncodeBuf<'_>),
     {
@@ -664,7 +670,8 @@ impl EncodingHeaderBlock {
 
         // Now, encode the header payload
         let continuation = if self.hpack.len() > dst.remaining_mut() {
-            dst.put((&mut self.hpack).take(dst.remaining_mut()));
+            let head_part = self.hpack.split_to(dst.remaining_mut());
+            dst.put_slice(&head_part);
 
             Some(Continuation {
                 stream_id: head.stream_id(),
@@ -672,6 +679,11 @@ impl EncodingHeaderBlock {
             })
         } else {
             dst.put_slice(&self.hpack);
+            // The block is fully written, so the buffer can be reused by the
+            // next frame on this connection.
+            if let Some(encoder) = encoder {
+                encoder.return_scratch(self.hpack);
+            }
 
             None
         };
@@ -978,7 +990,8 @@ impl HeaderBlock {
     }
 
     fn into_encoding(self, encoder: &mut hpack::Encoder) -> EncodingHeaderBlock {
-        let mut hpack = BytesMut::new();
+        let mut hpack = encoder.take_scratch();
+        hpack.clear();
         let headers = Iter {
             pseudo: Some(self.pseudo),
             fields: self.fields.into_iter(),
@@ -986,9 +999,7 @@ impl HeaderBlock {
 
         encoder.encode(headers, &mut hpack);
 
-        EncodingHeaderBlock {
-            hpack: hpack.freeze(),
-        }
+        EncodingHeaderBlock { hpack }
     }
 
     /// Calculates the size of the currently decoded header list.

--- a/src/hpack/encoder.rs
+++ b/src/hpack/encoder.rs
@@ -8,6 +8,13 @@ use http::header::{HeaderName, HeaderValue};
 pub struct Encoder {
     table: Table,
     size_update: Option<SizeUpdate>,
+    /// Reusable buffer for the encoded header block of a single frame.
+    ///
+    /// A header block only has to live until it is copied into the
+    /// connection write buffer, so the buffer that holds it can be reused
+    /// across frames instead of being allocated and freed per frame. See
+    /// `take_scratch` / `return_scratch`.
+    scratch: BytesMut,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -21,7 +28,23 @@ impl Encoder {
         Encoder {
             table: Table::new(max_size, capacity),
             size_update: None,
+            scratch: BytesMut::new(),
         }
+    }
+
+    /// Takes the reusable buffer for one header-block encode.
+    ///
+    /// The buffer is returned by `return_scratch` once the encoded block has
+    /// been copied into the write buffer. If it is not returned - the
+    /// CONTINUATION path keeps it, since the remainder is still needed - the
+    /// next call simply starts from a fresh buffer.
+    pub(crate) fn take_scratch(&mut self) -> BytesMut {
+        std::mem::take(&mut self.scratch)
+    }
+
+    /// Returns a fully-written header block buffer for reuse.
+    pub(crate) fn return_scratch(&mut self, scratch: BytesMut) {
+        self.scratch = scratch;
     }
 
     /// Queues a max size update.


### PR DESCRIPTION
## Motivation

`into_encoding` allocates a fresh `BytesMut` for every HEADERS/PUSH_PROMISE
frame, lets it grow through several capacity doublings while HPACK encodes
into it, and then calls `.freeze()` — which allocates again for the `Bytes`
refcount header. That is at least two allocations per outbound header block,
on every request and every response.

The block does not need to outlive the call: on the common path it is copied
into the connection write buffer (`dst.put_slice`) and dropped immediately.
So the buffer can simply be reused across frames on the same connection.

## Solution

`hpack::Encoder` keeps one scratch `BytesMut`. `into_encoding` takes it,
clears it, and encodes into it; once `EncodingHeaderBlock::encode` has
copied the block into the write buffer, it hands the buffer back.

`EncodingHeaderBlock::hpack` becomes `BytesMut` instead of `Bytes`, so the
`.freeze()` goes away too. The CONTINUATION path keeps its remainder and
does not return the buffer — the next encode just starts from a fresh one —
and splitting that remainder is now `split_to` on a uniquely-owned
`BytesMut` rather than a copy.

Nothing else changes: same bytes on the wire, no public API change, both new
methods are `pub(crate)`.

## Memory

Worth stating explicitly given #923: this retains one buffer per connection,
sized to the largest header block that connection has encoded, for the
connection's lifetime. For ordinary headers that is well under 1 KiB; a
connection that once sent a header block near `max_frame_size` will hold
that much until it closes. If that tradeoff is unwanted, the buffer could be
capped or released on idle — happy to add either.

## Measurements

`cargo bench --bench main` on this repo, 5 interleaved rounds per arm
(master vs this branch, rebuilt each round), Apple M-series, `Overall` in ms,
lower is better:

| Benchmark | master | this PR | Δ |
| --- | --- | --- | ---: |
| current-thread, 100k req | 372, 377, 377, 386, 376 | 383, 369, 369, 367, 372 | **+1.5 %** |
| multi-thread, 100k req | 496, 488, 490, 507, 501 | 489, 474, 479, 477, 469 | **+3.8 %** |
| write contention, 1 GiB | 270, 284, 286, 275, 278 | 288, 283, 275, 278, 271 | +0.0 % |

The multi-thread row separates cleanly — the patched arm is faster in 24 of
25 pairwise comparisons (exact permutation test, two-sided p = 0.016). The
write-contention benchmark is DATA-frame throughput and is unaffected, which
is what you would expect.

It is a small win, and I would not argue it is more than that. It is worth
having mainly because it is on every request in both directions and costs
nothing to keep.

## Testing

`cargo test --all` passes, including the full HPACK fixture suite and
`write_continuation_frames` / `read_continuation_frames` / 
`too_many_continuation_frames_sends_goaway`, which cover the split path this
change touches.
