### PR TITLE
Use tokio::time instead of std::time, to enable tokio's cool testing helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ atomic-waker = "1.0.0"
 futures-core = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3", default-features = false }
 tokio-util = { version = "0.7.1", features = ["codec", "io"] }
-tokio = { version = "1", features = ["io-util"] }
+tokio = { version = "1", features = ["io-util", "time"] }
 bytes = "1"
 http = "1.1"
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -4,11 +4,11 @@ use crate::frame::{PushPromiseHeaderError, Reason, DEFAULT_INITIAL_WINDOW_SIZE};
 use crate::proto;
 
 use http::{HeaderMap, Request, Response};
+use tokio::time::Instant;
 
 use std::cmp::Ordering;
 use std::io;
 use std::task::{Context, Poll, Waker};
-use std::time::Instant;
 
 #[derive(Debug)]
 pub(super) struct Recv {

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -4,7 +4,8 @@ use super::*;
 
 use std::fmt;
 use std::task::{Context, Waker};
-use std::time::Instant;
+
+use tokio::time::Instant;
 
 /// Tracks Stream related state
 ///

--- a/tests/h2-tests/Cargo.toml
+++ b/tests/h2-tests/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 h2-support = { path = "../h2-support" }
 tracing = "0.1.13"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-tokio = { version = "1", features = ["macros", "net", "rt", "io-util", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt", "io-util", "rt-multi-thread", "test-util"] }

--- a/tests/h2-tests/tests/flow_control.rs
+++ b/tests/h2-tests/tests/flow_control.rs
@@ -683,7 +683,7 @@ async fn padded_data_stream_error_releases_connection_capacity() {
 }
 
 // Regression test for TODO
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn padded_data_on_forgotten_stream_releases_connection_capacity() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();

--- a/tests/h2-tests/tests/stream_states.rs
+++ b/tests/h2-tests/tests/stream_states.rs
@@ -982,7 +982,7 @@ async fn send_rst_stream_allows_recv_trailers() {
     join(srv, client).await;
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn rst_stream_expires() {
     h2_support::trace_init!();
     let (io, mut srv) = mock::new();


### PR DESCRIPTION
[tokio::time::Instant](https://docs.rs/tokio/latest/tokio/time/struct.Instant.html) is a trivial newtype wrapper around `std::time::Instant`, and normally `tokio::time::Instant::now()` [simply calls the std version](https://docs.rs/tokio/1.53.1/src/tokio/time/instant.rs.html#212), so it's a zero-cost drop-in replacement. But! If you build tokio with the `test-util` feature enabled, then it also adds a [quick check to see if you've overridden the clock for testing](https://docs.rs/tokio/1.53.1/src/tokio/time/clock.rs.html#284).

It's not documented/publicized as much as it should be, but tokio's clock testing mode is actually really cool. When you call `sleep`, tokio doesn't actually sleep, it just makes a note that the task should be awakened when the virtual clock reaches the given timestamp, and then whenever all tasks are idle it peeks at the timer wheel and advances the virtual time to whatever thing wants to wake up next. So as long as you make sure your test code doesn't perform any real system IO, then you can write arbitrarily complex tokio programs involving sleeps and time calculations, and they run super fast and deterministically. It's awesome for testing, fuzzing, etc.

Anyway, you can _almost_ use h2 in these tests, except there are two places where it uses `std::time::Instant` instead of `tokio::time::Instant`. This PR fixes that.

I also switched two existing tests that use real sleeps to use the fake sleeps instead. I doubt it makes much difference because the sleeps were pretty short anyway, but in principle it should make them faster + less likely to get broken by janky CI runners with noisy neighbors, etc.

I also asked Claude to go look for invariants that would be good to test but aren't tested currently b/c real timing tests are so annoying and it came up with a few tests that look plausible enough to me, but I don't understand the code enough to really judge so ~~I'll stick those up as a followup PR that you can take or leave.~~ edit: I can't figure out how to post a stacked-PR from a fork into another org's repo, so I'll just link to the claude-slop tests here: https://github.com/njsmith/h2/compare/tokio-instant...tokio-instant-tests?expand=1