### PR TITLE
fix: limit excessive amount of small DATA frames

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -33,6 +33,10 @@ pub type WindowSize = u32;
 pub const MAX_WINDOW_SIZE: WindowSize = (1 << 31) - 1; // i32::MAX as u32
 pub const DEFAULT_REMOTE_RESET_STREAM_MAX: usize = 20;
 pub const DEFAULT_LOCAL_RESET_COUNT_MAX: usize = 1024;
+// Approximately the memory occupied by one buffered DATA event. Payloads
+// smaller than this consume more internal bookkeeping than useful data.
+pub const DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD: usize = 256;
+pub const DEFAULT_DATA_FRAME_BUDGET: usize = DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD * 100;
 // RFC 9113 suggests allowing at minimum 100 streams, it seems reasonable to
 // by default allow a portion of that to be remembered as reset for some time.
 pub const DEFAULT_RESET_STREAM_MAX: usize = 50;

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -1,6 +1,33 @@
 use super::*;
 
 #[derive(Debug)]
+struct Budget {
+    available: usize,
+    max: usize,
+}
+
+#[derive(Debug)]
+pub(super) struct BudgetExhausted;
+
+impl Budget {
+    fn new(max: usize) -> Self {
+        Budget {
+            available: max,
+            max,
+        }
+    }
+
+    fn consume(&mut self, amount: usize) -> Result<(), BudgetExhausted> {
+        self.available = self.available.checked_sub(amount).ok_or(BudgetExhausted)?;
+        Ok(())
+    }
+
+    fn replenish(&mut self, amount: usize) {
+        self.available = self.available.saturating_add(amount).min(self.max);
+    }
+}
+
+#[derive(Debug)]
 pub(super) struct Counts {
     /// Acting as a client or server. This allows us to track which values to
     /// inc / dec.
@@ -39,6 +66,9 @@ pub(super) struct Counts {
     /// Total number of locally reset streams due to protocol error across the
     /// lifetime of the connection.
     num_local_error_reset_streams: usize,
+
+    /// Credit for receiving DATA frames without excessive framing overhead.
+    data_frame_budget: Budget,
 }
 
 impl Counts {
@@ -56,6 +86,28 @@ impl Counts {
             num_remote_reset_streams: 0,
             max_local_error_reset_streams: config.local_max_error_reset_streams,
             num_local_error_reset_streams: 0,
+            data_frame_budget: Budget::new(DEFAULT_DATA_FRAME_BUDGET),
+        }
+    }
+
+    /// Records the framing overhead of a DATA frame.
+    pub fn record_data_frame(&mut self, payload_len: usize) -> Result<(), BudgetExhausted> {
+        if payload_len < DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD {
+            self.data_frame_budget
+                .consume(DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD - payload_len)
+        } else {
+            self.data_frame_budget
+                .replenish(payload_len - DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD);
+            Ok(())
+        }
+    }
+
+    /// Releases the framing overhead of a DATA frame that is no longer
+    /// buffered internally.
+    pub fn release_data_frame(&mut self, payload_len: usize) {
+        if payload_len < DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD {
+            self.data_frame_budget
+                .replenish(DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD - payload_len);
         }
     }
 
@@ -280,6 +332,70 @@ impl Drop for Counts {
 
         if !thread::panicking() {
             debug_assert!(!self.has_streams());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::DEFAULT_INITIAL_WINDOW_SIZE;
+
+    fn counts() -> Counts {
+        Counts::new(
+            peer::Dyn::Server,
+            &Config {
+                initial_max_send_streams: 0,
+                local_max_buffer_size: 0,
+                local_next_stream_id: 2.into(),
+                local_push_enabled: false,
+                extended_connect_protocol_enabled: false,
+                local_reset_duration: Duration::ZERO,
+                local_reset_max: 0,
+                remote_reset_max: 0,
+                remote_init_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
+                remote_max_initiated: None,
+                local_max_error_reset_streams: None,
+            },
+        )
+    }
+
+    #[test]
+    fn budget_is_bounded() {
+        let mut budget = Budget::new(10);
+
+        budget.consume(4).unwrap();
+        budget.replenish(20);
+        assert_eq!(budget.available, 10);
+    }
+
+    #[test]
+    fn budget_reports_exhaustion_without_underflowing() {
+        let mut budget = Budget::new(10);
+
+        budget.consume(10).unwrap();
+        assert!(budget.consume(1).is_err());
+        assert_eq!(budget.available, 0);
+    }
+
+    #[test]
+    fn good_sized_data_frames_do_not_exhaust_budget() {
+        let mut counts = counts();
+
+        for _ in 0..1_000_000 {
+            counts
+                .record_data_frame(DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD)
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn consumed_small_data_frames_do_not_exhaust_budget() {
+        let mut counts = counts();
+
+        for _ in 0..1_000_000 {
+            counts.record_data_frame(1).unwrap();
+            counts.release_data_frame(1);
         }
     }
 }

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -493,18 +493,16 @@ impl Recv {
     pub fn release_closed_capacity(&mut self, stream: &mut store::Ptr, task: &mut Option<Waker>) {
         debug_assert_eq!(stream.ref_count, 0);
 
-        if stream.in_flight_recv_data == 0 {
-            return;
+        if stream.in_flight_recv_data != 0 {
+            tracing::trace!(
+                "auto-release closed stream ({:?}) capacity: {:?}",
+                stream.id,
+                stream.in_flight_recv_data,
+            );
+
+            self.release_connection_capacity(stream.in_flight_recv_data, task);
+            stream.in_flight_recv_data = 0;
         }
-
-        tracing::trace!(
-            "auto-release closed stream ({:?}) capacity: {:?}",
-            stream.id,
-            stream.in_flight_recv_data,
-        );
-
-        self.release_connection_capacity(stream.in_flight_recv_data, task);
-        stream.in_flight_recv_data = 0;
 
         self.clear_recv_buffer(stream, task);
     }
@@ -748,6 +746,13 @@ impl Recv {
             let _res = self.release_capacity(padding, stream, &mut None);
             // cannot fail, we JUST added more in_flight data above.
             debug_assert!(_res.is_ok());
+        }
+
+        // An empty DATA frame without END_STREAM has no effect on the HTTP
+        // message. Padding has already been accounted for and released above,
+        // so there is no event to pass to the user.
+        if frame.payload().is_empty() && !frame.is_end_stream() {
+            return Ok(());
         }
 
         let event = Event::Data(frame.into_payload());

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -638,7 +638,14 @@ impl Inner {
 
         self.counts.transition(stream, |counts, stream| {
             let sz = frame.flow_controlled_len();
-            let res = actions.recv.recv_data(frame, stream);
+            let payload_len = frame.payload().len();
+            let mut res = actions.recv.recv_data(frame, stream);
+            if res.is_ok() {
+                res = counts.record_data_frame(payload_len).map_err(|_| {
+                    tracing::debug!("too many small DATA frames");
+                    Error::library_go_away_data(Reason::ENHANCE_YOUR_CALM, "too_many_data_frames")
+                });
+            }
 
             // Any stream error after receiving a DATA frame means
             // we won't give the data to the user, and so they can't
@@ -1503,7 +1510,11 @@ impl OpaqueStreamRef {
 
         let mut stream = me.store.resolve(self.key);
 
-        me.actions.recv.poll_data(cx, &mut stream)
+        let poll = me.actions.recv.poll_data(cx, &mut stream);
+        if let Poll::Ready(Some(Ok(ref payload))) = poll {
+            me.counts.release_data_frame(payload.len());
+        }
+        poll
     }
 
     pub fn poll_trailers(&mut self, cx: &Context) -> Poll<Option<Result<HeaderMap, proto::Error>>> {

--- a/tests/h2-tests/tests/stream_states.rs
+++ b/tests/h2-tests/tests/stream_states.rs
@@ -103,6 +103,188 @@ async fn send_recv_data() {
 }
 
 #[tokio::test]
+async fn recv_ignores_empty_data_without_end_stream() {
+    h2_support::trace_init!();
+
+    let (io, mut srv) = mock::new();
+
+    let mock = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200)).await;
+        for _ in 0..49 {
+            srv.send_frame(frames::data(1, "")).await;
+        }
+        for _ in 0..50 {
+            srv.send_frame(frames::data(1, [1, 0]).padded()).await;
+        }
+        srv.send_frame(frames::data(1, "hello").eos()).await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .uri("https://http2.akamai.com/")
+            .body(())
+            .unwrap();
+
+        let response = client.send_request(request, true).unwrap().0;
+        let response = h2.run(response).await.unwrap();
+        let chunks: Vec<_> = h2.run(response.into_body().try_collect()).await.unwrap();
+
+        assert_eq!(chunks, vec![Bytes::from_static(b"hello")]);
+        drop(client);
+        h2.await.unwrap();
+    };
+
+    join(mock, h2).await;
+}
+
+#[tokio::test]
+async fn too_many_empty_data_frames_sends_goaway() {
+    h2_support::trace_init!();
+
+    let (io, mut srv) = mock::new();
+
+    let mock = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200)).await;
+
+        for _ in 0..101 {
+            srv.send_frame(frames::data(1, "")).await;
+        }
+
+        srv.recv_frame(frames::go_away(0).calm().data("too_many_data_frames"))
+            .await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .uri("https://http2.akamai.com/")
+            .body(())
+            .unwrap();
+
+        let response = client.send_request(request, true).unwrap().0;
+        let response = h2.drive(response).await.unwrap();
+        let _body = response.into_body();
+        let err = h2.await.unwrap_err();
+        assert_eq!(err.reason(), Some(Reason::ENHANCE_YOUR_CALM));
+    };
+
+    join(mock, h2).await;
+}
+
+#[tokio::test]
+async fn too_many_padded_empty_data_frames_sends_goaway() {
+    h2_support::trace_init!();
+
+    let (io, mut srv) = mock::new();
+
+    let mock = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200)).await;
+
+        // One byte describing the padding length followed by one byte of
+        // padding leaves an empty application payload after decoding.
+        for _ in 0..101 {
+            srv.send_frame(frames::data(1, [1, 0]).padded()).await;
+        }
+
+        srv.recv_frame(frames::go_away(0).calm().data("too_many_data_frames"))
+            .await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .uri("https://http2.akamai.com/")
+            .body(())
+            .unwrap();
+
+        let response = client.send_request(request, true).unwrap().0;
+        let response = h2.drive(response).await.unwrap();
+        let _body = response.into_body();
+        let err = h2.await.unwrap_err();
+        assert_eq!(err.reason(), Some(Reason::ENHANCE_YOUR_CALM));
+    };
+
+    join(mock, h2).await;
+}
+
+#[tokio::test]
+async fn too_many_small_data_frames_sends_goaway() {
+    h2_support::trace_init!();
+
+    let (io, mut srv) = mock::new();
+
+    let mock = async move {
+        let settings = srv.assert_client_handshake().await;
+        assert_default_settings!(settings);
+        srv.recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .await;
+        srv.send_frame(frames::headers(1).response(200)).await;
+
+        for _ in 0..50 {
+            srv.send_frame(frames::data(1, "a")).await;
+        }
+
+        // A good-sized frame replenishes some of the budget.
+        srv.send_frame(frames::data(1, vec![0; 2048])).await;
+
+        // One-byte frames still impose almost all of the overhead of an empty
+        // frame. Even after replenishment, the 101st frame exhausts the
+        // bounded budget.
+        for _ in 0..101 {
+            srv.send_frame(frames::data(1, "a")).await;
+        }
+
+        srv.recv_frame(frames::go_away(0).calm().data("too_many_data_frames"))
+            .await;
+    };
+
+    let h2 = async move {
+        let (mut client, mut h2) = client::handshake(io).await.unwrap();
+        let request = Request::builder()
+            .uri("https://http2.akamai.com/")
+            .body(())
+            .unwrap();
+
+        let response = client.send_request(request, true).unwrap().0;
+        let response = h2.drive(response).await.unwrap();
+        let _body = response.into_body();
+        let err = h2.await.unwrap_err();
+        assert_eq!(err.reason(), Some(Reason::ENHANCE_YOUR_CALM));
+    };
+
+    join(mock, h2).await;
+}
+
+#[tokio::test]
 async fn send_headers_recv_data_single_frame() {
     h2_support::trace_init!();
 


### PR DESCRIPTION
HTTP/2 flow control limits DATA payload bytes, but it does not limit the number of frames carrying those bytes. A peer could fragment data into many tiny frames, causing disproportionate memory usage from queued events and slab entries while remaining within the flow-control windows.

To fix it, this adds a connection-level budget for DATA framing overhead. Small frames consume budget according to the difference between their payload length and the approximate cost of a buffered event. Larger frames replenish the budget, up to its original limit. When the application consumes a queued small frame, its buffering charge is also returned.

Non-final DATA frames with an empty decoded payload are discarded after their flow-control accounting is handled. Because they are never exposed to the application, their budget is not returned. Exhausting the budget closes the connection with ENHANCE_YOUR_CALM.