### PR TITLE
perf: defer send buffer locking while receiving

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -536,8 +536,6 @@ impl Inner {
         }
 
         let actions = &mut self.actions;
-        let mut send_buffer = send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
 
         self.counts.transition(stream, |counts, stream| {
             tracing::trace!(
@@ -551,8 +549,9 @@ impl Inner {
                     Ok(()) => Ok(()),
                     Err(RecvHeaderBlockError::Oversize(resp)) => {
                         if let Some(resp) = resp {
+                            let mut send_buffer = send_buffer.inner.lock().unwrap();
                             let sent = actions.send.send_headers(
-                                resp, send_buffer, stream, counts, &mut actions.task);
+                                resp, &mut send_buffer, stream, counts, &mut actions.task);
                             debug_assert!(sent.is_ok(), "oversize response should not fail");
 
                             actions.send.schedule_implicit_reset(
@@ -581,7 +580,7 @@ impl Inner {
                 actions.recv.recv_trailers(frame, stream)
             };
 
-            actions.reset_on_recv_stream_err(send_buffer, stream, counts, res)
+            actions.reset_on_recv_stream_err_deferred(send_buffer, stream, counts, res)
         })
     }
 
@@ -633,8 +632,6 @@ impl Inner {
         };
 
         let actions = &mut self.actions;
-        let mut send_buffer = send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
 
         self.counts.transition(stream, |counts, stream| {
             let sz = frame.flow_controlled_len();
@@ -648,7 +645,7 @@ impl Inner {
                     .recv
                     .release_connection_capacity(sz as WindowSize, &mut None);
             }
-            actions.reset_on_recv_stream_err(send_buffer, stream, counts, res)
+            actions.reset_on_recv_stream_err_deferred(send_buffer, stream, counts, res)
         })
     }
 
@@ -1737,6 +1734,21 @@ impl Actions {
 
             Ok(())
         })
+    }
+
+    fn reset_on_recv_stream_err_deferred<B>(
+        &mut self,
+        send_buffer: &SendBuffer<B>,
+        stream: &mut store::Ptr,
+        counts: &mut Counts,
+        res: Result<(), Error>,
+    ) -> Result<(), Error> {
+        if matches!(res, Err(Error::Reset(..))) {
+            let mut send_buffer = send_buffer.inner.lock().unwrap();
+            self.reset_on_recv_stream_err(&mut send_buffer, stream, counts, res)
+        } else {
+            res
+        }
     }
 
     fn reset_on_recv_stream_err<B>(


### PR DESCRIPTION
- [ ] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)

## Summary

- avoid taking the outbound frame-buffer mutex for every successfully received HEADERS or DATA frame
- acquire it only when receive processing must enqueue a response or reset

## Motivation

`recv_headers` and `recv_data` currently lock `SendBuffer` before processing an inbound frame, although the common successful path does not write to that buffer. Deferring the lock removes an unnecessary nested mutex acquisition and its cache traffic from the hot receive path.

The caller still holds the connection-wide `Inner` lock, so this patch does not remove the primary sender/driver serialization. It is intentionally a small lock-overhead optimization; oversized responses and receive errors still lock before queuing outbound frames.

## Scope

The implementation is limited to one file. Existing integration coverage already exercises ordinary HEADERS/DATA receipt, oversized responses, and receive errors that emit `RST_STREAM`, so no test tied only to mutex placement was added.

## Performance

In the initial isolated 256-stream, 65,536-frame run, median elapsed time moved from 369 ms to 355 ms (+3.9% throughput). Later Windows runs were scheduler-bimodal and placed the standalone result within roughly 1% in the fast cluster, so this should be treated as a modest hot-path improvement rather than a broad contention fix.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --offline`
- `cargo test -p h2 --lib --no-default-features --offline` (428 passed)
- `cargo test -p h2-tests --offline` (complete integration suite, including the 5,000-connection hammer test)
