### PR TITLE
perf: avoid relocking response stream references

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -237,6 +237,7 @@ pub struct Connection<T, B: Buf = Bytes> {
 #[must_use = "futures do nothing unless polled"]
 pub struct ResponseFuture {
     inner: proto::OpaqueStreamRef,
+    body: Option<proto::OpaqueStreamRef>,
     push_promise_consumed: bool,
 }
 
@@ -517,7 +518,7 @@ where
         self.inner
             .send_request(request, end_of_stream, self.pending.as_ref())
             .map_err(Into::into)
-            .map(|(stream, is_full)| {
+            .map(|(stream, response, body, is_full)| {
                 if stream.is_pending_open() && is_full {
                     // Only prevent sending another request when the request queue
                     // is not full.
@@ -525,7 +526,8 @@ where
                 }
 
                 let response = ResponseFuture {
-                    inner: stream.clone_to_opaque(),
+                    inner: response,
+                    body: Some(body),
                     push_promise_consumed: false,
                 };
 
@@ -1470,7 +1472,11 @@ impl Future for ResponseFuture {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let (parts, _) = ready!(self.inner.poll_response(cx))?.into_parts();
-        let body = RecvStream::new(FlowControl::new(self.inner.clone()));
+        let body = RecvStream::new(FlowControl::new(
+            self.body
+                .take()
+                .expect("ResponseFuture polled after completion"),
+        ));
 
         Poll::Ready(Ok(Response::from_parts(parts, body)))
     }
@@ -1478,10 +1484,6 @@ impl Future for ResponseFuture {
 
 impl ResponseFuture {
     /// Returns the stream ID of the response stream.
-    ///
-    /// # Panics
-    ///
-    /// If the lock on the stream store has been poisoned.
     pub fn stream_id(&self) -> crate::StreamId {
         crate::StreamId::from_internal(self.inner.stream_id())
     }
@@ -1532,10 +1534,11 @@ impl PushPromises {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<PushPromise, crate::Error>>> {
         match self.inner.poll_pushed(cx) {
-            Poll::Ready(Some(Ok((request, response)))) => {
+            Poll::Ready(Some(Ok((request, response, body)))) => {
                 let response = PushedResponseFuture {
                     inner: ResponseFuture {
                         inner: response,
+                        body: Some(body),
                         push_promise_consumed: false,
                     },
                 };
@@ -1589,10 +1592,6 @@ impl Future for PushedResponseFuture {
 
 impl PushedResponseFuture {
     /// Returns the stream ID of the response stream.
-    ///
-    /// # Panics
-    ///
-    /// If the lock on the stream store has been poisoned.
     pub fn stream_id(&self) -> crate::StreamId {
         self.inner.stream_id()
     }

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -29,6 +29,12 @@ pub(crate) struct Key {
     stream_id: StreamId,
 }
 
+impl Key {
+    pub(crate) fn stream_id(self) -> StreamId {
+        self.stream_id
+    }
+}
+
 // We can never have more than `StreamId::MAX` streams in the store,
 // so we can save a smaller index (u32 vs usize).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -264,7 +264,7 @@ where
         mut request: Request<()>,
         end_of_stream: bool,
         pending: Option<&OpaqueStreamRef>,
-    ) -> Result<(StreamRef<B>, bool), SendError> {
+    ) -> Result<(StreamRef<B>, OpaqueStreamRef, OpaqueStreamRef, bool), SendError> {
         use super::stream::ContentLength;
         use http::Method;
 
@@ -344,14 +344,18 @@ where
 
         // TODO: ideally, OpaqueStreamRefs::new would do this, but we're holding
         // the lock, so it can't.
-        me.refs += 1;
+        me.refs += 3;
 
         let is_full = me.counts.next_send_stream_will_reach_capacity();
+        let response = OpaqueStreamRef::new(self.inner.clone(), &mut stream);
+        let body = OpaqueStreamRef::new(self.inner.clone(), &mut stream);
         Ok((
             StreamRef {
                 opaque: OpaqueStreamRef::new(self.inner.clone(), &mut stream),
                 send_buffer: self.send_buffer.clone(),
             },
+            response,
+            body,
             is_full,
         ))
     }
@@ -1472,7 +1476,7 @@ impl OpaqueStreamRef {
     pub fn poll_pushed(
         &mut self,
         cx: &Context,
-    ) -> Poll<Option<Result<(Request<()>, OpaqueStreamRef), proto::Error>>> {
+    ) -> Poll<Option<Result<(Request<()>, OpaqueStreamRef, OpaqueStreamRef), proto::Error>>> {
         let mut me = self.inner.lock().unwrap();
         let me = &mut *me;
 
@@ -1481,10 +1485,11 @@ impl OpaqueStreamRef {
             .recv
             .poll_pushed(cx, &mut stream)
             .map_ok(|(h, key)| {
-                me.refs += 1;
-                let opaque_ref =
-                    OpaqueStreamRef::new(self.inner.clone(), &mut me.store.resolve(key));
-                (h, opaque_ref)
+                me.refs += 2;
+                let stream = &mut me.store.resolve(key);
+                let response = OpaqueStreamRef::new(self.inner.clone(), stream);
+                let body = OpaqueStreamRef::new(self.inner.clone(), stream);
+                (h, response, body)
             })
     }
 
@@ -1557,7 +1562,7 @@ impl OpaqueStreamRef {
     }
 
     pub fn stream_id(&self) -> StreamId {
-        self.inner.lock().unwrap().store[self.key].id
+        self.key.stream_id()
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1297,10 +1297,6 @@ impl<B: Buf> SendResponse<B> {
     }
 
     /// Returns the stream ID of the response stream.
-    ///
-    /// # Panics
-    ///
-    /// If the lock on the stream store has been poisoned.
     pub fn stream_id(&self) -> crate::StreamId {
         crate::StreamId::from_internal(self.inner.stream_id())
     }
@@ -1369,10 +1365,6 @@ impl<B: Buf> SendPushedResponse<B> {
     }
 
     /// Returns the stream ID of the response stream.
-    ///
-    /// # Panics
-    ///
-    /// If the lock on the stream store has been poisoned.
     pub fn stream_id(&self) -> crate::StreamId {
         self.inner.stream_id()
     }

--- a/src/share.rs
+++ b/src/share.rs
@@ -373,10 +373,6 @@ impl<B: Buf> SendStream<B> {
     }
 
     /// Returns the stream ID of this `SendStream`.
-    ///
-    /// # Panics
-    ///
-    /// If the lock on the stream store has been poisoned.
     pub fn stream_id(&self) -> StreamId {
         StreamId::from_internal(self.inner.stream_id())
     }
@@ -451,10 +447,6 @@ impl RecvStream {
     }
 
     /// Returns the stream ID of this stream.
-    ///
-    /// # Panics
-    ///
-    /// If the lock on the stream store has been poisoned.
     pub fn stream_id(&self) -> StreamId {
         self.inner.stream_id()
     }

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -1,4 +1,4 @@
-use futures::future::{ready, Either};
+use futures::future::{poll_fn, ready, Either};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use h2_support::prelude::*;
@@ -47,12 +47,12 @@ async fn client_other_thread() {
                 .uri("https://http2.akamai.com/")
                 .body(())
                 .unwrap();
-            let _res = client
-                .send_request(request, true)
-                .unwrap()
-                .0
+            let mut response = client.send_request(request, true).unwrap().0;
+            let stream_id = response.stream_id();
+            let _res = poll_fn(|cx| Pin::new(&mut response).poll(cx))
                 .await
                 .expect("request");
+            assert_eq!(response.stream_id(), stream_id);
         });
         h2.await.expect("h2");
     };

--- a/tests/h2-tests/tests/informational_responses.rs
+++ b/tests/h2-tests/tests/informational_responses.rs
@@ -3,6 +3,7 @@
 use futures::{future::poll_fn, StreamExt};
 use h2_support::prelude::*;
 use http::{Response, StatusCode};
+use std::{pin::Pin, task::Poll};
 
 #[tokio::test]
 async fn send_100_continue() {
@@ -297,8 +298,14 @@ async fn client_poll_informational_responses_none() {
         sync_sender.send(()).unwrap();
 
         // Get the final response
-        let response = response_future.await.expect("response error");
+        let response = poll_fn(|cx| Pin::new(&mut response_future).poll(cx))
+            .await
+            .expect("response error");
         assert_eq!(response.status(), StatusCode::OK);
+        assert!(matches!(
+            poll_fn(|cx| Poll::Ready(response_future.poll_informational(cx))).await,
+            Poll::Pending
+        ));
         let (_hdr, mut recv_stream) = response.into_parts();
         let data = recv_stream.data().await.unwrap().unwrap();
         assert_eq!("request body", data);

--- a/tests/h2-tests/tests/push_promise.rs
+++ b/tests/h2-tests/tests/push_promise.rs
@@ -1,5 +1,6 @@
-use futures::{StreamExt, TryStreamExt};
+use futures::{future::poll_fn, StreamExt, TryStreamExt};
 use h2_support::prelude::*;
+use std::pin::Pin;
 
 #[tokio::test]
 async fn recv_push_works() {
@@ -32,27 +33,29 @@ async fn recv_push_works() {
             .body(())
             .unwrap();
         let (mut resp, _) = client.send_request(request, true).unwrap();
-        let pushed = resp.push_promises();
-        let check_resp_status = async move {
-            let resp = resp.await.unwrap();
-            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-        };
-        let check_pushed_response = async move {
+        let check_responses = async move {
+            let response = poll_fn(|cx| Pin::new(&mut resp).poll(cx)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            let pushed = resp.push_promises();
             let p = pushed.and_then(|headers| async move {
-                let (request, response) = headers.into_parts();
+                let (request, mut response) = headers.into_parts();
                 assert_eq!(request.into_parts().0.method, Method::GET);
-                let resp = response.await.unwrap();
+                let stream_id = response.stream_id();
+                let resp = poll_fn(|cx| Pin::new(&mut response).poll(cx))
+                    .await
+                    .unwrap();
+                assert_eq!(response.stream_id(), stream_id);
                 assert_eq!(resp.status(), StatusCode::OK);
                 let b = util::concat(resp.into_body()).await.unwrap();
                 assert_eq!(b, "promised_data");
                 Ok(())
             });
             let ps: Vec<_> = p.collect().await;
-            assert_eq!(1, ps.len())
+            assert_eq!(1, ps.len());
         };
 
-        h2.drive(join(check_resp_status, check_pushed_response))
-            .await;
+        h2.drive(check_responses).await;
     };
 
     join(mock, h2).await;


### PR DESCRIPTION
- [ ] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)

## Summary

- create the request stream, response handle, and response-body handle while the stream store is already locked
- transfer the precreated body handle into `RecvStream` instead of cloning at response completion
- read the stream ID from its stable key without locking shared stream state

## Motivation

A normal client request currently reacquires the connection-wide stream mutex to clone its response handle after insertion, then reacquires it at response completion to clone the body handle. This creates both handles during the existing locked stream insertion and moves the body handle on completion.

`ResponseFuture` retains its original handle, preserving post-completion informational-response and push-promise access. Reference drops keep their existing locking behavior.

## Scope

This is independent of the receive-side send-buffer lock patch and is based directly on `master`. Existing fixtures now cover ordinary and pushed response IDs after manual completion, plus post-completion `push_promises()` and `poll_informational()` behavior.

## Performance

Seven rotated 100,000-request pairs produced these medians:

| Server runtime | master | this PR | elapsed change |
| --- | ---: | ---: | ---: |
| current-thread | 414 ms | 412 ms | -0.5% |
| 4-worker | 467 ms | 455 ms | -2.6% |

Each variant won four of seven paired runs, so the current-thread result is effectively neutral and the multi-thread result is a small, noisy improvement. The 1 GiB sustained-transfer case showed no reliable gain, which is expected for a change aimed at request/reference churn.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --offline`
- `cargo test -p h2 --lib --no-default-features --offline` (428 passed, 1 ignored)
- `cargo test -p h2-tests --offline` (complete integration suite, including the 5,000-connection hammer test)
